### PR TITLE
Wait for socket to be ready before starting the command

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -983,6 +983,9 @@ func (p *ptpProcess) cmdRun(stdoutToSocket bool) {
 		}
 		// Don't restart after termination
 		if !p.Stopped() {
+			// Wait for a small amount ot time to give a chance for the socket to be up before starting the command
+			// otherwise the initial logs will be lost.
+			time.Sleep(time.Second)
 			err = p.cmd.Start() // this is asynchronous call,
 			if err != nil {
 				glog.Errorf("CmdRun() error starting %s: %v", p.name, err)


### PR DESCRIPTION
When events are enabled, logs from ptp4l and other commands are sent to the cloud-event-proxy container via a socket. This PR delays the start of the command until after the socket is setup.
Otherwise, the early logs are missed, so early state transitions used in metrics are lost