### PR TITLE
Send ptp4l event when running without proxy

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -994,6 +994,9 @@ func (p *ptpProcess) cmdRun(stdoutToSocket bool, pm *PluginManager) {
 					printWhenNotEmpty(logfilter.FilterOutput(p.logFilters, output))
 					p.processPTPMetrics(output)
 					if p.name == ptp4lProcessName {
+						if profileClockType == TBC {
+							p.tBCTransitionCheck(output, pm)
+						}
 						if strings.Contains(output, ClockClassChangeIndicator) {
 							go p.updateClockClass(nil)
 						}


### PR DESCRIPTION
This commit fixes T-BC ptp4l event when configured to run without the cloud-event proxy.

/cc @aneeshkp @jzding @josephdrichard @nocturnalastro 