### PR TITLE
Adding gated ptp-operator pre-merge CI

### DIFF
--- a/.github/workflows/aws-ci.yaml
+++ b/.github/workflows/aws-ci.yaml
@@ -1,0 +1,107 @@
+name: CI tests AWS
+on:
+  pull_request_target:
+    types: [labeled, synchronize]  # Triggered when the PR is labeled or synchronized
+permissions:
+  id-token: write
+  contents: read
+  pull-requests: write
+jobs:
+  deploy-ec2:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Remove ok-to-test label if new commit
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const label = "ok-to-test";
+            const pr = context.payload.pull_request;
+            const labels = pr.labels.map(l => l.name);
+            if (labels.includes(label)) {
+              await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pr.number,
+                name: label
+              });
+              console.log(`Removed ${label} due to new push`);
+            }
+      - name: Checkout the code
+        uses: actions/checkout@v3
+        with:
+          repository: k8snetworkplumbingwg/ptp-operator
+          ref: main
+          path: ptp-operator
+      
+      - name: checkout the Current SHA for the linuxptp-daemon
+        id: sha
+        run: |
+          sed -i '/^RUN git clone -b main https:\/\/github.com\/k8snetworkplumbingwg\/linuxptp-daemon.git  \/go\/src\/github.com\/k8snetworkplumbingwg\/linuxptp-daemon$/c\
+          RUN git clone -b main https://github.com/k8snetworkplumbingwg/linuxptp-daemon.git  /go/src/github.com/k8snetworkplumbingwg/linuxptp-daemon\nRUN git checkout ${{ github.sha }}' ./ptp-operator/ptp-tools/Dockerfile.lptpd
+          cat ./ptp-operator/ptp-tools/Dockerfile.lptpd
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+            role-to-assume: arn:aws:iam::058264082309:role/github-oidc-setup-david-Role-Kk44xkca6vIm
+            role-session-name: ${{ github.run_id }}
+            aws-region: us-east-1
+
+      - name: Launch EC2 instance
+        id: launch
+        run: |
+          INSTANCE_ID=$(aws ec2 run-instances \
+            --image-id ami-0f7270e9a0e492eac \
+            --subnet-id subnet-04ee218fe8f32cad5 \
+            --instance-type m6a.xlarge \
+            --security-group-ids sg-05e700edc2ed0a2d5 \
+            --tag-specifications 'ResourceType=instance,Tags=[{Key=Name,Value=ptp-operator PR-${{ github.event.number }}}]' \
+            --query 'Instances[0].InstanceId' \
+            --key-name ptp-sshkey-1 \
+            --output text)
+
+          echo "instance_id=$INSTANCE_ID" >> $GITHUB_ENV
+
+      - name: Wait for instance and get public IP
+        id: wait
+        run: |
+          aws ec2 wait instance-running --instance-ids $instance_id
+          PUBLIC_IP=$(aws ec2 describe-instances \
+            --instance-ids $instance_id \
+            --query 'Reservations[0].Instances[0].PublicIpAddress' \
+            --output text)
+          echo "public_ip=$PUBLIC_IP" >> $GITHUB_ENV
+          PRIVATE_IP=$(aws ec2 describe-instances \
+            --instance-ids $instance_id \
+            --query 'Reservations[0].Instances[0].PrivateIpAddress' \
+            --output text)
+          echo "private_ip=$PRIVATE_IP" >> $GITHUB_ENV
+          
+      - name: Wait for instance to be online
+        run: |
+          ./ptp-operator/scripts/retry.sh 180 10 sh -c "aws ssm describe-instance-information --query \"InstanceInformationList[?InstanceId=='$instance_id'].PingStatus\" --output text | grep -q 'Online'"
+
+      - name: Run test script
+        run: |
+            echo "VM IP is $public_ip"
+            eval "$(ssh-agent -s)"
+            ssh-keygen -t rsa -b 4096 -f temp_key -N ""
+            aws ssm send-command --instance-ids $instance_id \
+                --document-name "AWS-RunShellScript" \
+                --parameters 'commands=["sudo bash -c '\''echo '"$(cat temp_key.pub)"' >> /home/fedora/.ssh/authorized_keys'\''"]'
+            
+            ssh-add temp_key
+            
+            ./ptp-operator/scripts/retry.sh 60 5 ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null fedora@"$public_ip" uptime
+            rsync -r -e "ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null" ptp-operator fedora@"$public_ip":~/.
+            ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null fedora@"$public_ip" sudo ./ptp-operator/scripts/run-on-vm.sh "$private_ip"
+
+      - name: Cleanup - Delete EC2 instance
+        if: always()  # Ensure cleanup runs even if previous steps fail
+        run: |
+            echo "Cleaning up EC2 INSTANCE_ID=$instance_id"
+            aws ec2 terminate-instances --instance-ids $instance_id
+
+      - name: Notify cleanup complete
+        run: echo "Cleanup task completed."


### PR DESCRIPTION
This PR runs the ptp CI tests added to ptp-operator but runs them before merging.
- To start the job, an ok-to-test label is required. Only members with write permission on the repository are allowed to set labels
- a member with write access sets the ok-to-test label
- the ok-to-test label is immediately removed before the tests are started in aws
- the tests are started in aws and have 30 minutes to complete.
If the used wants to run the tests again when pushing changes, he would need again someone with write access to set the label
Members with write access can just set the label themselves to retest.