### PR TITLE
Fix panics when running tests in actions

### DIFF
--- a/pkg/daemon/daemon_internal_test.go
+++ b/pkg/daemon/daemon_internal_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/bigkevmcd/go-configparser"
 	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/leap"
@@ -40,7 +41,12 @@ func applyProfileSyncE(t *testing.T, profile *ptpv1.PtpProfile) {
 
 	stopCh := make(<-chan struct{})
 	assert.NoError(t, leap.MockLeapFile())
-	defer close(leap.LeapMgr.Close)
+	defer func() {
+		close(leap.LeapMgr.Close)
+		// Sleep to allow context to switch
+		time.Sleep(100 * time.Millisecond)
+		assert.Nil(t, leap.LeapMgr)
+	}()
 	dn := New(
 		"test-node-name",
 		"openshift-ptp",

--- a/pkg/daemon/daemon_test.go
+++ b/pkg/daemon/daemon_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/event"
 	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/leap"
@@ -235,9 +236,15 @@ func TestMain(m *testing.M) {
 	teardown()
 	os.Exit(code)
 }
+
 func Test_ProcessPTPMetrics(t *testing.T) {
 	leap.MockLeapFile()
-	defer close(leap.LeapMgr.Close)
+	defer func() {
+		close(leap.LeapMgr.Close)
+		// Sleep to allow context to switch
+		time.Sleep(100 * time.Millisecond)
+		assert.Nil(t, leap.LeapMgr)
+	}()
 
 	assert := assert.New(t)
 	for _, tc := range testCases {

--- a/pkg/event/event_test.go
+++ b/pkg/event/event_test.go
@@ -291,7 +291,12 @@ func TestEventHandler_ProcessEvents(t *testing.T) {
 	eventManager.MockEnable()
 	go eventManager.ProcessEvents()
 	assert.NoError(t, leap.MockLeapFile())
-	defer close(leap.LeapMgr.Close)
+	defer func() {
+		close(leap.LeapMgr.Close)
+		// Sleep to allow context to switch
+		time.Sleep(100 * time.Millisecond)
+		assert.Nil(t, leap.LeapMgr)
+	}()
 	time.Sleep(1 * time.Second)
 	for _, test := range tests {
 		select {


### PR DESCRIPTION
Fixed by adding sleep allows go routine context to switch allowing the close side effect to happen before function exits