### PR TITLE
CI: Increased the upstream CI tests timeout 115 minutes

### DIFF
--- a/.github/workflows/aws-ci.yaml
+++ b/.github/workflows/aws-ci.yaml
@@ -12,7 +12,7 @@ concurrency:
 jobs:
   deploy-ec2:
     runs-on: ubuntu-latest
-    timeout-minutes: 55
+    timeout-minutes: 115
     steps:
       - name: Remove ok-to-test label if new commit
         uses: actions/github-script@v7
@@ -48,7 +48,7 @@ jobs:
           repository: k8snetworkplumbingwg/ptp-operator
           ref: main
           path: ptp-operator
-      
+
       - name: checkout the Current SHA for the linuxptp-daemon
         id: sha
         run: |
@@ -92,7 +92,7 @@ jobs:
             --query 'Reservations[0].Instances[0].PrivateIpAddress' \
             --output text)
           echo "private_ip=$PRIVATE_IP" >> $GITHUB_ENV
-          
+
       - name: Wait for instance to be online
         run: |
           ./ptp-operator/scripts/retry.sh 180 10 sh -c "aws ssm describe-instance-information --query \"InstanceInformationList[?InstanceId=='$instance_id'].PingStatus\" --output text | grep -q 'Online'"
@@ -105,9 +105,9 @@ jobs:
             aws ssm send-command --instance-ids $instance_id \
                 --document-name "AWS-RunShellScript" \
                 --parameters 'commands=["sudo bash -c '\''echo '"$(cat temp_key.pub)"' >> /home/fedora/.ssh/authorized_keys'\''"]'
-            
+
             ssh-add temp_key
-            
+
             ./ptp-operator/scripts/retry.sh 60 5 ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null fedora@"$public_ip" uptime
             rsync -r -e "ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null" ptp-operator fedora@"$public_ip":~/.
             ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null fedora@"$public_ip" sudo ./ptp-operator/scripts/run-on-vm.sh "$private_ip"


### PR DESCRIPTION
Test added recently lead to timeout in CI because they took more than 55 minutes to run. This PR extends the timeout to 115 minutes to match the new 2h OIDC timeout.