### PR TITLE
Wait one ticker interval before loading the ptpconfig

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -154,6 +154,10 @@ func main() {
 
 	daemon.StartReadyServer("0.0.0.0:8081", tracker)
 
+	// Wait for one ticker interval before loading the profile
+	// This allows linuxptp-daemon connection to the cloud-event-proxy container to
+	// be up and running before PTP state logs are printed.
+	time.Sleep(time.Second * time.Duration(cp.updateInterval/2))
 	for {
 		select {
 		case <-tickerPull.C:


### PR DESCRIPTION
Related to https://github.com/k8snetworkplumbingwg/linuxptp-daemon/pull/28
To get the early logs from ptp4l in the cloud-event-proxy, an alternative way is to delay loading the ptpconfig file with the ticker interval. Thanks @aneeshkp to suggest this. 
Using 1/2 ticker interval delay to save some time.