### PR TITLE
When Locking PTP Source to One NIC With Dual NIC PTP Synchronization Configured, Incorrect Clock Class Reported via REST API

### DIFF
--- a/pkg/daemon/daemon_test.go
+++ b/pkg/daemon/daemon_test.go
@@ -107,7 +107,7 @@ func (tc *TestCase) cleanupMetrics() {
 	daemon.FrequencyAdjustment.With(map[string]string{"from": tc.from, "process": tc.process, "node": tc.node, "iface": tc.iface}).Set(CLEANUP)
 	daemon.Delay.With(map[string]string{"from": tc.from, "process": tc.process, "node": tc.node, "iface": tc.iface}).Set(CLEANUP)
 	daemon.ClockState.With(map[string]string{"process": tc.process, "node": tc.node, "iface": tc.iface}).Set(CLEANUP)
-	daemon.ClockClassMetrics.With(map[string]string{"process": tc.process, "node": tc.node}).Set(CLEANUP)
+	daemon.ClockClassMetrics.With(map[string]string{"process": tc.process, "config": "ptp4l.0.config", "node": tc.node}).Set(CLEANUP)
 	daemon.InterfaceRole.With(map[string]string{"process": tc.process, "node": tc.node, "iface": tc.iface}).Set(CLEANUP)
 }
 
@@ -590,7 +590,7 @@ func Test_ProcessPTPMetrics(t *testing.T) {
 				assert.Equal(tc.expectedClockState, testutil.ToFloat64(clockState), "ClockState does not match\n%s", tc.String())
 			}
 			if tc.expectedClockClassMetrics != SKIP {
-				clockClassMetrics := daemon.ClockClassMetrics.With(map[string]string{"process": tc.process, "node": tc.node})
+				clockClassMetrics := daemon.ClockClassMetrics.With(map[string]string{"process": tc.process, "config": "ptp4l.0.config", "node": tc.node})
 				assert.Equal(tc.expectedClockClassMetrics, testutil.ToFloat64(clockClassMetrics), "ClockClassMetrics does not match\n%s", tc.String())
 			}
 			if tc.expectedInterfaceRole != SKIP {

--- a/pkg/event/event.go
+++ b/pkg/event/event.go
@@ -228,10 +228,7 @@ func Init(nodeName string, stdOutToSocket bool, socketName string, processChanne
 			downstreamParentDataSet:  &protocol.ParentDataSet{},
 		},
 	}
-	if clockClassMetric != nil {
-		clockClassMetric.With(prometheus.Labels{
-			"process": PTP4lProcessName, "node": nodeName}).Set(248)
-	}
+
 	StateRegisterer = NewStateNotifier()
 	return ptpEvent
 
@@ -686,7 +683,9 @@ connect:
 				if event.WriteToLog && logDataValues != "" {
 					logOut = append(logOut, logDataValues)
 				}
-				e.UpdateClockStateMetrics(event.State, string(event.ProcessName), event.IFace)
+				if !e.stdoutToSocket {
+					e.UpdateClockStateMetrics(event.State, string(event.ProcessName), event.IFace)
+				}
 			} else {
 
 				// Update the in MemData
@@ -896,6 +895,9 @@ func (e *EventHandler) GetPTPState(source EventSource, cfgName string) PTPState 
 
 // UpdateClockStateMetrics ...
 func (e *EventHandler) UpdateClockStateMetrics(state PTPState, process, iFace string) {
+	if e.stdoutToSocket {
+		return
+	}
 	labels := prometheus.Labels{
 		"process": process, "node": e.nodeName, "iface": iFace}
 	if state == PTP_LOCKED {
@@ -990,6 +992,9 @@ func registerMetrics(m *prometheus.GaugeVec) {
 }
 
 func (e *EventHandler) unregisterMetrics(configName string, processName string) {
+	if e.stdoutToSocket {
+		return // no need to unregister metrics if events are going to socket
+	}
 	if data, ok := e.data[configName]; ok {
 		for _, v := range data {
 			if string(v.ProcessName) == processName || processName == "" {
@@ -1056,9 +1061,9 @@ func (e *EventHandler) UpdateClockClass(c net.Conn, clk ClockClassRequest) {
 			} else {
 				glog.Errorf("failed to write class change event, connection is nil")
 			}
-		} else {
+		} else if e.clockClassMetric != nil {
 			e.clockClassMetric.With(prometheus.Labels{
-				"process": PTP4lProcessName, "node": e.nodeName}).Set(float64(clockClass))
+				"process": PTP4lProcessName, "config": clk.cfgName, "node": e.nodeName}).Set(float64(clockClass))
 		}
 		fmt.Printf("%s", clockClassOut)
 	}

--- a/pkg/event/event_tbc.go
+++ b/pkg/event/event_tbc.go
@@ -259,9 +259,9 @@ func (e *EventHandler) announceClockClass(clockClass int, cfgName string, c net.
 		} else {
 			glog.Errorf("failed to write class change event, connection is nil")
 		}
-	} else {
+	} else if e.clockClassMetric != nil {
 		e.clockClassMetric.With(prometheus.Labels{
-			"process": PTP4lProcessName, "node": e.nodeName}).Set(float64(clockClass))
+			"process": PTP4lProcessName, "config": cfgName, "node": e.nodeName}).Set(float64(clockClass))
 	}
 	glog.Infof("%s", message)
 }


### PR DESCRIPTION
This commit implements logic to correctly update the clock class
when a FAULTY/RECOVERY condition of the port is detected.
Summary :
Ensure PMC clock-class queries run at most once per configName concurrently.
Trigger PMC on port Faulty/Holdover and recovery transitions to refresh GM class.
Run PMC polling outside the log scanner so we still update when ptp4l is silent.

What’s changed
Per-config single-flight guard:
updateClockClass now cases on the shared guard and logs when a run is skipped.
Cleanup: guard entry is removed on cmdStop() of the corresponding process.

Faulty/Holdover and recovery handling:
When the clock enters HOLDOVER or LOCKED without a specific iface, we now trigger updateClockClass (after a short delay) so GM class is refreshed on port fault/recovery events, not just on normal offset updates.
PMC polling outside the scanner:
Introduced/relied on a background loop that consumes a pmcCheck flag and calls updateClockClass independent of log scanner activity.
A periodic ticker sets pmcCheck for ptp4l processes; the background loop handles the PMC call even if ptp4l is not emitting logs.

Release note
Improve clock class update robustness: deduplicate PMC queries per config, update on Faulty/Holdover and recovery, and poll PMC independently of log output.