### PR TITLE
Endpoint to be triggered by cloud-event-proxy when starting

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -159,7 +159,7 @@ func main() {
 		daemon.StartMetricsServer("0.0.0.0:9091")
 	}
 
-	daemon.StartReadyServer("0.0.0.0:8081", tracker)
+	daemon.StartReadyServer("0.0.0.0:8081", tracker, stdoutToSocket)
 
 	// Wait for one ticker interval before loading the profile
 	// This allows linuxptp-daemon connection to the cloud-event-proxy container to

--- a/pkg/daemon/gpsd.go
+++ b/pkg/daemon/gpsd.go
@@ -57,7 +57,7 @@ type GPSD struct {
 	subscriber           *GPSDSubscriber
 	monitorCtx           context.Context
 	monitorCancel        context.CancelFunc
-	c                    *net.Conn
+	c                    net.Conn
 }
 
 // GPSDSubscriber ... event subscriber
@@ -162,7 +162,8 @@ func (g *GPSD) CmdInit() {
 	g.cmdLine = fmt.Sprintf("/usr/local/sbin/%s -p -n -S 2947 -G -N %s", g.Name(), g.SerialPort())
 }
 
-func (g *GPSD) ProcessStatus(c *net.Conn, status int64) {
+// ProcessStatus ...
+func (g *GPSD) ProcessStatus(c net.Conn, status int64) {
 	if c != nil {
 		g.c = c
 	}

--- a/pkg/daemon/gpspipe.go
+++ b/pkg/daemon/gpspipe.go
@@ -36,7 +36,7 @@ type gpspipe struct {
 	exitCh     chan struct{}
 	stopped    bool
 	messageTag string
-	c          *net.Conn
+	c          net.Conn
 }
 
 // Name ... Process name
@@ -135,7 +135,7 @@ func (gp *gpspipe) CmdInit() {
 	gp.cmdLine = fmt.Sprintf("/usr/local/bin/gpspipe -v -R -l -o %s", gp.SerialPort())
 }
 
-func (gp *gpspipe) ProcessStatus(c *net.Conn, status int64) {
+func (gp *gpspipe) ProcessStatus(c net.Conn, status int64) {
 	if c != nil {
 		gp.c = c
 	}

--- a/pkg/daemon/log_parsing.go
+++ b/pkg/daemon/log_parsing.go
@@ -14,20 +14,20 @@ import (
 	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/utils"
 )
 
-func convertParserRoleToMetricsRole(role parserconstants.PTPPortRole) ptpPortRole {
+func convertParserRoleToMetricsRole(role parserconstants.PTPPortRole) event.PtpPortRole {
 	switch role {
 	case parserconstants.PortRoleSlave:
-		return SLAVE
+		return event.SLAVE
 	case parserconstants.PortRoleMaster:
-		return MASTER
+		return event.MASTER
 	case parserconstants.PortRolePassive:
-		return PASSIVE
+		return event.PASSIVE
 	case parserconstants.PortRoleFaulty:
-		return FAULTY
+		return event.FAULTY
 	case parserconstants.PortRoleListening:
-		return LISTENING
+		return event.LISTENING
 	default:
-		return UNKNOWN
+		return event.UNKNOWN
 	}
 }
 
@@ -155,7 +155,9 @@ func processParsedEvent(process *ptpProcess, ptpEvent *parser.PTPEvent) {
 		configName = strings.Split(configName, MessageTagSuffixSeperator)[0]
 
 		interfaceName := process.ifaces[ptpEvent.PortID-1].Name
-		UpdateInterfaceRoleMetrics(process.name, interfaceName, convertParserRoleToMetricsRole(ptpEvent.Role))
+		role := convertParserRoleToMetricsRole(ptpEvent.Role)
+		UpdateInterfaceRoleMetrics(process.name, interfaceName, role)
+		process.handler.SetPortRole(configName, interfaceName, ptpEvent)
 
 		if configName == "" {
 			return

--- a/pkg/daemon/log_parsing.go
+++ b/pkg/daemon/log_parsing.go
@@ -14,20 +14,20 @@ import (
 	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/utils"
 )
 
-func convertParserRoleToMetricsRole(role parserconstants.PTPPortRole) event.PtpPortRole {
+func convertParserRoleToMetricsRole(role parserconstants.PTPPortRole) ptpPortRole {
 	switch role {
 	case parserconstants.PortRoleSlave:
-		return event.SLAVE
+		return SLAVE
 	case parserconstants.PortRoleMaster:
-		return event.MASTER
+		return MASTER
 	case parserconstants.PortRolePassive:
-		return event.PASSIVE
+		return PASSIVE
 	case parserconstants.PortRoleFaulty:
-		return event.FAULTY
+		return FAULTY
 	case parserconstants.PortRoleListening:
-		return event.LISTENING
+		return LISTENING
 	default:
-		return event.UNKNOWN
+		return UNKNOWN
 	}
 }
 

--- a/pkg/daemon/process.go
+++ b/pkg/daemon/process.go
@@ -1,14 +1,17 @@
 package daemon
 
-import "net"
-import "github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/config"
+import (
+	"net"
+
+	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/config"
+)
 
 type process interface {
 	Name() string
 	Stopped() bool
 	CmdStop()
 	CmdInit()
-	ProcessStatus(c *net.Conn, status int64)
+	ProcessStatus(c net.Conn, status int64)
 	CmdRun(stdToSocket bool)
 	MonitorProcess(p config.ProcessConfig)
 	ExitCh() chan struct{}

--- a/pkg/daemon/ready.go
+++ b/pkg/daemon/ready.go
@@ -1,13 +1,16 @@
 package daemon
 
 import (
+	"encoding/json"
 	"fmt"
+	"net"
 	"net/http"
 	"strings"
 	"sync"
 	"time"
 
 	"github.com/golang/glog"
+	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/event"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	utilwait "k8s.io/apimachinery/pkg/util/wait"
 )
@@ -76,10 +79,80 @@ func (h readyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func StartReadyServer(bindAddress string, tracker *ReadyTracker) {
+type metricHandler struct {
+	tracker *ReadyTracker
+}
+
+type ProcessStateSnapshot struct {
+	ProcessName string `json:"process_name"`
+	IsUp        bool   `json:"is_up"`
+	ConfigName  string `json:"config_name"`
+}
+
+type Snapshot struct {
+	Timestamp int64
+	Processes []ProcessStateSnapshot `json:"processes"`
+	Metrics   event.MetricSnapshot   `json:"metrics"`
+}
+
+func (h metricHandler) ServeHTTP(w http.ResponseWriter, _ *http.Request) {
+	if isReady, _ := h.tracker.Ready(); !isReady {
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+	processManager := h.tracker.processManager
+	eventHandler := h.tracker.processManager.ptpEventHandler
+
+	snapshot := Snapshot{
+		Timestamp: time.Now().Unix(), // TODO: Track last time values changed
+		Metrics:   eventHandler.GetMetricSnapshot(),
+		Processes: make([]ProcessStateSnapshot, 0),
+	}
+	for _, p := range processManager.process {
+		snapshot.Processes = append(snapshot.Processes, ProcessStateSnapshot{
+			ProcessName: p.name,
+			IsUp:        !p.Stopped(),
+			ConfigName:  p.configName,
+		})
+	}
+
+	data, err := json.Marshal(snapshot)
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		fmt.Fprint(w, "failed to marshal snapshot")
+	}
+	w.WriteHeader(http.StatusOK)
+	fmt.Fprint(w, string(data))
+
+	go func() {
+		var socketConnection net.Conn
+		for {
+			var err error
+			socketConnection, err = dialSocket()
+			if err == nil {
+				break
+			}
+		}
+		defer socketConnection.Close()
+
+		eventHandler := h.tracker.processManager.ptpEventHandler
+		eventHandler.EmitClockSyncLogs(socketConnection)
+		eventHandler.EmitPortRoleLogs(socketConnection)
+
+		processManager := h.tracker.processManager
+		processManager.EmitProcessStatusLogs()
+		processManager.EmitClockClassLogs(socketConnection)
+	}()
+}
+
+// StartReadyServer ...
+func StartReadyServer(bindAddress string, tracker *ReadyTracker, serveInitMetrics bool) {
 	glog.Info("Starting Ready Server")
 	mux := http.NewServeMux()
 	mux.Handle("/ready", readyHandler{tracker: tracker})
+	if serveInitMetrics {
+		mux.Handle("/inital-metrics", metricHandler{tracker: tracker})
+	}
 	go utilwait.Until(func() {
 		err := http.ListenAndServe(bindAddress, mux)
 		if err != nil {

--- a/pkg/dpll/dpll.go
+++ b/pkg/dpll/dpll.go
@@ -281,7 +281,7 @@ func (d *DpllConfig) CmdInit() {
 }
 
 // ProcessStatus ... process status
-func (d *DpllConfig) ProcessStatus(c *net.Conn, status int64) {
+func (d *DpllConfig) ProcessStatus(_ net.Conn, _ int64) {
 }
 
 // CmdRun ... run command

--- a/pkg/event/event.go
+++ b/pkg/event/event.go
@@ -18,6 +18,7 @@ import (
 	fbprotocol "github.com/facebook/time/ptp/protocol"
 	"github.com/golang/glog"
 	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/leap"
+	parserconstants "github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/parser/constants"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -37,7 +38,7 @@ const (
 	//Status           ValueType = "status"
 	PHASE_STATUS              ValueType = "phase_status"
 	FREQUENCY_STATUS          ValueType = "frequency_status"
-	NMEA_STATUS               ValueType = "nmea_status"
+	NMEA_STATUS               ValueType = parserconstants.NmeaStatus
 	PROCESS_STATUS            ValueType = "process_status"
 	PPS_STATUS                ValueType = "pps_status"
 	LEADING_INTERFACE_UNKNOWN string    = "unknown"

--- a/pkg/event/event.go
+++ b/pkg/event/event.go
@@ -48,8 +48,7 @@ const (
 	EXT_QL                    ValueType = "ext_ql"
 	CLOCK_QUALITY             ValueType = "clock_quality"
 	NETWORK_OPTION            ValueType = "network_option"
-	EEC_STATE                 ValueType = "eec_state"
-	PORT_ROLE                 ValueType = "role"
+	EEC_STATE                           = "eec_state"
 )
 
 var valueTypeHelpTxt = map[ValueType]string{
@@ -72,17 +71,6 @@ type ClockClassRequest struct {
 	clockClass    fbprotocol.ClockClass
 	clockAccuracy fbprotocol.ClockAccuracy
 }
-
-type PtpPortRole int
-
-const (
-	PASSIVE PtpPortRole = iota
-	SLAVE
-	MASTER
-	FAULTY
-	UNKNOWN
-	LISTENING
-)
 
 var (
 	//  make sure only one clock class update is tried if it fails next  try will pass
@@ -1096,35 +1084,6 @@ func (e *EventHandler) SetPortRole(cfgName, portNane string, event *parser.PTPEv
 		e.portRole[cfgName] = make(map[string]*parser.PTPEvent)
 	}
 	e.portRole[cfgName][portNane] = event
-}
-
-type MetricSnapshot struct {
-	ClockClass        map[string]fbprotocol.ClockClass `json:"clock_class"`
-	OverallClockClass fbprotocol.ClockClass            `json:"overall_clock_class"`
-	PortRoles         map[string]map[string]string     `json:"port_roles"`
-}
-
-func (e *EventHandler) GetMetricSnapshot() MetricSnapshot {
-	res := MetricSnapshot{
-		OverallClockClass: e.clockClass,
-		ClockClass:        make(map[string]fbprotocol.ClockClass),
-		PortRoles:         make(map[string]map[string]string),
-	}
-
-	for cfgName, syncState := range e.clkSyncState {
-		res.ClockClass[cfgName] = syncState.clockClass
-	}
-
-	for cfgName, portRole := range e.portRole {
-		for portName, role := range portRole {
-			if _, ok := res.PortRoles[cfgName]; !ok {
-				res.PortRoles[cfgName] = make(map[string]string)
-			}
-			res.PortRoles[cfgName][portName] = role.Role.String()
-		}
-	}
-
-	return res
 }
 
 // EmitClockSyncLogs emits the clock sync state logs

--- a/pkg/event/event.go
+++ b/pkg/event/event.go
@@ -602,7 +602,7 @@ connect:
 	}
 
 	if redialClockClass {
-		go func(eConn *net.Conn) {
+		go func() {
 			defer func() {
 				if err := recover(); err != nil {
 					glog.Errorf("restored from clock class update: %s", err)
@@ -633,7 +633,7 @@ connect:
 					}
 				}
 			}
-		}(&c)
+		}()
 		redialClockClass = false
 	}
 	// call all monitoring candidates; verify every 5 secs for any new

--- a/pkg/parser/constants/port_roles.go
+++ b/pkg/parser/constants/port_roles.go
@@ -17,3 +17,20 @@ const (
 	// PortRoleListening ...
 	PortRoleListening
 )
+
+func (pr PTPPortRole) String() string {
+	switch pr {
+	case PortRoleSlave:
+		return "SLAVE"
+	case PortRoleMaster:
+		return "MASTER"
+	case PortRolePassive:
+		return "PASSIVE"
+	case PortRoleFaulty:
+		return "FAULTY"
+	case PortRoleListening:
+		return "LISTENING"
+	default:
+		return "UNKNOWN"
+	}
+}

--- a/pkg/parser/ts2phc_parser.go
+++ b/pkg/parser/ts2phc_parser.go
@@ -5,8 +5,6 @@ import (
 	"regexp"
 	"strconv"
 
-	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/event"
-
 	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/parser/constants"
 )
 
@@ -170,7 +168,7 @@ func extractTS2PHCnmeaStatus(parsed *ts2phcParsed) (*Metrics, error) {
 	var statusMetrics []StatusMetric
 	if parsed.Status != nil {
 		statusMetrics = append(statusMetrics, StatusMetric{
-			Subtype: string(event.NMEA_STATUS),
+			Subtype: string(constants.NmeaStatus),
 			Status:  *parsed.Status,
 		})
 	}


### PR DESCRIPTION
The end point is required to populate initial values when
it has crashed. The approach triggers logs to be emitted
as it maintains the current mechanisms for update values
in cloud-event-proxy.
