### PR TITLE
fix clock class change messaging

### DIFF
--- a/pkg/event/event.go
+++ b/pkg/event/event.go
@@ -709,7 +709,7 @@ connect:
 				} else { // T-BC or T-TSC
 					event = e.convergeConfig(event)
 					dataDetails = e.addEvent(event)
-					clockState = e.updateBCState(event)
+					clockState = e.updateBCState(event, c)
 				}
 				logDataValues = dataDetails.logData
 				if event.WriteToLog && logDataValues != "" {

--- a/pkg/event/event_internal_test.go
+++ b/pkg/event/event_internal_test.go
@@ -4,7 +4,6 @@ package event
 import (
 	"testing"
 
-	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/protocol"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -89,32 +88,23 @@ func TestUpdateLeadingClockData_PTP4lProcessName(t *testing.T) {
 	event := EventChannel{
 		ProcessName: PTP4lProcessName,
 		Values: map[ValueType]interface{}{
-			TimePropertiesDataSet: &protocol.TimePropertiesDS{},
 			ControlledPortsConfig: "config",
-			ParentDataSet:         &protocol.ParentDataSet{},
-			CurrentDataSet:        &protocol.CurrentDS{StepsRemoved: 10},
+			ClockIDKey:            "clockID",
 		},
 	}
 
 	expectedLeadingClockData := LeadingClockParams{
-		upstreamTimeProperties:        event.Values[TimePropertiesDataSet].(*protocol.TimePropertiesDS),
-		controlledPortsConfig:         "config",
-		upstreamParentDataSet:         event.Values[ParentDataSet].(*protocol.ParentDataSet),
-		upstreamCurrentDSStepsRemoved: 10,
+		controlledPortsConfig: "config",
+		clockID:               "clockID",
 	}
 
 	e := EventHandler{
-		LeadingClockData: &LeadingClockParams{
-			upstreamTimeProperties: &protocol.TimePropertiesDS{},
-			upstreamParentDataSet:  &protocol.ParentDataSet{},
-		},
+		LeadingClockData: &LeadingClockParams{},
 	}
 	e.updateLeadingClockData(event)
 
-	assert.Equal(t, expectedLeadingClockData.upstreamParentDataSet, e.LeadingClockData.upstreamParentDataSet)
-	assert.Equal(t, expectedLeadingClockData.upstreamTimeProperties, e.LeadingClockData.upstreamTimeProperties)
 	assert.Equal(t, expectedLeadingClockData.controlledPortsConfig, e.LeadingClockData.controlledPortsConfig)
-	assert.Equal(t, expectedLeadingClockData.upstreamCurrentDSStepsRemoved, e.LeadingClockData.upstreamCurrentDSStepsRemoved)
+	assert.Equal(t, expectedLeadingClockData.clockID, e.LeadingClockData.clockID)
 }
 
 func TestUpdateLeadingClockData_DPLL(t *testing.T) {

--- a/pkg/event/event_internal_test.go
+++ b/pkg/event/event_internal_test.go
@@ -44,7 +44,7 @@ func TestConvergeConfig(t *testing.T) {
 		mockData := &MockData{
 			Data: map[string][]*Data{
 				"config1": {
-					{ProcessName: DPLL, Details: DDetails{{IFace: "eth1"}}},
+					{ProcessName: DPLL, Details: DDetails{{IFace: "ens4f1"}}},
 				},
 			},
 		}
@@ -54,7 +54,7 @@ func TestConvergeConfig(t *testing.T) {
 			},
 			Event: EventChannel{
 				ProcessName: PTP4lProcessName,
-				IFace:       "eth0",
+				IFace:       "ens5f0",
 			},
 		}
 

--- a/pkg/event/event_tbc.go
+++ b/pkg/event/event_tbc.go
@@ -3,10 +3,13 @@ package event
 import (
 	"fmt"
 	"math"
+	"net"
 	"time"
 
 	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/pmc"
 	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/protocol"
+	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/utils"
+	"github.com/prometheus/client_golang/prometheus"
 
 	fbprotocol "github.com/facebook/time/ptp/protocol"
 	"github.com/golang/glog"
@@ -37,6 +40,8 @@ const (
 	MaxInSpecOffset ValueType = "max-in-spec"
 	// FaultyPhaseOffset is a value assigned to the phase offset when free-running
 	FaultyPhaseOffset int64 = 99999999999
+	// StaleEventAfter is the number of seconds after which an event is considered stale
+	StaleEventAfter int64 = 2
 )
 
 // LeadingClockParams ... leading clock parameters includes state
@@ -61,7 +66,7 @@ type LeadingClockParams struct {
 	clockID                       string
 }
 
-func (e *EventHandler) updateBCState(event EventChannel) clockSyncState {
+func (e *EventHandler) updateBCState(event EventChannel, c net.Conn) clockSyncState {
 	cfgName := event.CfgName
 	dpllState := PTP_NOTSET
 	ts2phcState := PTP_FREERUN
@@ -69,8 +74,8 @@ func (e *EventHandler) updateBCState(event EventChannel) clockSyncState {
 	// For External GM data announces in the locked state, update whenever any of the
 	// information elements change
 	updateDownstreamData := false
+	leadingTS2phcActive := false
 
-	syncSrcLost := e.isSourceLost(cfgName)
 	leadingInterface := e.getLeadingInterfaceBC()
 	if leadingInterface == LEADING_INTERFACE_UNKNOWN {
 		glog.Infof("Leading interface is not yet identified, clock state reporting delayed.")
@@ -83,12 +88,12 @@ func (e *EventHandler) updateBCState(event EventChannel) clockSyncState {
 			state:         PTP_FREERUN,
 			clockClass:    protocol.ClockClassUninitialized,
 			clockAccuracy: fbprotocol.ClockAccuracyUnknown,
-			sourceLost:    syncSrcLost,
+			sourceLost:    false,
 			leadingIFace:  leadingInterface,
 		}
 	}
 	// glog.Infof("cfgName %s syncSourceLost %t, leadingIface %s e.clkSyncState %++v", cfgName, syncSrcLost, leadingInterface, e.clkSyncState)
-	e.clkSyncState[cfgName].sourceLost = syncSrcLost
+	e.clkSyncState[cfgName].sourceLost = false
 	e.clkSyncState[cfgName].leadingIFace = leadingInterface
 	if data, ok := e.data[cfgName]; ok {
 		for _, d := range data {
@@ -96,8 +101,30 @@ func (e *EventHandler) updateBCState(event EventChannel) clockSyncState {
 			case DPLL:
 				dpllState = d.State
 			case TS2PHCProcessName:
+				if event.IFace == leadingInterface {
+					leadingTS2phcActive = true
+				}
 				ts2phcState = d.State
 			case PTP4lProcessName:
+
+				if leadingTS2phcActive && event.IFace == leadingInterface {
+					// In T-BC configuration, leading card PHC is either updated by ts2phc, or by ptp4l
+					// During holdover, when ts2phc is active, ptp4l is not updating the PHC
+					// During the normal operation, ptp4l is updating the PHC, and ts2phc events stop
+					// However, the data with the processName "ts2phc" is still present in the data map
+					// If taken into account, it will contribute an outdated information into the decision making
+					// The construct below detects the transition from ts2phc to ptp4l and invalidates the ts2phc data
+					for _, tsphcData := range data {
+						if tsphcData.ProcessName == TS2PHCProcessName {
+							for _, tsphcDetail := range tsphcData.Details {
+								if tsphcDetail.time < time.Now().Unix()-StaleEventAfter {
+									tsphcDetail.Offset = 0
+									leadingTS2phcActive = false
+								}
+							}
+						}
+					}
+				}
 			}
 		}
 	} else {
@@ -107,13 +134,15 @@ func (e *EventHandler) updateBCState(event EventChannel) clockSyncState {
 		e.clkSyncState[cfgName].clockAccuracy = fbprotocol.ClockAccuracyUnknown
 		e.clkSyncState[cfgName].lastLoggedTime = time.Now().Unix()
 		e.clkSyncState[cfgName].leadingIFace = leadingInterface
-		e.clkSyncState[cfgName].clkLog = fmt.Sprintf("T-BC[%d]:[%s] %s T-BC-STATUS %s\n", e.clkSyncState[cfgName].lastLoggedTime, cfgName, leadingInterface, e.clkSyncState[cfgName].state)
+		e.clkSyncState[cfgName].clkLog = fmt.Sprintf("T-BC[%d]:[%s] %s offset %d T-BC-STATUS %s\n",
+			e.clkSyncState[cfgName].lastLoggedTime, cfgName, leadingInterface, e.clkSyncState[cfgName].clockOffset,
+			e.clkSyncState[cfgName].state)
 		return *e.clkSyncState[cfgName]
 	}
 	glog.Info("current BC state: ", e.clkSyncState[cfgName].state)
 	switch e.clkSyncState[cfgName].state {
 	case PTP_NOTSET, PTP_FREERUN:
-		if e.inSyncCondition(cfgName) && !e.isSourceLostBC(cfgName) {
+		if !e.isSourceLostBC(cfgName) && e.inSyncCondition(cfgName) {
 			e.clkSyncState[cfgName].state = PTP_LOCKED
 			glog.Info("BC FSM: FREERUN to LOCKED")
 			e.LeadingClockData.lastInSpec = true
@@ -200,10 +229,10 @@ func (e *EventHandler) updateBCState(event EventChannel) clockSyncState {
 		if gSycState.state == PTP_LOCKED {
 			if e.LeadingClockData.upstreamParentDataSet != nil && e.LeadingClockData.upstreamTimeProperties != nil {
 				go e.downstreamAnnounceIWF(e.LeadingClockData.upstreamCurrentDSStepsRemoved,
-					*e.LeadingClockData.upstreamParentDataSet, *e.LeadingClockData.upstreamTimeProperties, cfgName)
+					*e.LeadingClockData.upstreamParentDataSet, *e.LeadingClockData.upstreamTimeProperties, cfgName, c)
 			}
 		} else {
-			go e.announceLocalData(cfgName)
+			go e.announceLocalData(cfgName, c)
 		}
 	}
 	// this will reduce log noise and prints 1 per sec
@@ -220,20 +249,36 @@ func (e *EventHandler) updateBCState(event EventChannel) clockSyncState {
 	return rclockSyncState
 }
 
+func (e *EventHandler) announceClockClass(clockClass int, cfgName string, c net.Conn) {
+	message := fmt.Sprintf("ptp4l[%d]:[%s] CLOCK_CLASS_CHANGE %d\n", time.Now().Unix(),
+		cfgName, clockClass)
+	if e.stdoutToSocket {
+		if c != nil {
+			_, err := c.Write([]byte(message))
+			if err != nil {
+				glog.Errorf("failed to write class change event %s", err.Error())
+			}
+		} else {
+			glog.Errorf("failed to write class change event, connection is nil")
+		}
+	} else {
+		e.clockClassMetric.With(prometheus.Labels{
+			"process": PTP4lProcessName, "node": e.nodeName}).Set(float64(clockClass))
+	}
+	glog.Infof("%s", message)
+}
+
 // Implements Rec. ITU-T G.8275 (2024) Amd. 1 (08/2024)
 // Table VIII.3 − T-BC-/ T-BC-P/ T-BC-A Announce message contents
 // for free-run (acquiring), holdover within / out of the specification
-func (e *EventHandler) announceLocalData(cfgName string) {
-	glog.Info("in announceLocalData")
-
+func (e *EventHandler) announceLocalData(cfgName string, c net.Conn) {
 	egp := protocol.ExternalGrandmasterProperties{
 		GrandmasterIdentity: e.LeadingClockData.clockID,
 		StepsRemoved:        0,
 	}
 	glog.Infof("EGP %++v", egp)
 	go pmc.RunPMCExpSetExternalGMPropertiesNP(e.LeadingClockData.controlledPortsConfig, egp)
-	fmt.Printf("ptp4l[%d]:[%s] CLOCK_CLASS_CHANGE %d\n", time.Now().Unix(), cfgName, e.clkSyncState[cfgName].clockClass)
-
+	e.announceClockClass(int(e.clkSyncState[cfgName].clockClass), cfgName, c)
 	gs := protocol.GrandmasterSettings{
 		ClockQuality: fbprotocol.ClockQuality{
 			ClockClass:              e.clkSyncState[cfgName].clockClass,
@@ -279,7 +324,7 @@ func (e *EventHandler) announceLocalData(cfgName string) {
 	go pmc.RunPMCExpSetGMSettings(e.LeadingClockData.controlledPortsConfig, gs)
 }
 
-func (e *EventHandler) downstreamAnnounceIWF(stepsRemoved uint16, pds protocol.ParentDataSet, tp protocol.TimePropertiesDS, cfgName string) {
+func (e *EventHandler) downstreamAnnounceIWF(stepsRemoved uint16, pds protocol.ParentDataSet, tp protocol.TimePropertiesDS, cfgName string, c net.Conn) {
 	gs := protocol.GrandmasterSettings{
 		ClockQuality: fbprotocol.ClockQuality{
 			ClockClass:              fbprotocol.ClockClass(pds.GrandmasterClockClass),
@@ -293,7 +338,7 @@ func (e *EventHandler) downstreamAnnounceIWF(stepsRemoved uint16, pds protocol.P
 		// stepsRemoved at this point is already incremented, representing the current clock position
 		StepsRemoved: stepsRemoved,
 	}
-	fmt.Printf("ptp4l[%d]:[%s] CLOCK_CLASS_CHANGE %d\n", time.Now().Unix(), cfgName, gs.ClockQuality.ClockClass)
+	e.announceClockClass(int(gs.ClockQuality.ClockClass), cfgName, c)
 	if err := pmc.RunPMCExpSetExternalGMPropertiesNP(e.LeadingClockData.controlledPortsConfig, es); err != nil {
 		glog.Error(err)
 	}
@@ -361,16 +406,16 @@ func (e *EventHandler) getLargestOffset(cfgName string) int64 {
 	worstOffset := FaultyPhaseOffset
 	if data, ok := e.data[cfgName]; ok {
 		for _, d := range data {
-			if d.ProcessName == DPLL {
-				for _, dd := range d.Details {
-					if math.Abs(float64(dd.Offset)) > math.Abs(float64(worstOffset)) || worstOffset == FaultyPhaseOffset {
-						worstOffset = dd.Offset
-					}
+			for _, dd := range d.Details {
+				if worstOffset == FaultyPhaseOffset {
+					worstOffset = dd.Offset
+				} else if !(dd.time < time.Now().Unix()-StaleEventAfter) && math.Abs(float64(dd.Offset)) > math.Abs(float64(worstOffset)) {
+					worstOffset = dd.Offset
 				}
 			}
 		}
 	}
-	glog.Info("Largest DPLL offset ", worstOffset)
+	glog.Info("Largest offset ", worstOffset)
 	return worstOffset
 }
 
@@ -434,7 +479,7 @@ func (e *EventHandler) convergeConfig(event EventChannel) EventChannel {
 					continue
 				}
 				for _, dp := range item.Details {
-					if dp.IFace == iface {
+					if utils.GetAlias(dp.IFace) == utils.GetAlias(iface) {
 						// We want to process ptp4l having a separate config with ts2phc and dpll events having ts2phc config
 						// so in the rare occurrence of ptp4l state change we modify the event.CfgName
 						event.CfgName = cfg

--- a/pkg/protocol/type.go
+++ b/pkg/protocol/type.go
@@ -148,10 +148,7 @@ func btoi(b bool) uint8 {
 }
 
 func stob(s string) bool {
-	if s == "1" {
-		return true
-	}
-	return false
+	return s == "1"
 }
 
 func stou8(s string) uint8 {
@@ -212,7 +209,7 @@ func stou32h(s string) uint32 {
 // ValueRegEx provides the regex method for the ParentDS values matching
 func (p *ParentDataSet) ValueRegEx() map[string]string {
 	return map[string]string{
-		"parentPortIdentity":                    `(\d*\.\d*\.\d*\-\d*)`,
+		"parentPortIdentity":                    `(.*)`,
 		"parentStats":                           `(\d+)`,
 		"observedParentOffsetScaledLogVariance": `(0x[\da-f]+)`,
 		"observedParentClockPhaseChangeRate":    `(0x[\da-f]+)`,
@@ -221,7 +218,7 @@ func (p *ParentDataSet) ValueRegEx() map[string]string {
 		"gm.ClockAccuracy":                      `(0x[\da-f]+)`,
 		"gm.OffsetScaledLogVariance":            `(0x[\da-f]+)`,
 		"grandmasterPriority2":                  `(\d+)`,
-		"grandmasterIdentity":                   `(\d*\.\d*\.\d*)`,
+		"grandmasterIdentity":                   `(.*)`,
 	}
 }
 
@@ -236,9 +233,18 @@ func (p *ParentDataSet) RegEx() string {
 
 // Keys provides the keys method for the ParentDS values
 func (p *ParentDataSet) Keys() []string {
-	return []string{"parentPortIdentity", "parentStats", "observedParentOffsetScaledLogVariance",
-		"observedParentClockPhaseChangeRate", "grandmasterPriority1", "gm.ClockClass", "gm.ClockAccuracy",
-		"gm.OffsetScaledLogVariance", "grandmasterPriority2", "grandmasterIdentity"}
+	return []string{
+		"parentPortIdentity",
+		"parentStats",
+		"observedParentOffsetScaledLogVariance",
+		"observedParentClockPhaseChangeRate",
+		"grandmasterPriority1",
+		"gm.ClockClass",
+		"gm.ClockAccuracy",
+		"gm.OffsetScaledLogVariance",
+		"grandmasterPriority2",
+		"grandmasterIdentity",
+	}
 }
 
 // Update provides the Update method for the ParentDS values


### PR DESCRIPTION
This commit fixes clock class change messagin to cloud-events. In addition it fixes ts2phc offset processing in T-BC event:
- take ts2phc offsets into account when calculating the worst offset
- fix transition from ts2phc updates to ptp4l updates when exiting holdover
/cc @aneeshkp @nocturnalastro @josephdrichard @jzding 