### PR TITLE
Allow clock chain without input delays

### DIFF
--- a/addons/intel/e810.go
+++ b/addons/intel/e810.go
@@ -23,7 +23,7 @@ type E810Opts struct {
 	DevicePins          map[string]map[string]string `json:"pins"`
 	DpllSettings        map[string]uint64            `json:"settings"`
 	PhaseOffsetPins     map[string]map[string]string `json:"phaseOffsetPins"`
-	InputDelays         []InputPhaseDelays           `json:"interconnections"`
+	PhaseInputs         []PhaseInputs                `json:"interconnections"`
 }
 
 type E810UblxCmds struct {
@@ -145,7 +145,7 @@ func OnPTPConfigChangeE810(data *interface{}, nodeProfile *ptpv1.PtpProfile) err
 			for device, pins := range e810Opts.DevicePins {
 				dpllClockIdStr := fmt.Sprintf("%s[%s]", dpll.ClockIdStr, device)
 				if !unitTest {
-					(*nodeProfile).PtpSettings[dpllClockIdStr] = strconv.FormatUint(getClockIdE810(device), 10)
+					(*nodeProfile).PtpSettings[dpllClockIdStr] = strconv.FormatUint(getClockIDE810(device), 10)
 					for pin, value := range pins {
 						deviceDir := fmt.Sprintf("/sys/class/net/%s/device/ptp/", device)
 						phcs, err := os.ReadDir(deviceDir)
@@ -184,11 +184,11 @@ func OnPTPConfigChangeE810(data *interface{}, nodeProfile *ptpv1.PtpProfile) err
 					break
 				}
 				for pinProperty, value := range properties {
-					key := strings.Join([]string{iface, "phaseOffsetFilter", strconv.FormatUint(getClockIdE810(iface), 10), pinProperty}, ".")
+					key := strings.Join([]string{iface, "phaseOffsetFilter", strconv.FormatUint(getClockIDE810(iface), 10), pinProperty}, ".")
 					(*nodeProfile).PtpSettings[key] = value
 				}
 			}
-			if e810Opts.InputDelays != nil {
+			if e810Opts.PhaseInputs != nil {
 				if unitTest {
 					// Mock clock chain DPLL pins in unit test
 					clockChain.DpllPins = DpllPins
@@ -305,7 +305,7 @@ func E810(name string) (*plugin.Plugin, *interface{}) {
 	return &_plugin, &iface
 }
 
-func getClockIdE810(device string) uint64 {
+func getClockIDE810(device string) uint64 {
 	const (
 		PCI_EXT_CAP_ID_DSN       = 3
 		PCI_CFG_SPACE_SIZE       = 256

--- a/addons/intel/intel_test.go
+++ b/addons/intel/intel_test.go
@@ -52,6 +52,14 @@ func Test_ProcessProfileTGMNew(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+// Test that the profile with no phase inputs is processed correctly
+func Test_ProcessProfileTBCNoPhaseInputs(t *testing.T) {
+	unitTest = true
+	profile, err := loadProfile("./testdata/profile-tbc-no-input-delays.yaml")
+	assert.NoError(t, err)
+	err = OnPTPConfigChangeE810(nil, profile)
+	assert.NoError(t, err)
+}
 func Test_ProcessProfilesTbcTtsc(t *testing.T) {
 	unitTest = true
 	for _, config := range []string{"./testdata/profile-tbc.yaml", "./testdata/profile-t-tsc.yaml"} {
@@ -63,7 +71,7 @@ func Test_ProcessProfilesTbcTtsc(t *testing.T) {
 		err = OnPTPConfigChangeE810(nil, profile)
 		assert.NoError(t, err)
 		assert.Equal(t, ClockTypeTBC, clockChain.Type, "identified a wrong clock type")
-		assert.Equal(t, "5799633565432596414", clockChain.LeadingNIC.DpllClockId, "identified a wrong clock ID ")
+		assert.Equal(t, "5799633565432596414", clockChain.LeadingNIC.DpllClockID, "identified a wrong clock ID ")
 		assert.Equal(t, 9, len(clockChain.LeadingNIC.Pins), "wrong number of configurable pins")
 		assert.Equal(t, "ens4f1", clockChain.LeadingNIC.UpstreamPort, "wrong upstream port")
 		// Test holdover entry

--- a/addons/intel/testdata/profile-tbc-no-input-delays.yaml
+++ b/addons/intel/testdata/profile-tbc-no-input-delays.yaml
@@ -20,12 +20,10 @@ plugins:
       part: E810-XXVDA4T
       inputConnector:
         connector: SMA1
-        delayPs: 920
     - id: ens8f0
       part: E810-XXVDA4T
       inputConnector:
         connector: SMA1
-        delayPs: 920
       phaseOutputConnectors:
       - U.FL1
     pins:

--- a/addons/intel/testdata/profile-tgm.yaml
+++ b/addons/intel/testdata/profile-tgm.yaml
@@ -17,12 +17,12 @@ plugins:
       - SMA2
     - id: ens5f0
       part: E810-XXVDA4T
-      inputPhaseDelay:
+      inputConnector:
         connector: SMA1
         delayPs: 920
     - id: ens8f0
       part: E810-XXVDA4T
-      inputPhaseDelay:
+      inputConnector:
         connector: SMA1
         delayPs: 920
       phaseOutputConnectors:

--- a/doc/t-bc-dev-preview.md
+++ b/doc/t-bc-dev-preview.md
@@ -70,7 +70,7 @@ spec:
           - SMA1
         - id: ens2f0
           part: E810-XXVDA4T
-          inputPhaseDelay:
+          inputConnector:
             connector: SMA1
             delayPs: 0
         pins:
@@ -256,7 +256,7 @@ The profile above is for a dual-NIC chain of clocks operating as a single bounda
           - SMA1
         - id: ens2f0
           part: E810-XXVDA4T
-          inputPhaseDelay:
+          inputConnector:
             connector: SMA1
             delayPs: 0
         pins:

--- a/pkg/daemon/testdata/profile-tbc-tr.yaml
+++ b/pkg/daemon/testdata/profile-tbc-tr.yaml
@@ -20,12 +20,12 @@ plugins:
       - SMA2
     - id: ens5f0
       part: E810-XXVDA4T
-      inputPhaseDelay:
+      inputConnector:
         connector: SMA1
         delayPs: 920
     - id: ens8f0
       part: E810-XXVDA4T
-      inputPhaseDelay:
+      inputConnector:
         connector: SMA1
         delayPs: 920
       phaseOutputConnectors:


### PR DESCRIPTION
Due to the e810 driver / FW bug, phase compensations can't be effectively applied on the input side. 
This change removes the need to specify input delays for interconnections. 
The delays can still be compensated for by the ts2phc setting
/cc @aneeshkp @nocturnalastro @josephdrichard @jzding 