### PR TITLE
CNF-22128: Add E830 DPLL handling with hardwareconfig

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -467,6 +467,8 @@ type Daemon struct {
 	delayedPhc2sysMu sync.Mutex // protects skipInitialStartup on phc2sys processes
 }
 
+type initialStateSyncer interface{ SyncInitialState() }
+
 // UpdateHardwareConfig implements controller.HardwareConfigUpdateHandler.
 // It is invoked by the controller reconciler via HardwareConfigHandler
 // (wired in cmd/main.go) to push the effective hardware configuration
@@ -489,6 +491,12 @@ func (dn *Daemon) getHoldoverParameters(profileName string, clockID uint64) *ptp
 	return dn.hardwareConfigManager.GetHoldoverParameters(profileName, clockID)
 }
 
+// getDPLLFlags retrieves DPLL monitoring flags from HardwareConfig for a specific clock ID.
+// Returns nil if no hardware config is available or no flags are configured for the clock.
+func (dn *Daemon) getDPLLFlags(profileName string, clockID uint64) *dpll.Flag {
+	return dn.hardwareConfigManager.GetDPLLFlags(profileName, clockID)
+}
+
 // getInterfacesFromHardwareConfig derives interfaces from hardwareconfig structure for T-BC mode.
 // It extracts the first interface from structure[*]->dpll->networkInterface.
 // Returns an empty slice if no hardwareconfig is available or no interfaces are found.
@@ -506,24 +514,31 @@ func (dn *Daemon) getInterfacesFromHardwareConfig(nodeProfile *ptpv1.PtpProfile)
 
 	var interfaces config.IFaces
 
-	// Iterate through hardware profiles and extract interfaces from structure
+	// Iterate through hardware profiles and extract interfaces from all subsystems.
+	// All subsystems (not just the first) are included so that unmanaged DPLL subsystems
+	// (e.g., Intel E830 CF1/CF2) enter the DPLL initialisation loop.
 	for _, hwProfile := range hwProfiles {
 		if hwProfile.ClockChain == nil || len(hwProfile.ClockChain.Structure) == 0 {
 			continue
 		}
 
-		// Get the first subsystem from structure and use GetSubsystemNetworkInterface
-		firstSubsystem := hwProfile.ClockChain.Structure[0]
-		networkInterface, err := hardwareconfig.GetSubsystemNetworkInterface(hwProfile.ClockChain, firstSubsystem.Name)
-		if err != nil {
-			glog.V(2).Infof("Failed to get network interface for first subsystem %s: %v", firstSubsystem.Name, err)
-			continue
+		profileName := "<unnamed>"
+		if hwProfile.Name != nil {
+			profileName = *hwProfile.Name
 		}
+		glog.Infof("getInterfacesFromHardwareConfig: iterating %d subsystems in profile %s",
+			len(hwProfile.ClockChain.Structure), profileName)
 
-		if networkInterface != "" {
-			// Determine event source based on T-BC configuration
-			// For T-BC, the interface typically depends on PTP4l
-			eventSource := event.PTP4l
+		for _, subsystem := range hwProfile.ClockChain.Structure {
+			networkInterface, err := hardwareconfig.GetSubsystemNetworkInterface(hwProfile.ClockChain, subsystem.Name)
+			if err != nil {
+				glog.Infof("getInterfacesFromHardwareConfig: subsystem %s: no network interface: %v", subsystem.Name, err)
+				continue
+			}
+			if networkInterface == "" {
+				glog.Infof("getInterfacesFromHardwareConfig: subsystem %s: empty network interface, skipping", subsystem.Name)
+				continue
+			}
 
 			// Get PHC ID for the interface
 			phcID := ptpnetwork.GetPhcId(networkInterface)
@@ -538,9 +553,21 @@ func (dn *Daemon) getInterfacesFromHardwareConfig(nodeProfile *ptpv1.PtpProfile)
 				glog.Warningf("getInterfacesFromHardwareConfig: could not get PHC ID for iface %s, convergeConfig PHC fallback will not work", networkInterface)
 			}
 
+			// Subsystems that have PhaseInputs configured are driven by ptp4l (they
+			// receive a PTP time-receiver pin and run a ptp4l process).  Subsystems
+			// without PhaseInputs are hardware-slaved (e.g., Intel E830 CF cards that
+			// receive timing through hardware SDP/esync signals from the leader card)
+			// and must not use PTP4l as their source: getDpllState() would otherwise
+			// always return phaseStatus which stays DPLL_INVALID because no pps device
+			// notification ever arrives for these cards.  PPS is the correct source for
+			// hardware-slaved unmanaged DPLLs.
+			source := event.PTP4l
+			if len(subsystem.DPLL.PhaseInputs) == 0 {
+				source = event.PPS
+			}
 			interfaces = append(interfaces, config.Iface{
 				Name:     networkInterface,
-				Source:   eventSource,
+				Source:   source,
 				PhcId:    phcID,
 				IsMaster: false,
 			})
@@ -869,6 +896,13 @@ func (dn *Daemon) applyNodePTPProfiles() error {
 						},
 						InitialPTPState: event.PTP_FREERUN,
 					})
+					// Pre-populate event state immediately after the EventChannel
+					// is set up so that hardware-slaved DPLLs (e.g. E830 CF) are
+					// present in the event data before the async monitoring goroutine
+					// completes its own initial dump.
+					if syncer, ok := d.(initialStateSyncer); ok {
+						syncer.SyncInitialState()
+					}
 					glog.Infof("enabling dep process %s with Max %d Min %d Holdover %d", d.Name(), p.ptpClockThreshold.MaxOffsetThreshold, p.ptpClockThreshold.MinOffsetThreshold, p.ptpClockThreshold.HoldOverTimeout)
 				}
 			}
@@ -1382,6 +1416,23 @@ func (dn *Daemon) applyNodePtpProfile(runID int, nodeProfile *ptpv1.PtpProfile) 
 						// Fall back to plugin/profile settings (backward compatibility)
 						glog.Infof("Using holdover parameters from profile/plugin for clock %#x: MaxInSpec=%dns, LocalMaxOffset=%dns, Timeout=%ds",
 							clockId, maxInSpecOffset, localMaxHoldoverOffSet, localHoldoverTimeout)
+					}
+
+					// Try to get DPLL flags from HardwareConfig (new system)
+					// This takes precedence over plugin-provided values
+					hwFlags := dn.getDPLLFlags(profileName, clockId)
+					if hwFlags != nil {
+						flags = *hwFlags
+						glog.Infof("Using DPLL flags from HardwareConfig for clock %#x: %d", clockId, flags)
+					}
+
+					// Hardware-slaved DPLLs (e.g. E830 CF cards, identified by
+					// FlagOnlyPhaseStatus) never perform holdover
+					if flags&dpll.FlagOnlyPhaseStatus == dpll.FlagOnlyPhaseStatus {
+						localMaxHoldoverOffSet = 0
+						localHoldoverTimeout = 1 //do not divide by zero in case it is ever used
+						maxInSpecOffset = 0
+						glog.Infof("Resetting holdover parameters for %s (FlagOnlyPhaseStatus): not applicable for hardware-slaved DPLLs", iface.Name)
 					}
 
 					eventSource = []event.EventSource{iface.Source}
@@ -1944,7 +1995,7 @@ func (p *ptpProcess) cmdSetEnabled(enabled bool) {
 				go p.cmdRun(p.dn.stdoutToSocket, &(p.dn.pluginManager))
 			}
 		} else {
-			go p.cmdStop()
+			p.cmdStop()
 		}
 	case phc2sysProcessName:
 		if enabled {

--- a/pkg/dpll/dpll.go
+++ b/pkg/dpll/dpll.go
@@ -5,9 +5,7 @@ import (
 	"fmt"
 	"math"
 	"net"
-	"os"
 	"strconv"
-	"strings"
 	"sync"
 	"time"
 
@@ -81,7 +79,6 @@ type dpllApiType string
 var MockDpllReplies chan *nl.DoDeviceGetReply
 
 const (
-	SYSFS   dpllApiType = "sysfs"
 	NETLINK dpllApiType = "netlink"
 	MOCK    dpllApiType = "mock"
 	NONE    dpllApiType = "none"
@@ -108,8 +105,7 @@ type DpllConfig struct {
 	holdoverCloseCh        chan bool
 	ticker                 *time.Ticker
 	apiType                dpllApiType
-	// DPLL netlink connection pointer. If 'nil', use sysfs
-	conn *nl.Conn
+	conn                   *nl.Conn
 	// We need to keep latest DPLL status values, since Netlink device
 	// change indications don't contain all the status fields, but
 	// only the changed one(s)
@@ -278,6 +274,36 @@ func (d *DpllConfig) CmdInit() {
 	glog.Infof("api type %v", d.apiType)
 }
 
+// SyncInitialState does a one-shot synchronous DPLL device dump and sends an
+// initial state event. It must be called after MonitorProcess has set up the
+// EventChannel. This closes the race window between profile application
+// (which sends a Reset that wipes all DPLL event data) and the asynchronous
+// MonitorDpllNetlink goroutine completing its own initial dump. Without this,
+// hardware-slaved DPLLs (e.g. E830 CF cards) may be absent from the event
+// data when the first SourceLost event from the leader DPLL arrives.
+func (d *DpllConfig) SyncInitialState() {
+	if d.apiType != NETLINK {
+		return
+	}
+	if d.processConfig.EventChannel == nil {
+		glog.Infof("SyncInitialState: EventChannel not set for %s, skipping", d.iface)
+		return
+	}
+	conn, err := nl.Dial(nil)
+	if err != nil {
+		glog.Infof("SyncInitialState: failed to dial netlink for %s: %v", d.iface, err)
+		return
+	}
+	defer conn.Close()
+	replies, err := conn.DumpDeviceGet()
+	if err != nil {
+		glog.Infof("SyncInitialState: failed to dump DPLL devices for %s: %v", d.iface, err)
+		return
+	}
+	glog.Infof("SyncInitialState: pre-populating DPLL state for %s (%d devices)", d.iface, len(replies))
+	d.applyStateUpdate(replies, nil)
+}
+
 // ProcessStatus ... process status
 func (d *DpllConfig) ProcessStatus(_ net.Conn, _ int64) {
 }
@@ -385,6 +411,8 @@ func (d *DpllConfig) nlUpdateState(devices []*nl.DoDeviceGetReply, pins []*nl.Pi
 				d.phaseStatus = int64(reply.LockStatus)
 				glog.Infof("%s (%#x) updating pps to %s (%d)", d.iface, d.clockId, stateName(d.phaseStatus), d.phaseStatus)
 				valid = true
+			default:
+				glog.Infof("discarding irrelevant dpll type: %s, id %#x", nl.GetDpllType(reply.Type), d.clockId)
 			}
 		}
 	}
@@ -396,6 +424,17 @@ func (d *DpllConfig) nlUpdateState(devices []*nl.DoDeviceGetReply, pins []*nl.Pi
 		}
 	}
 	return valid
+}
+
+// applyStateUpdate atomically updates DPLL state from device/pin data and
+// re-evaluates the state machine. The lock ensures no concurrent goroutine
+// can observe or mutate a partially-updated DpllConfig.
+func (d *DpllConfig) applyStateUpdate(devices []*nl.DoDeviceGetReply, pins []*nl.PinInfo) {
+	d.Lock()
+	defer d.Unlock()
+	if d.nlUpdateState(devices, pins) {
+		d.stateDecision()
+	}
 }
 
 // monitorNtf receives a multicast unsolicited notification and
@@ -439,22 +478,10 @@ func (d *DpllConfig) monitorNtf(c *genetlink.Conn) {
 				glog.Errorf("hardwareconfig handler error: %v", err)
 			}
 		}
-		if d.nlUpdateState(devices, pins) {
-			d.stateDecision()
-		}
+		d.applyStateUpdate(devices, pins)
 	}
 }
 
-// checks whether sysfs file structure exists for dpll associated with the interface
-func (d *DpllConfig) isSysFsPresent() bool {
-	path := fmt.Sprintf("/sys/class/net/%s/device/dpll_0_state", d.iface)
-	if _, err := os.Stat(path); err == nil {
-		return true
-	}
-	return false
-}
-
-// MonitorDpllSysfs monitors DPLL through sysfs
 func (d *DpllConfig) isNetLinkPresent() bool {
 	conn, err := nl.Dial(nil)
 	if err != nil {
@@ -465,11 +492,8 @@ func (d *DpllConfig) isNetLinkPresent() bool {
 	return true
 }
 
-// setAPIType
 func (d *DpllConfig) setAPIType() {
-	if d.isSysFsPresent() {
-		d.apiType = SYSFS
-	} else if d.isNetLinkPresent() {
+	if d.isNetLinkPresent() {
 		d.apiType = NETLINK
 	} else {
 		d.apiType = NONE
@@ -479,9 +503,7 @@ func (d *DpllConfig) setAPIType() {
 func (d *DpllConfig) MonitorDpllMock() {
 	glog.Info("starting dpll mock monitoring")
 
-	if d.nlUpdateState([]*nl.DoDeviceGetReply{<-MockDpllReplies}, []*nl.PinInfo{}) {
-		d.stateDecision()
-	}
+	d.applyStateUpdate([]*nl.DoDeviceGetReply{<-MockDpllReplies}, []*nl.PinInfo{})
 
 	glog.Infof("closing dpll mock ")
 }
@@ -518,9 +540,7 @@ func (d *DpllConfig) MonitorDpllNetlink() {
 
 			d.devices = replies
 
-			if d.nlUpdateState(replies, []*nl.PinInfo{}) {
-				d.stateDecision()
-			}
+			d.applyStateUpdate(replies, []*nl.PinInfo{})
 
 			err = c.JoinGroup(mcastID)
 			if err != nil {
@@ -615,14 +635,11 @@ func (d *DpllConfig) MonitorDpll() {
 	fmt.Println(d.apiType)
 	if d.apiType == MOCK {
 		return
-	} else if d.apiType == SYSFS {
-		go d.MonitorDpllSysfs()
-		d.isMonitoring = true
 	} else if d.apiType == NETLINK {
 		go d.MonitorDpllNetlink()
 		d.isMonitoring = true
 	} else {
-		glog.Errorf("dpll monitoring is not possible, both sysfs is not available or netlink implementation is not present")
+		glog.Errorf("dpll monitoring is not possible, netlink implementation is not present")
 		return
 	}
 }
@@ -755,55 +772,6 @@ func (d *DpllConfig) sendDpllEvent() {
 	}
 }
 
-// MonitorDpllSysfs ... monitor dpPPS_STATUSll events
-func (d *DpllConfig) MonitorDpllSysfs() {
-	defer func() {
-		if r := recover(); r != nil {
-			glog.Warning("Recovered from panic from Monitor DPLL: ", r)
-			// Handle the closed channel panic if necessary
-		}
-	}()
-
-	d.ticker = time.NewTicker(monitoringInterval)
-
-	// Determine DPLL state
-	d.inSpec = true
-
-	for {
-		select {
-		case <-d.exitCh:
-			glog.Infof("Terminating sysfs DPLL monitoring")
-			d.sendDpllTerminationEvent()
-
-			if d.onHoldover {
-				close(d.holdoverCloseCh) // Cancel any holdover
-			}
-			return
-		case <-d.ticker.C:
-			// Monitor DPLL
-			d.phaseStatus, d.frequencyStatus, d.phaseOffset = d.sysfs(d.iface)
-			d.stateDecision()
-		}
-	}
-}
-
-// sendDpllTerminationEvent sends a termination event to the event channel
-func (d *DpllConfig) sendDpllTerminationEvent() {
-	select {
-	case d.processConfig.EventChannel <- event.Event{
-		Source:    event.DPLL,
-		IFace:     d.iface,
-		CfgName:   d.processConfig.ConfigName,
-		ClockType: d.processConfig.ClockType,
-		Time:      time.Now().UnixMilli(),
-		Reset:     true,
-	}:
-	default:
-		glog.Error("failed to send dpll terminated event")
-	}
-
-}
-
 func (d *DpllConfig) getDpllState() int64 {
 	switch {
 	case d.hasPTPAsSource():
@@ -849,8 +817,10 @@ func (d *DpllConfig) holdover() {
 	ticker := time.NewTicker(1 * time.Second)
 	defer func() {
 		ticker.Stop()
+		d.Lock()
 		d.onHoldover = false
-		d.stateDecision()
+		d.sendDpllEvent()
+		d.Unlock()
 	}()
 	d.sendDpllEvent()
 	glog.Infof("setting dpll holdover for max holdover %v", d.LocalHoldoverTimeout)
@@ -868,6 +838,7 @@ func (d *DpllConfig) holdover() {
 				} else if !d.isInSpecOffsetInRange() { // when holdover verify with local max holdover not with regular threshold
 					d.inSpec = false // will be in HO, Out of spec only if  frequency is traceable
 					d.state = event.PTP_FREERUN
+					d.phaseOffset = FaultyPhaseOffset
 					d.sendDpllEvent()
 					return
 				}
@@ -936,50 +907,6 @@ func (d *DpllConfig) isOffsetInRange() bool {
 // Index of DPLL being configured [0:EEC (DPLL0), 1:PPS (DPLL1)]
 // Frequency State (EEC_DPLL)
 // cat /sys/class/net/interface_name/device/dpll_0_state
-// Phase State
-// cat /sys/class/net/ens7f0/device/dpll_1_state
-// Phase Offset
-// cat /sys/class/net/ens7f0/device/dpll_1_offset
-func (d *DpllConfig) sysfs(iface string) (phaseState, frequencyState, phaseOffset int64) {
-	if iface == "" {
-		return DPLL_INVALID, DPLL_INVALID, 0
-	}
-
-	readInt64FromFile := func(path string) (int64, error) {
-		content, err := os.ReadFile(path)
-		if err != nil {
-			return 0, err
-		}
-		contentStr := strings.TrimSpace(string(content))
-		value, err := strconv.ParseInt(contentStr, 10, 64)
-		if err != nil {
-			return 0, err
-		}
-		return value, nil
-	}
-
-	frequencyStateStr := fmt.Sprintf("/sys/class/net/%s/device/dpll_0_state", iface)
-	phaseStateStr := fmt.Sprintf("/sys/class/net/%s/device/dpll_1_state", iface)
-	phaseOffsetStr := fmt.Sprintf("/sys/class/net/%s/device/dpll_1_offset", iface)
-
-	frequencyState, err := readInt64FromFile(frequencyStateStr)
-	if err != nil {
-		glog.Errorf("Error reading frequency state from %s: %v", frequencyStateStr, err)
-	}
-
-	phaseState, err = readInt64FromFile(phaseStateStr)
-	if err != nil {
-		glog.Errorf("Error reading phase state from %s: %v %s", phaseStateStr, err, d.iface)
-	}
-
-	phaseOffset, err = readInt64FromFile(phaseOffsetStr)
-	if err != nil {
-		glog.Errorf("Error reading phase offset from %s: %v %s", phaseOffsetStr, err, d.iface)
-	} else {
-		phaseOffset /= 100 // Convert to nanoseconds from tens of picoseconds (divide by 100)
-	}
-	return phaseState, frequencyState, phaseOffset
-}
 
 func CalculateTimer(nodeProfile *ptpv1.PtpProfile) (int64, int64, int64, int64, bool) {
 	var localMaxHoldoverOffSet uint64 = LocalMaxHoldoverOffSet

--- a/pkg/dpll/dpll_internal_test.go
+++ b/pkg/dpll/dpll_internal_test.go
@@ -25,6 +25,9 @@ func TestDpllFlags(t *testing.T) {
 		{"NoFrequencyStatus", FlagNoFreqencyStatus, true, false, true, []string{"NoFrequencyStatus"}, "100"},
 		{"NoPhaseOffset", FlagNoPhaseOffset, true, true, false, []string{"NoPhaseOffset"}, "UNKNOWN"},
 		{"OnlyPhaseStatus", FlagOnlyPhaseStatus, true, false, false, []string{"NoFrequencyStatus", "NoPhaseOffset"}, "UNKNOWN"},
+		{"AllPinFlags", FlagNoPhaseOffset | FlagNoPhaseStatus | FlagNoFreqencyStatus,
+			false, false, false,
+			[]string{"NoFrequencyStatus", "NoPhaseStatus", "NoPhaseOffset"}, "UNKNOWN"},
 	}
 
 	for _, tt := range tests {
@@ -51,6 +54,8 @@ func TestDpllStateDecisionWithFlags(t *testing.T) {
 		{"NoFlags_WorstIsPhase", 0, DPLL_HOLDOVER, DPLL_LOCKED, DPLL_HOLDOVER},
 		{"NoPhaseStatus", FlagNoPhaseStatus, DPLL_LOCKED, DPLL_FREERUN, DPLL_FREERUN},
 		{"NoFrequencyStatus", FlagNoFreqencyStatus, DPLL_LOCKED, DPLL_FREERUN, DPLL_LOCKED},
+		// E830: only pps device exists; getDpllState must return phaseStatus (LOCKED), not frequencyStatus (FREERUN)
+		{"OnlyPhaseStatus_E830", FlagOnlyPhaseStatus, DPLL_LOCKED, DPLL_FREERUN, DPLL_LOCKED},
 	}
 
 	for _, tt := range tests {

--- a/pkg/event/event_internal_test.go
+++ b/pkg/event/event_internal_test.go
@@ -673,7 +673,7 @@ func TestAddEvent_SourceLostPropagation(t *testing.T) {
 		expectedSrcLost map[string]bool
 	}{
 		{
-			name: "source-lost propagates to stale LOCKED detail on different iface",
+			name: "source-lost does not propagate to other iface (no cross-hardware bleeding)",
 			initialDetails: []*DataDetails{
 				{IFace: "eno8903", State: PTP_LOCKED, sourceLost: false, time: now - 5000},
 				{IFace: "eno8703", State: PTP_LOCKED, sourceLost: false, time: now - 3000},
@@ -685,11 +685,11 @@ func TestAddEvent_SourceLostPropagation(t *testing.T) {
 				Data:   &PTPData{State: PTP_FREERUN, SourceLost: true},
 			},
 			expectedStates: map[string]PTPState{
-				"eno8903": PTP_FREERUN,
+				"eno8903": PTP_LOCKED,
 				"eno8703": PTP_FREERUN,
 			},
 			expectedSrcLost: map[string]bool{
-				"eno8903": true,
+				"eno8903": false,
 				"eno8703": true,
 			},
 		},
@@ -755,7 +755,7 @@ func TestAddEvent_SourceLostPropagation(t *testing.T) {
 func TestIsSourceLostBC_StaleDetailFixed(t *testing.T) {
 	now := time.Now().UnixMilli()
 
-	t.Run("stale LOCKED detail no longer fools isSourceLostBC after source-lost propagation", func(t *testing.T) {
+	t.Run("stale LOCKED detail on other iface keeps isSourceLostBC false (no cross-hardware bleeding)", func(t *testing.T) {
 		ptp4lData := &Data{
 			ProcessName: PTP4l,
 			Details: []*DataDetails{
@@ -776,10 +776,8 @@ func TestIsSourceLostBC_StaleDetailFixed(t *testing.T) {
 			},
 		}
 
-		// Before source-lost event: PTP source should NOT be lost
 		assert.False(t, e.isSourceLostBC("cfg"), "before source-lost event, ptpLost should be false")
 
-		// Simulate source-lost event on eno8703 (active port fallback)
 		ptp4lData.AddEvent(Event{
 			Source: PTP4l,
 			IFace:  "eno8703",
@@ -787,8 +785,10 @@ func TestIsSourceLostBC_StaleDetailFixed(t *testing.T) {
 			Data:   &PTPData{State: PTP_FREERUN, SourceLost: true},
 		})
 
-		// After source-lost propagation: PTP source should be lost
-		assert.True(t, e.isSourceLostBC("cfg"), "after source-lost propagation, ptpLost should be true")
+		// Without cross-hardware propagation, the stale LOCKED detail on
+		// eno8903 is not overwritten, so isSourceLostBC still sees a LOCKED
+		// port and returns false.
+		assert.False(t, e.isSourceLostBC("cfg"), "stale LOCKED detail on other iface prevents ptpLost")
 	})
 
 	t.Run("single LOCKED detail keeps source as not lost", func(t *testing.T) {

--- a/pkg/event/event_tbc.go
+++ b/pkg/event/event_tbc.go
@@ -85,6 +85,7 @@ func (e *EventHandler) updateBCState(event Event) (clockSyncState, bool, bool) {
 	cfgName := event.CfgName
 	dpllState := PTP_NOTSET
 	ts2phcState := PTP_FREERUN
+
 	// For internal data announces, only update the downstream data on class change
 	// For External GM data announces in the locked state, update whenever any of the
 	// information elements change
@@ -511,7 +512,9 @@ func (e *EventHandler) isSourceLostBC(cfgName string) bool {
 				}
 			}
 			if d.ProcessName == DPLL {
+				glog.Infof("isSourceLostBC[%s]", cfgName)
 				for _, dd := range d.Details {
+					glog.Infof("  DPLL detail: iface=%s state=%s signalSource=%s sourceLost=%t offset=%d time=%d metrics=%+v", dd.IFace, dd.State, dd.signalSource, dd.sourceLost, dd.Offset, dd.time, dd.Metrics)
 					if dd.State != PTP_LOCKED {
 						dpllLost = true
 						dpllLostIface = dd.IFace

--- a/pkg/event/stats.go
+++ b/pkg/event/stats.go
@@ -108,20 +108,6 @@ func (d *Data) AddEvent(event Event) {
 		}
 	}
 
-	// When a source-lost event arrives, propagate to all details that still
-	// show LOCKED. The active TR port may differ from ports that received
-	// earlier offset events, leaving stale LOCKED states on inactive details
-	// that would otherwise fool isSourceLostBC.
-	if sourceLost {
-		for _, dd := range d.Details {
-			if dd.IFace != event.IFace && dd.State == PTP_LOCKED {
-				dd.State = state
-				dd.sourceLost = true
-				dd.time = event.Time
-			}
-		}
-	}
-
 	for _, dd := range d.Details {
 		if dd.IFace == event.IFace {
 			if dd.time <= event.Time {
@@ -159,17 +145,6 @@ func (d *Data) AddEvent(event Event) {
 	}
 	d.logData = details.logData
 	d.Details = append(d.Details, details)
-}
-
-// ToString ... data
-func (d *Data) toString() string {
-	out := strings.Builder{}
-	out.WriteString("  logData : " + d.logData)
-	out.WriteString("  state: " + string(d.State))
-	out.WriteString("   process name: " + string(d.ProcessName))
-	out.WriteString("  Data Details: " + d.Details.toString())
-	out.WriteString("-----\r\n")
-	return out.String()
 }
 
 // toString ... data details

--- a/pkg/hardwareconfig/clockchain_resolution.go
+++ b/pkg/hardwareconfig/clockchain_resolution.go
@@ -227,6 +227,26 @@ func (hcm *HardwareConfigManager) ResolveClockChain(hwConfig *ptpv2alpha1.Hardwa
 	for i := range resolvedConfig.Spec.Profile.ClockChain.Structure {
 		subsystem := &resolvedConfig.Spec.Profile.ClockChain.Structure[i]
 
+		// Load hardware defaults once per subsystem (result is cached by getHardwareDefaults).
+		// Use them here to detect unmanaged DPLLs (e.g., E830) so that extractDPLLFlags
+		// can reuse the cached entry later without a redundant load.
+		// Unmanaged DPLLs intentionally have no PhaseInputs/Ethernet or behavior templates.
+		hwDefPath := strings.TrimSpace(subsystem.HardwareSpecificDefinitions)
+		if hwDefPath != "" {
+			hwDefaults, err := hcm.getHardwareDefaults(hwDefPath)
+			if err != nil {
+				glog.Warningf("Subsystem %s: failed to load hardware defaults from %s: %v", subsystem.Name, hwDefPath, err)
+			} else if hwDefaults != nil {
+				dpllFlags, flagErr := hwDefaults.ParseDPLLFlags()
+				if flagErr != nil {
+					glog.Warningf("Subsystem %s: failed to parse DPLL flags from %s: %v", subsystem.Name, hwDefPath, flagErr)
+				} else if dpllFlags != 0 {
+					glog.Infof("Subsystem %s is an unmanaged DPLL (has dpllFlags), skipping structure derivation", subsystem.Name)
+					continue
+				}
+			}
+		}
+
 		// Derive structure from ptpconfig if not explicitly provided
 		if subsystem.DPLL.NetworkInterface == "" || len(subsystem.DPLL.PhaseInputs) == 0 || len(subsystem.Ethernet) == 0 {
 			if err := hcm.deriveSubsystemStructure(subsystem, ptpProfile, clockType); err != nil {

--- a/pkg/hardwareconfig/clockchain_resolution_test.go
+++ b/pkg/hardwareconfig/clockchain_resolution_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	ptpv1 "github.com/k8snetworkplumbingwg/ptp-operator/api/v1"
 	ptpv2alpha1 "github.com/k8snetworkplumbingwg/ptp-operator/api/v2alpha1"
@@ -99,9 +100,9 @@ func TestClockChainResolution(t *testing.T) {
 		expectedGnssInput string
 	}{
 		{
-			name:              "intel/e825",
+			name:              HwDefIntelE825,
 			hwConfigFile:      "testdata/gnrd-hwconfig-minimal.yaml",
-			hwDefPath:         "intel/e825",
+			hwDefPath:         HwDefIntelE825,
 			expectedPtpInput:  "GNR-D_SDP0",
 			expectedGnssInput: "GNSS_1PPS_IN",
 		},
@@ -471,4 +472,86 @@ func TestProfileNamesMatch(t *testing.T) {
 		got := ProfileNamesMatch(tc.stored, tc.requested)
 		assert.Equal(t, tc.want, got, "ProfileNamesMatch(%q, %q)", tc.stored, tc.requested)
 	}
+}
+
+// TestClockChainResolutionWithE830 verifies that ResolveClockChain succeeds for
+// a combined E825+E830 config: the leader (E825) gets full structure/behavior
+// derivation while E830 subsystems are skipped as unmanaged DPLLs.
+func TestClockChainResolutionWithE830(t *testing.T) {
+	hwConfig, err := loadHardwareConfigFromFile("testdata/gnrd-hwconfig-e830.yaml")
+	require.NoError(t, err)
+	require.NotNil(t, hwConfig, "hwConfig must not be nil")
+
+	assert.Equal(t, "T-BC", *hwConfig.Spec.Profile.ClockType)
+	assert.GreaterOrEqual(t, len(hwConfig.Spec.Profile.ClockChain.Structure), 2)
+
+	// Capture original E830 subsystem state before resolution
+	type e830Snapshot struct {
+		name             string
+		networkInterface string
+	}
+	var e830Before []e830Snapshot
+	for _, sub := range hwConfig.Spec.Profile.ClockChain.Structure[1:] {
+		e830Before = append(e830Before, e830Snapshot{
+			name:             sub.Name,
+			networkInterface: sub.DPLL.NetworkInterface,
+		})
+	}
+
+	// Load ptpconfig
+	ptpConfig, err := loadPtpConfigFromFile("testdata/tbc-gnrd.yaml")
+	assert.NoError(t, err)
+	if ptpConfig == nil {
+		t.Fatal("ptpConfig is nil")
+	}
+
+	// Set up mock leading interface resolver for the leader subsystem
+	mockResolver := newMockLeadingInterfaceResolver()
+	mockResolver.phcIDs["eno2"] = "/dev/ptp0"
+	mockResolver.symlinks["/sys/class/ptp/ptp0/device"] = "../../../0000:13:00.0"
+	mockResolver.dirEntries["/sys/bus/pci/devices/0000:13:00.0/net"] = []os.DirEntry{
+		&mockDirEntry{name: "eno5", isDir: false},
+	}
+	SetLeadingInterfaceResolver(mockResolver)
+	defer ResetLeadingInterfaceResolver()
+
+	fakeClient := fake.NewClientset()
+	hcm := NewHardwareConfigManager(fakeClient, "default")
+
+	resolvedConfig, err := hcm.ResolveClockChain(hwConfig, ptpConfig)
+	require.NoError(t, err, "ResolveClockChain should succeed with E830 subsystems")
+	require.NotNil(t, resolvedConfig, "resolvedConfig must not be nil")
+
+	// Verify leader (E825) was resolved normally
+	leader := resolvedConfig.Spec.Profile.ClockChain.Structure[0]
+	assert.Equal(t, "leader", leader.Name)
+	assert.Equal(t, "dell/XR8720t", leader.HardwareSpecificDefinitions)
+	assert.Equal(t, "eno5", leader.DPLL.NetworkInterface,
+		"Leader NetworkInterface should be derived")
+	assert.NotEmpty(t, leader.DPLL.PhaseInputs,
+		"Leader should have derived PhaseInputs")
+	assert.NotEmpty(t, leader.Ethernet,
+		"Leader should have derived Ethernet ports")
+
+	// Verify behavior was derived (only for the leader, E830 skipped)
+	assert.NotNil(t, resolvedConfig.Spec.Profile.ClockChain.Behavior)
+	ptpSource := findSourceByName(resolvedConfig.Spec.Profile.ClockChain.Behavior.Sources, "PTP")
+	assert.NotNil(t, ptpSource, "PTP source should be present from leader behavior")
+
+	// Verify E830 subsystems were left untouched
+	for i, snap := range e830Before {
+		sub := resolvedConfig.Spec.Profile.ClockChain.Structure[1+i]
+		assert.Equal(t, snap.name, sub.Name)
+		assert.Equal(t, "intel/e830", sub.HardwareSpecificDefinitions)
+		assert.Equal(t, snap.networkInterface, sub.DPLL.NetworkInterface,
+			"E830 subsystem %s networkInterface should be preserved", sub.Name)
+		assert.Empty(t, sub.DPLL.PhaseInputs,
+			"E830 subsystem %s should have no PhaseInputs", sub.Name)
+		assert.Empty(t, sub.DPLL.PhaseOutputs,
+			"E830 subsystem %s should have no PhaseOutputs", sub.Name)
+		assert.Empty(t, sub.Ethernet,
+			"E830 subsystem %s should have no Ethernet ports", sub.Name)
+	}
+
+	t.Logf("ResolveClockChain succeeded: leader derived, %d E830 subsystems skipped", len(e830Before))
 }

--- a/pkg/hardwareconfig/hardware-vendor/intel/e830/defaults.yaml
+++ b/pkg/hardwareconfig/hardware-vendor/intel/e830/defaults.yaml
@@ -1,0 +1,15 @@
+# E830 (Carter Flats) - Unmanaged DPLL
+# This DPLL only reports device status via unsolicited notifications.
+# No pins are reported, so no phase offset or frequency status is available.
+
+# Clock ID transformation method for this hardware
+# "direct" - use serial number bytes directly (keeps ff-ff in middle)
+clockIdTransformation:
+  method: direct
+
+# DPLL monitoring flags intrinsic to this hardware.
+# E830 CF DPLL only provides phase status (PPS lock/unlock) via the pps device.
+# Phase offset and frequency status (eec device) are not available.
+dpllFlags:
+  - noPhaseOffset
+  - noFrequencyStatus

--- a/pkg/hardwareconfig/hardwareconfig.go
+++ b/pkg/hardwareconfig/hardwareconfig.go
@@ -198,6 +198,8 @@ type enrichedHardwareConfig struct {
 	structureSysFSCommands []SysFSCommand
 	// Holdover parameters mapped by clock ID
 	holdoverParams map[uint64]*ptpv2alpha1.HoldoverParameters
+	// DPLL monitoring flags mapped by clock ID (from hardware vendor defaults)
+	dpllFlags map[uint64]dpllcfg.Flag
 }
 
 // HardwareConfigManager manages hardware configurations and their application
@@ -361,6 +363,13 @@ func (hcm *HardwareConfigManager) UpdateHardwareConfig(hwConfigs []ptpv2alpha1.H
 		prepared[i].holdoverParams = holdoverParams
 		if len(holdoverParams) > 0 {
 			glog.Infof("  holdover: extracted parameters for %d DPLLs", len(holdoverParams))
+		}
+
+		// Extract DPLL flags from hardware vendor defaults
+		dpllFlags := hcm.extractDPLLFlags(*resolvedConfig)
+		prepared[i].dpllFlags = dpllFlags
+		if len(dpllFlags) > 0 {
+			glog.Infof("  dpllFlags: extracted flags for %d DPLLs", len(dpllFlags))
 		}
 	}
 
@@ -2219,6 +2228,82 @@ func (hcm *HardwareConfigManager) GetHoldoverParameters(profileName string, cloc
 				return params
 			}
 		}
+	}
+
+	return nil
+}
+
+// extractDPLLFlags extracts DPLL monitoring flags from hardware vendor defaults for all subsystems.
+// Flags are intrinsic to the hardware model (e.g., E830 only reports phase status)
+// and are loaded from the embedded defaults.yaml for each subsystem's hardwareSpecificDefinitions.
+func (hcm *HardwareConfigManager) extractDPLLFlags(hwConfig ptpv2alpha1.HardwareConfig) map[uint64]dpllcfg.Flag {
+	flags := make(map[uint64]dpllcfg.Flag)
+
+	for _, subsystem := range hwConfig.Spec.Profile.ClockChain.Structure {
+		hwDefPath := strings.TrimSpace(subsystem.HardwareSpecificDefinitions)
+		if hwDefPath == "" {
+			continue
+		}
+
+		hwDefaults, err := hcm.getHardwareDefaults(hwDefPath)
+		if err != nil {
+			glog.Warningf("Subsystem %s: failed to load hardware defaults from %s: %v", subsystem.Name, hwDefPath, err)
+			continue
+		}
+		if hwDefaults == nil {
+			glog.Warningf("Subsystem %s: hardware defaults not found for %s", subsystem.Name, hwDefPath)
+			continue
+		}
+
+		dpllFlags, err := hwDefaults.ParseDPLLFlags()
+		if err != nil {
+			glog.Warningf("Subsystem %s: failed to parse DPLL flags from %s: %v", subsystem.Name, hwDefPath, err)
+			continue
+		}
+		if dpllFlags == 0 {
+			continue
+		}
+
+		networkInterface := subsystem.DPLL.NetworkInterface
+		if networkInterface == "" && len(subsystem.Ethernet) > 0 && len(subsystem.Ethernet[0].Ports) > 0 {
+			networkInterface = subsystem.Ethernet[0].Ports[0]
+		}
+		if networkInterface == "" {
+			glog.Warningf("Subsystem %s has DPLL flags but no network interface", subsystem.Name)
+			continue
+		}
+
+		clockID, err := hcm.getClockIDCached(networkInterface, hwDefPath)
+		if err != nil {
+			glog.Warningf("Subsystem %s: failed to resolve clock ID from interface %s: %v", subsystem.Name, networkInterface, err)
+			continue
+		}
+
+		flags[clockID] = dpllFlags
+		glog.Infof("  DPLL flags for clock %#x (subsystem %s, hw %s): %d", clockID, subsystem.Name, hwDefPath, dpllFlags)
+	}
+
+	return flags
+}
+
+// GetDPLLFlags returns DPLL monitoring flags for a specific clock ID from the given profile.
+// Returns nil if no DPLL flags are configured for the clock ID.
+func (hcm *HardwareConfigManager) GetDPLLFlags(profileName string, clockID uint64) *dpllcfg.Flag {
+	hcm.mu.RLock()
+	defer hcm.mu.RUnlock()
+
+	matchedProfile := false
+	for _, hwConfig := range hcm.hardwareConfigs {
+		if ProfileNamesMatch(profileName, hwConfig.Spec.RelatedPtpProfileName) {
+			matchedProfile = true
+			if f, found := hwConfig.dpllFlags[clockID]; found {
+				return &f
+			}
+			glog.Infof("No DPLL flags found for clock %#x (profile %s, hwConfig %s)", clockID, profileName, hwConfig.Name)
+		}
+	}
+	if !matchedProfile {
+		glog.Infof("No matching hardware config found for profile %s", profileName)
 	}
 
 	return nil

--- a/pkg/hardwareconfig/hardwareconfig_gnrd_test.go
+++ b/pkg/hardwareconfig/hardwareconfig_gnrd_test.go
@@ -201,7 +201,7 @@ func validateGNRDStructureCommands(t *testing.T, hcm *HardwareConfigManager, clo
 	t.Logf("Structure commands: %d", len(structureCommands))
 
 	// Load e825 defaults for validation
-	hwSpec, err := LoadHardwareDefaults("intel/e825", nil)
+	hwSpec, err := LoadHardwareDefaults(HwDefIntelE825, nil)
 	if !assert.NoError(t, err, "Failed to load e825 defaults") {
 		return
 	}
@@ -329,7 +329,7 @@ func validateGNRDInitCommands(t *testing.T, dpllCommands []dpll.PinParentDeviceC
 func validateGNRDVendorDefaults(t *testing.T) {
 	t.Logf("\n=== Validating Vendor Defaults (intel/e825) ===")
 
-	hwSpec, err := LoadHardwareDefaults("intel/e825", nil)
+	hwSpec, err := LoadHardwareDefaults(HwDefIntelE825, nil)
 	if !assert.NoError(t, err, "Failed to load e825 defaults") {
 		return
 	}
@@ -732,7 +732,7 @@ func TestLoadBehaviorProfile_MultiVendor(t *testing.T) {
 		expectedGnssInput string
 	}{
 		{
-			hwDefPath:         "intel/e825",
+			hwDefPath:         HwDefIntelE825,
 			clockType:         "T-BC",
 			expectedPtpInput:  "GNR-D_SDP0",
 			expectedGnssInput: "GNSS_1PPS_IN",
@@ -788,7 +788,7 @@ func TestLoadHardwareDefaults_MultiVendor(t *testing.T) {
 		expectedPinDefs int  // minimum number of pin defaults (0 means unchecked)
 	}{
 		{
-			hwDefPath:       "intel/e825",
+			hwDefPath:       HwDefIntelE825,
 			expectDefaults:  true,
 			expectDelays:    true,
 			expectedPinDefs: 1,
@@ -872,7 +872,7 @@ func TestClockIDResolution(t *testing.T) {
 	defer ResetCommandExecutor()
 
 	// Resolve clock ID
-	clockID, err := GetClockIDFromInterface("eno5", "intel/e825")
+	clockID, err := GetClockIDFromInterface("eno5", HwDefIntelE825)
 	if !assert.NoError(t, err, "Failed to resolve clock ID") {
 		return
 	}

--- a/pkg/hardwareconfig/hardwareconfig_test.go
+++ b/pkg/hardwareconfig/hardwareconfig_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	dpllcfg "github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/dpll"
 	dpll "github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/dpll-netlink"
 	ptpv1 "github.com/k8snetworkplumbingwg/ptp-operator/api/v1"
 	ptpv2alpha1 "github.com/k8snetworkplumbingwg/ptp-operator/api/v2alpha1"
@@ -1773,7 +1774,7 @@ func TestBuildPhaseAdjustmentCommandsWithGranularity(t *testing.T) {
 			}
 
 			// Build phase adjustment commands
-			commands, bldErr := hcm.buildPhaseAdjustmentCommands(subsystem, "intel/e825")
+			commands, bldErr := hcm.buildPhaseAdjustmentCommands(subsystem, HwDefIntelE825)
 			if !assert.NoError(t, bldErr, "buildPhaseAdjustmentCommands should succeed") {
 				return
 			}
@@ -1807,4 +1808,245 @@ func TestBuildPhaseAdjustmentCommandsWithGranularity(t *testing.T) {
 				tt.boardLabel, tt.adjustment, *cmd.PhaseAdjust, pin.PhaseAdjustGran)
 		})
 	}
+}
+
+func TestParseDPLLFlags(t *testing.T) {
+	tests := []struct {
+		name     string
+		hd       *HardwareDefaults
+		expected dpllcfg.Flag
+		wantErr  bool
+	}{
+		{
+			name:     "nil HardwareDefaults",
+			hd:       nil,
+			expected: 0,
+		},
+		{
+			name:     "empty flags",
+			hd:       &HardwareDefaults{},
+			expected: 0,
+		},
+		{
+			name:     "noPhaseOffset only",
+			hd:       &HardwareDefaults{DPLLFlags: []string{dpllFlagNameNoPhaseOffset}},
+			expected: dpllcfg.FlagNoPhaseOffset,
+		},
+		{
+			name:     "noFrequencyStatus only",
+			hd:       &HardwareDefaults{DPLLFlags: []string{dpllFlagNameNoFrequencyStatus}},
+			expected: dpllcfg.FlagNoFreqencyStatus,
+		},
+		{
+			name:     "E830 flags - equivalent to FlagOnlyPhaseStatus",
+			hd:       &HardwareDefaults{DPLLFlags: []string{dpllFlagNameNoPhaseOffset, dpllFlagNameNoFrequencyStatus}},
+			expected: dpllcfg.FlagOnlyPhaseStatus,
+		},
+		{
+			name:     "all three pin flags",
+			hd:       &HardwareDefaults{DPLLFlags: []string{dpllFlagNameNoPhaseOffset, dpllFlagNameNoPhaseStatus, dpllFlagNameNoFrequencyStatus}},
+			expected: dpllcfg.FlagNoPhaseOffset | dpllcfg.FlagNoPhaseStatus | dpllcfg.FlagNoFreqencyStatus,
+		},
+		{
+			name:    "unknown flag",
+			hd:      &HardwareDefaults{DPLLFlags: []string{"bogusFlag"}},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			flags, err := tt.hd.ParseDPLLFlags()
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expected, flags)
+		})
+	}
+}
+
+func TestLoadE830Defaults(t *testing.T) {
+	hd, err := LoadHardwareDefaults("intel/e830", nil)
+	assert.NoError(t, err)
+	assert.NotNil(t, hd)
+
+	assert.NotNil(t, hd.ClockIDTransformation)
+	assert.Equal(t, "direct", hd.ClockIDTransformation.Method)
+
+	assert.Nil(t, hd.PinDefaults)
+	assert.Nil(t, hd.ConnectorCommands)
+	assert.Nil(t, hd.PinEsyncCommands)
+	assert.Nil(t, hd.InternalDelays)
+
+	flags, err := hd.ParseDPLLFlags()
+	assert.NoError(t, err)
+	assert.Equal(t, dpllcfg.FlagOnlyPhaseStatus, flags, "E830 should only have phase status (pps) available")
+}
+
+func TestDPLLFlagsExtraction(t *testing.T) {
+	mockCmd := NewMockCommandExecutor()
+	mockCmd.SetResponse("ethtool", []string{"-i", "eno5"}, "driver: ice\nbus-info: 0000:17:00.0")
+	mockCmd.SetResponse("lspci", []string{"-s", "0000:17:00.0"}, "17:00.0 Ethernet controller: Intel Corporation")
+	mockCmd.SetResponse("devlink", []string{"dev", "info", "pci/0000:17:00.0"}, "serial_number 50-7c-6f-ff-ff-5c-4a-e8")
+	mockCmd.SetResponse("ethtool", []string{"-i", "enp108s0f0"}, "driver: ice\nbus-info: 0000:6c:00.0")
+	mockCmd.SetResponse("lspci", []string{"-s", "0000:6c:00.0"}, "6c:00.0 Ethernet controller: Intel Corporation")
+	mockCmd.SetResponse("devlink", []string{"dev", "info", "pci/0000:6c:00.0"}, "serial_number 50-7c-6f-ff-ff-ab-cd-ef")
+	SetCommandExecutor(mockCmd)
+	defer ResetCommandExecutor()
+
+	clockIDE825 := uint64(0x507c6fffff5c4ae8) // eno5
+	clockIDE830 := uint64(0x507c6fffffabcdef) // enp108s0f0
+
+	hwConfig := ptpv2alpha1.HardwareConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-flags"},
+		Spec: ptpv2alpha1.HardwareConfigSpec{
+			RelatedPtpProfileName: "test-profile",
+			Profile: ptpv2alpha1.HardwareProfile{
+				ClockChain: &ptpv2alpha1.ClockChain{
+					Structure: []ptpv2alpha1.Subsystem{
+						{
+							Name:                        "leader",
+							HardwareSpecificDefinitions: HwDefIntelE825,
+							DPLL: ptpv2alpha1.DPLL{
+								NetworkInterface: "eno5",
+							},
+						},
+						{
+							Name:                        "cf",
+							HardwareSpecificDefinitions: "intel/e830",
+							DPLL: ptpv2alpha1.DPLL{
+								NetworkInterface: "enp108s0f0",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	hcm := newHardwareConfigManagerForTests()
+
+	flags := hcm.extractDPLLFlags(hwConfig)
+
+	// E825 should not have DPLL flags (no dpllFlags in its defaults.yaml)
+	_, hasE825Flags := flags[clockIDE825]
+	assert.False(t, hasE825Flags, "E825 should not have DPLL flags")
+
+	// E830 should only have phase status (pps) available
+	e830Flags, hasE830Flags := flags[clockIDE830]
+	assert.True(t, hasE830Flags, "E830 should have DPLL flags")
+	assert.Equal(t, dpllcfg.FlagOnlyPhaseStatus, e830Flags, "E830 should only have phase status (pps) available")
+
+	// Test GetDPLLFlags API
+	enriched := enrichedHardwareConfig{
+		HardwareConfig: hwConfig,
+		dpllFlags:      flags,
+	}
+	hcm.mu.Lock()
+	hcm.hardwareConfigs = []enrichedHardwareConfig{enriched}
+	hcm.ready = true
+	hcm.mu.Unlock()
+
+	// GetDPLLFlags uses ProfileNamesMatch: caller passes the full node profile name
+	// (e.g. "t-bc_test-profile") which is matched against RelatedPtpProfileName ("test-profile")
+	retrieved := hcm.GetDPLLFlags("prefix_test-profile", clockIDE830)
+	assert.NotNil(t, retrieved, "Should retrieve DPLL flags for E830 clock")
+	assert.Equal(t, dpllcfg.FlagOnlyPhaseStatus, *retrieved)
+
+	retrievedE825 := hcm.GetDPLLFlags("prefix_test-profile", clockIDE825)
+	assert.Nil(t, retrievedE825, "Should return nil for E825 (no flags)")
+
+	retrievedBad := hcm.GetDPLLFlags("non-existent", clockIDE830)
+	assert.Nil(t, retrievedBad, "Should return nil for non-existent profile")
+}
+
+// TestE830HardwareConfigFromTestdata loads the gnrd-hwconfig-e830.yaml testdata file
+// and validates the structure, DPLL flags extraction, and the full GetDPLLFlags flow.
+func TestE830HardwareConfigFromTestdata(t *testing.T) {
+	// Load testdata
+	hwConfig, err := loadHardwareConfigFromFile("testdata/gnrd-hwconfig-e830.yaml")
+	assert.NoError(t, err, "Failed to load gnrd-hwconfig-e830.yaml")
+	assert.NotNil(t, hwConfig)
+
+	// Validate top-level structure
+	assert.Equal(t, "t-bc-e830", hwConfig.Name)
+	assert.Equal(t, "01-tbc-tr", hwConfig.Spec.RelatedPtpProfileName)
+	assert.NotNil(t, hwConfig.Spec.Profile.ClockType)
+	assert.Equal(t, "T-BC", *hwConfig.Spec.Profile.ClockType)
+
+	// Validate clock chain has leader + E830 subsystems
+	chain := hwConfig.Spec.Profile.ClockChain
+	assert.NotNil(t, chain)
+	assert.GreaterOrEqual(t, len(chain.Structure), 2, "Should have at least leader + one CF subsystem")
+
+	// Validate leader subsystem (intel/e825)
+	leader := chain.Structure[0]
+	assert.Equal(t, "leader", leader.Name)
+	assert.Equal(t, "dell/XR8720t", leader.HardwareSpecificDefinitions)
+	assert.NotNil(t, leader.DPLL.HoldoverParameters, "Leader should have holdover parameters")
+	assert.Equal(t, uint64(20), leader.DPLL.HoldoverParameters.MaxInSpecOffset)
+	assert.Equal(t, uint64(30), leader.DPLL.HoldoverParameters.LocalMaxHoldoverOffset)
+	assert.Equal(t, uint64(288), leader.DPLL.HoldoverParameters.LocalHoldoverTimeout)
+
+	// Validate E830 subsystems
+	for _, sub := range chain.Structure[1:] {
+		assert.Equal(t, "intel/e830", sub.HardwareSpecificDefinitions,
+			"Non-leader subsystem %s should use intel/e830", sub.Name)
+		assert.NotEmpty(t, sub.DPLL.NetworkInterface,
+			"E830 subsystem %s should have a network interface", sub.Name)
+		assert.Nil(t, sub.DPLL.HoldoverParameters,
+			"E830 subsystem %s should not have holdover parameters", sub.Name)
+		assert.Empty(t, sub.DPLL.PhaseInputs,
+			"E830 subsystem %s should not have phase inputs", sub.Name)
+		assert.Empty(t, sub.DPLL.PhaseOutputs,
+			"E830 subsystem %s should not have phase outputs", sub.Name)
+		assert.Empty(t, sub.Ethernet,
+			"E830 subsystem %s should not have ethernet ports", sub.Name)
+	}
+
+	// Validate that vendor defaults for both hardware types load correctly
+	e825Defaults, err := LoadHardwareDefaults(HwDefIntelE825, nil)
+	assert.NoError(t, err)
+	assert.NotNil(t, e825Defaults)
+	e825Flags, err := e825Defaults.ParseDPLLFlags()
+	assert.NoError(t, err)
+	assert.Equal(t, dpllcfg.Flag(0), e825Flags, "E825 should have no DPLL flags")
+
+	e830Defaults, err := LoadHardwareDefaults("intel/e830", nil)
+	assert.NoError(t, err)
+	assert.NotNil(t, e830Defaults)
+	e830Flags, err := e830Defaults.ParseDPLLFlags()
+	assert.NoError(t, err)
+	assert.Equal(t, dpllcfg.FlagOnlyPhaseStatus, e830Flags, "E830 should only have phase status (pps) available")
+
+	// Validate DPLL flags extraction with mock command executor
+	mockCmd := NewMockCommandExecutor()
+	for i, sub := range chain.Structure[1:] {
+		iface := sub.DPLL.NetworkInterface
+		busInfo := fmt.Sprintf("0000:%02x:00.0", 0x6c+i)
+		mockCmd.SetResponse("ethtool", []string{"-i", iface}, fmt.Sprintf("driver: ice\nbus-info: %s", busInfo))
+		mockCmd.SetResponse("lspci", []string{"-s", busInfo}, fmt.Sprintf("%s Ethernet controller: Intel Corporation", busInfo))
+		mockCmd.SetResponse("devlink", []string{"dev", "info", fmt.Sprintf("pci/%s", busInfo)},
+			fmt.Sprintf("serial_number 50-7c-6f-ff-ff-ab-cd-%02x", 0xe0+i))
+	}
+	SetCommandExecutor(mockCmd)
+	defer ResetCommandExecutor()
+
+	hcm := newHardwareConfigManagerForTests()
+	flags := hcm.extractDPLLFlags(*hwConfig)
+
+	// E830 subsystems should have flags extracted
+	e830Count := 0
+	for clockID, f := range flags {
+		assert.Equal(t, dpllcfg.FlagOnlyPhaseStatus, f,
+			"Clock %#x should only have phase status (pps) available", clockID)
+		e830Count++
+	}
+	assert.Equal(t, len(chain.Structure)-1, e830Count,
+		"Should extract DPLL flags for all E830 subsystems (not the leader)")
+
+	t.Logf("Loaded gnrd-hwconfig-e830.yaml: %d subsystems, %d with DPLL flags",
+		len(chain.Structure), e830Count)
 }

--- a/pkg/hardwareconfig/testdata/gnrd-hwconfig-e830.yaml
+++ b/pkg/hardwareconfig/testdata/gnrd-hwconfig-e830.yaml
@@ -1,0 +1,27 @@
+apiVersion: ptp.openshift.io/v2alpha1
+kind: HardwareConfig
+metadata:
+  name: t-bc-e830
+spec:
+  profile:
+    name: GNR-D-T-BC-E830
+    clockType: T-BC
+    clockChain:
+      structure:
+      - name: leader
+        hardwareSpecificDefinitions: dell/XR8720t
+        dpll:
+          holdoverParameters:
+            maxInSpecOffset: 20
+            localMaxHoldoverOffset: 30
+            localHoldoverTimeout: 288
+      - name: cf1
+        hardwareSpecificDefinitions: intel/e830
+        dpll:
+          networkInterface: enp108s0f0
+      - name: cf2
+        hardwareSpecificDefinitions: intel/e830
+        dpll:
+          networkInterface: enp109s0f0
+
+  relatedPtpProfileName: 01-tbc-tr

--- a/pkg/hardwareconfig/testdata/tbc-gnrd-perla4.yaml
+++ b/pkg/hardwareconfig/testdata/tbc-gnrd-perla4.yaml
@@ -1,0 +1,266 @@
+apiVersion: ptp.openshift.io/v1
+kind: PtpConfig
+metadata:
+  name: t-bc
+  namespace: openshift-ptp
+spec:
+  profile:
+  - name: 00-tbc-tt
+    ptp4lConf: |
+      [eno8803]
+      masterOnly 1
+      [enp108s0f0]
+      masterOnly 1
+      [enp109s0f0]
+      masterOnly 1
+      [global]
+      #
+      # Default Data Set
+      #
+      twoStepFlag 1
+      slaveOnly 0
+      priority1 128
+      priority2 128
+      domainNumber 24
+      clockClass 248
+      clockAccuracy 0xFE
+      offsetScaledLogVariance 0xFFFF
+      free_running 0
+      freq_est_interval 1
+      dscp_event 0
+      dscp_general 0
+      dataset_comparison G.8275.x
+      G.8275.defaultDS.localPriority 128
+      #
+      # Port Data Set
+      #
+      logAnnounceInterval -3
+      logSyncInterval -4
+      logMinDelayReqInterval -4
+      logMinPdelayReqInterval -4
+      announceReceiptTimeout 3
+      syncReceiptTimeout 0
+      delayAsymmetry 0
+      fault_reset_interval -4
+      neighborPropDelayThresh 20000000
+      masterOnly 0
+      G.8275.portDS.localPriority 128
+      #
+      # Run time options
+      #
+      assume_two_step 0
+      logging_level 6
+      path_trace_enabled 0
+      follow_up_info 0
+      hybrid_e2e 0
+      inhibit_multicast_service 0
+      net_sync_monitor 0
+      tc_spanning_tree 0
+      tx_timestamp_timeout 50
+      unicast_listen 0
+      unicast_master_table 0
+      unicast_req_duration 3600
+      use_syslog 1
+      verbose 0
+      summary_interval 0
+      kernel_leap 1
+      check_fup_sync 0
+      clock_class_threshold 135
+      #
+      # Servo Options
+      #
+      pi_proportional_const 0.60
+      pi_integral_const 0.001
+      pi_proportional_scale 0.0
+      pi_proportional_exponent -0.3
+      pi_proportional_norm_max 0.7
+      pi_integral_scale 0.0
+      pi_integral_exponent 0.4
+      pi_integral_norm_max 0.3
+      step_threshold 2.0
+      first_step_threshold 0.00002
+      max_frequency 900000000
+      clock_servo pi
+      sanity_freq_limit 200000000
+      ntpshm_segment 0
+      #
+      # Transport options
+      #
+      transportSpecific 0x0
+      ptp_dst_mac 01:1B:19:00:00:00
+      p2p_dst_mac 01:80:C2:00:00:0E
+      udp_ttl 1
+      udp6_scope 0x0E
+      uds_address /var/run/ptp4l
+      #
+      # Default interface options
+      #
+      clock_type BC
+      network_transport L2
+      delay_mechanism E2E
+      time_stamping hardware
+      tsproc_mode filter
+      delay_filter moving_median
+      delay_filter_length 10
+      egressLatency 0
+      ingressLatency 0
+      boundary_clock_jbod 1
+      #
+      # Clock description
+      #
+      productDescription ;;
+      revisionData ;;
+      manufacturerIdentity 00:00:00
+      userDescription ;
+      timeSource 0xA0
+    ptp4lOpts: -2 --summary_interval -4
+    ptpSchedulingPolicy: SCHED_FIFO
+    ptpSchedulingPriority: 10
+    ptpSettings:
+      controllingProfile: 01-tbc-tr
+      logReduce: "false"
+  - name: 01-tbc-tr
+    phc2sysOpts: -r -n 24 -N 8 -R 16 -u 0 -m -s eno8703
+    ptp4lConf: |
+      # The interface name is hardware-specific
+      [eno8703]
+      masterOnly 0
+      [global]
+      #
+      # Default Data Set
+      #
+      twoStepFlag 1
+      slaveOnly 0
+      priority1 128
+      priority2 128
+      domainNumber 24
+      #utc_offset 37
+      clockClass 248
+      clockAccuracy 0xFE
+      offsetScaledLogVariance 0xFFFF
+      free_running 0
+      freq_est_interval 1
+      dscp_event 0
+      dscp_general 0
+      dataset_comparison G.8275.x
+      G.8275.defaultDS.localPriority 128
+      #
+      # Port Data Set
+      #
+      logAnnounceInterval -3
+      logSyncInterval -4
+      logMinDelayReqInterval -4
+      logMinPdelayReqInterval -4
+      announceReceiptTimeout 3
+      syncReceiptTimeout 0
+      delayAsymmetry 0
+      fault_reset_interval -4
+      neighborPropDelayThresh 20000000
+      masterOnly 0
+      G.8275.portDS.localPriority 128
+      #
+      # Run time options
+      #
+      assume_two_step 0
+      logging_level 6
+      path_trace_enabled 0
+      follow_up_info 0
+      hybrid_e2e 0
+      inhibit_multicast_service 0
+      net_sync_monitor 0
+      tc_spanning_tree 0
+      tx_timestamp_timeout 50
+      unicast_listen 0
+      unicast_master_table 0
+      unicast_req_duration 3600
+      use_syslog 1
+      verbose 0
+      summary_interval 0
+      kernel_leap 1
+      check_fup_sync 0
+      clock_class_threshold 135
+      #
+      # Servo Options
+      #
+      pi_proportional_const 0.60
+      pi_integral_const 0.001
+      pi_proportional_scale 0.0
+      pi_proportional_exponent -0.3
+      pi_proportional_norm_max 0.7
+      pi_integral_scale 0.0
+      pi_integral_exponent 0.4
+      pi_integral_norm_max 0.3
+      step_threshold 2.0
+      first_step_threshold 0.00002
+      max_frequency 900000000
+      clock_servo pi
+      sanity_freq_limit 200000000
+      ntpshm_segment 0
+      #
+      # Transport options
+      #
+      transportSpecific 0x0
+      ptp_dst_mac 01:1B:19:00:00:00
+      p2p_dst_mac 01:80:C2:00:00:0E
+      udp_ttl 1
+      udp6_scope 0x0E
+      uds_address /var/run/ptp4l
+      #
+      # Default interface options
+      #
+      clock_type OC
+      network_transport L2
+      delay_mechanism E2E
+      time_stamping hardware
+      tsproc_mode filter
+      delay_filter moving_median
+      delay_filter_length 10
+      egressLatency 0
+      ingressLatency 0
+      boundary_clock_jbod 1
+      #
+      # Clock description
+      #
+      productDescription ;;
+      revisionData ;;
+      manufacturerIdentity 00:00:00
+      userDescription ;
+      timeSource 0xA0
+    ptp4lOpts: -2 --summary_interval -4
+    ptpSchedulingPolicy: SCHED_FIFO
+    ptpSchedulingPriority: 10
+    ptpSettings:
+      clockType: T-BC
+      inSyncConditionThreshold: "10"
+      inSyncConditionTimes: "12"
+      logReduce: "false"
+    ts2phcConf: |
+      [global]
+      use_syslog  0
+      verbose 1
+      logging_level 7
+      ts2phc.pulsewidth 500000000
+      leapfile  /usr/share/zoneinfo/leap-seconds.list
+      domainNumber 24
+      uds_address /var/run/ptp4l.1.socket
+      [enp108s0f0]
+      ts2phc.extts_correction 0
+      ts2phc.master 0
+      ts2phc.channel 0
+      ts2phc.pin_index 1
+      [enp109s0f0]
+      ts2phc.extts_polarity rising
+      ts2phc.extts_correction 0
+      ts2phc.master 0
+      ts2phc.channel 0
+      ts2phc.pin_index 1
+    ts2phcOpts: -s generic -a --ts2phc.rh_external_pps 1
+  recommend:
+  - match:
+    - nodeLabel: node-role.kubernetes.io/master
+    priority: 4
+    profile: 00-tbc-tt
+  - match:
+    - nodeLabel: node-role.kubernetes.io/master
+    priority: 4
+    profile: 01-tbc-tr

--- a/pkg/hardwareconfig/vendor_embedded.go
+++ b/pkg/hardwareconfig/vendor_embedded.go
@@ -8,6 +8,7 @@ import (
 const (
 	HwDefIntelE810     = "intel/e810"
 	HwDefIntelE825     = "intel/e825"
+	HwDefIntelE830     = "intel/e830"
 	HwDefDellXR8720t   = "dell/XR8720t"
 	HwDefHPEEL140Gen12 = "hpe/EL140-Gen12"
 )
@@ -26,6 +27,9 @@ var dellXR8720tDefaultsYAML []byte
 
 //go:embed hardware-vendor/hpe/EL140-Gen12/defaults.yaml
 var hpeEL140Gen12DefaultsYAML []byte
+
+//go:embed hardware-vendor/intel/e830/defaults.yaml
+var intelE830DefaultsYAML []byte
 
 //go:embed hardware-vendor/intel/e825/behavior-profiles.yaml
 var intelE825BehaviorProfilesYAML []byte
@@ -48,14 +52,14 @@ var hpeEL140Gen12DelaysYAML []byte
 // embeddedDefaults maps hwDefPath -> raw YAML contents.
 // Example key: "intel/e810"
 var embeddedDefaults = map[string][]byte{
-	HwDefIntelE810:     intelE810DefaultsYAML,
-	HwDefIntelE825:     intelE825DefaultsYAML,
 	HwDefDellXR8720t:   dellXR8720tDefaultsYAML,
 	HwDefHPEEL140Gen12: hpeEL140Gen12DefaultsYAML,
+	HwDefIntelE810:     intelE810DefaultsYAML,
+	HwDefIntelE825:     intelE825DefaultsYAML,
+	HwDefIntelE830:     intelE830DefaultsYAML,
 }
 
 // embeddedBehaviorProfiles maps hwDefPath -> raw YAML contents for behavior profiles.
-// Example key: "intel/e825"
 var embeddedBehaviorProfiles = map[string][]byte{
 	HwDefIntelE825:     intelE825BehaviorProfilesYAML,
 	HwDefDellXR8720t:   dellXR8720tBehaviorProfilesYAML,
@@ -63,7 +67,6 @@ var embeddedBehaviorProfiles = map[string][]byte{
 }
 
 // embeddedDelays maps hwDefPath -> raw YAML contents for delay compensation models.
-// Example key: "intel/e825"
 var embeddedDelays = map[string][]byte{
 	HwDefIntelE825:     intelE825DelaysYAML,
 	HwDefDellXR8720t:   dellXR8720tDelaysYAML,

--- a/pkg/hardwareconfig/vendor_loader.go
+++ b/pkg/hardwareconfig/vendor_loader.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/golang/glog"
+	dpllcfg "github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/dpll"
 	ptpv2alpha1 "github.com/k8snetworkplumbingwg/ptp-operator/api/v2alpha1"
 	"sigs.k8s.io/yaml"
 )
@@ -30,6 +31,41 @@ type HardwareDefaults struct {
 
 	// DelayCompensation defines the delay compensation model (components, connections, routes)
 	DelayCompensation *DelayCompensationModel `json:"delayCompensation,omitempty" yaml:"delayCompensation,omitempty"`
+
+	// DPLLFlags defines DPLL monitoring behavior flags intrinsic to this hardware.
+	// Valid values: "noPhaseOffset", "noPhaseStatus", "noFrequencyStatus"
+	DPLLFlags []string `json:"dpllFlags,omitempty" yaml:"dpllFlags,omitempty"`
+}
+
+// DPLL flag name constants mirror the YAML representation of dpll.Flag bits.
+const (
+	dpllFlagNameNoPhaseOffset     = "noPhaseOffset"
+	dpllFlagNameNoPhaseStatus     = "noPhaseStatus"
+	dpllFlagNameNoFrequencyStatus = "noFrequencyStatus"
+)
+
+// dpllFlagNames maps YAML flag names to dpll.Flag bitmask values
+var dpllFlagNames = map[string]dpllcfg.Flag{
+	dpllFlagNameNoPhaseOffset:     dpllcfg.FlagNoPhaseOffset,
+	dpllFlagNameNoPhaseStatus:     dpllcfg.FlagNoPhaseStatus,
+	dpllFlagNameNoFrequencyStatus: dpllcfg.FlagNoFreqencyStatus,
+}
+
+// ParseDPLLFlags converts the string-based DPLLFlags from YAML into a dpll.Flag bitmask.
+// Returns 0 if no flags are defined.
+func (hd *HardwareDefaults) ParseDPLLFlags() (dpllcfg.Flag, error) {
+	if hd == nil || len(hd.DPLLFlags) == 0 {
+		return 0, nil
+	}
+	var flags dpllcfg.Flag
+	for _, name := range hd.DPLLFlags {
+		flag, ok := dpllFlagNames[name]
+		if !ok {
+			return 0, fmt.Errorf("unknown DPLL flag: %q (valid: noPhaseOffset, noPhaseStatus, noFrequencyStatus)", name)
+		}
+		flags |= flag
+	}
+	return flags, nil
 }
 
 // ClockIDTransformation defines how to convert serial number to clock ID


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Intel E830 support with phase-only DPLL monitoring.
  * Hardware-configurable per-clock DPLL monitoring flags, including improved startup initial-state synchronization.
  * Improved T-BC clock-chain handling across all subsystems to derive correct network interfaces and event sources.

* **Bug Fixes**
  * Refined `SourceLost` propagation for PPS-sourced devices.
  * Corrected holdover behavior for phase-only, hardware-slaved DPLLs.
  * Stopping `chronyd` is now synchronous for more consistent timing.

* **Tests**
  * Expanded coverage for E830 defaults, clock-chain resolution, and DPLL flag parsing/behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->