### PR TITLE
Fix Github action concurrency

### DIFF
--- a/.github/workflows/aws-ci.yaml
+++ b/.github/workflows/aws-ci.yaml
@@ -7,7 +7,7 @@ permissions:
   contents: read
   pull-requests: write
 concurrency:
-  group: ${{ github.repository }}-${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.head.repo.full_name }}-${{ github.event.pull_request.head.ref }}
   cancel-in-progress: true
 jobs:
   deploy-ec2:


### PR DESCRIPTION
Because pull_request_target is used github.ref is pointing at the main repo. So the string used to identify a unique job is the same for all PRs
Instead use the per PR refs to identify the job pull_request_target : ${{ github.workflow }}-${{ github.event.pull_request.head.repo.full_name }}-${{ github.event.pull_request.head.ref }}