### PR TITLE
2: Cleanup temp files

### DIFF
--- a/pkg/daemon/metrics.go
+++ b/pkg/daemon/metrics.go
@@ -31,6 +31,7 @@ const (
 	syncEProcessName   = "synce4l"
 	clockRealTime      = "CLOCK_REALTIME"
 	master             = "master"
+	pmcSocketName      = "pmc"
 
 	faultyOffset = 999999
 


### PR DESCRIPTION
Config and socket files can all be deleted when applying a new ptp profile, and will be recreated by the new profile.