### PR TITLE
Fix clock class metrics lost after cloud-event-proxy restart

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -250,12 +250,7 @@ func (p *ProcessManager) EmitClockClassLogs() {
 			for _, dp := range proc.depProcess {
 				if dp.Name() == PMCProcessName {
 					pmc := dp.(*PMCProcess)
-					if pmc.parentDS != nil {
-						// if parentDS is nil that means the clock class will
-						// be announced as soon as we get one
-						// therefore no need force it.
-						pmc.EmitClockClassLogs()
-					}
+					pmc.EmitClockClassLogs()
 				}
 			}
 		}

--- a/pkg/daemon/daemon_internal_test.go
+++ b/pkg/daemon/daemon_internal_test.go
@@ -1786,3 +1786,34 @@ func TestPtp4lConf_PopulatePtp4lConf_ClockTypeWithCliArgs(t *testing.T) {
 		})
 	}
 }
+
+func TestEmitClockClassLogs_EmitsWithNilParentDS(t *testing.T) {
+	// Create a minimal event handler (no socket needed — the event package
+	// tests already cover the socket write path via EmitClockClass).
+	eventChannel := make(chan event.EventChannel)
+	closeCh := make(chan bool, 1)
+	handler := event.Init("testnode", false, "", eventChannel, closeCh, nil, nil, nil)
+
+	// Create a PMC process with parentDS = nil (the bug condition).
+	// Before the fix, EmitClockClassLogs skipped the call when parentDS was nil.
+	pmcProc := NewPMCProcess(0, handler, "OC")
+	assert.Nil(t, pmcProc.parentDS, "parentDS should be nil for this test")
+
+	// Create a ptp4l process with the PMC as a dependent process
+	pm := &ProcessManager{
+		process: []*ptpProcess{
+			{
+				name:       ptp4lProcessName,
+				depProcess: []process{pmcProc},
+			},
+		},
+	}
+
+	// EmitClockClassLogs should dispatch to pmc.EmitClockClassLogs()
+	// without panicking, even when parentDS is nil.
+	// EmitClockClass returns early (no clkSyncState data) but the key
+	// assertion is that the call is made at all — the old code skipped it.
+	assert.NotPanics(t, func() {
+		pm.EmitClockClassLogs()
+	}, "EmitClockClassLogs should not panic with nil parentDS")
+}

--- a/pkg/event/event.go
+++ b/pkg/event/event.go
@@ -700,6 +700,9 @@ func (e *EventHandler) reconnectEventSocket() bool {
 // Returns true if the connection is still usable for subsequent writes,
 // false if the connection is unavailable and remaining writes should be skipped.
 func (e *EventHandler) writeLogToSocket(l string) bool {
+	if !strings.HasSuffix(l, "\n") {
+		l += "\n"
+	}
 	conn := e.getConn()
 	if conn == nil {
 		return false
@@ -1378,11 +1381,7 @@ func (e *EventHandler) EmitPortRoleLogs() {
 
 	for _, entry := range entries {
 		glog.Infof("Port Event %s", entry.raw)
-		raw := entry.raw
-		if !strings.HasSuffix(raw, "\n") {
-			raw += "\n"
-		}
-		if !e.writeLogToSocket(raw) {
+		if !e.writeLogToSocket(entry.raw) {
 			glog.Warning("Broken pipe detected while emitting port role logs, stopping.")
 			break
 		}
@@ -1394,5 +1393,5 @@ func (e *EventHandler) EmitPortRoleLogs() {
 func (e *EventHandler) EmitProcessStatusLog(processName, cfgName string, status int64) {
 	message := fmt.Sprintf("%s[%d]:[%s] PTP_PROCESS_STATUS:%d", processName, time.Now().Unix(), cfgName, status)
 	glog.Info(message)
-	e.writeLogToSocket(message + "\n")
+	e.writeLogToSocket(message)
 }

--- a/pkg/event/event.go
+++ b/pkg/event/event.go
@@ -176,10 +176,9 @@ type EventHandler struct {
 	stdoutToSocket     bool
 	processChannel     <-chan EventChannel
 	closeCh            chan bool
-	brokenPipeCh       chan struct{} // signals broken pipe from background goroutines to trigger reconnection
-	conn               net.Conn      // event socket connection, guarded by connMu
-	connMu             sync.Mutex    // separate mutex for conn to avoid deadlocks with embedded sync.Mutex
-	reconnectMu        sync.Mutex    // serializes reconnection attempts to prevent leaked connections
+	conn               net.Conn   // event socket connection, guarded by connMu
+	connMu             sync.Mutex // separate mutex for conn to avoid deadlocks with embedded sync.Mutex
+	reconnectMu        sync.Mutex // serializes reconnection attempts to prevent leaked connections
 	data               map[string][]*Data
 	offsetMetric       *prometheus.GaugeVec
 	clockMetric        *prometheus.GaugeVec
@@ -249,7 +248,6 @@ func Init(nodeName string, stdOutToSocket bool, socketName string, processChanne
 		stdoutSocket:       socketName,
 		stdoutToSocket:     stdOutToSocket,
 		closeCh:            closeCh,
-		brokenPipeCh:       make(chan struct{}, 1),
 		processChannel:     processChannel,
 		data:               map[string][]*Data{},
 		clockMetric:        clockMetric,
@@ -600,7 +598,6 @@ func (e *EventHandler) hasMetric(name string) (*prometheus.GaugeVec, bool) {
 }
 
 // AnnounceClockClass announces clock class changes to the event handler and writes to the connection.
-// Broken pipe errors are handled internally via signalBrokenPipe.
 // It also sends a non-blocking clock class update request to the ProcessEvents goroutine,
 // which calls UpdateClockClass to read the local GRANDMASTER_SETTINGS_NP and determine
 // the correct clock class for the local clock (e.g., 255 for OC slave).
@@ -637,26 +634,15 @@ func (e *EventHandler) setClockClassLocked(clockClass fbprotocol.ClockClass, clo
 }
 
 // emitClockClass writes the clock class to the socket and updates the metric.
-// It uses e.getConn() to obtain the current connection and signals broken pipe internally.
 // Must NOT be called while holding e.Lock().
 func (e *EventHandler) emitClockClass(clockClass fbprotocol.ClockClass, cfgName string) {
-	brokenPipe := utils.EmitClockClass(e.getConn(), PTP4lProcessName, cfgName, clockClass)
+	if e.stdoutToSocket {
+		logMsg := utils.GetClockClassLogMessage(PTP4lProcessName, cfgName, clockClass)
+		e.writeLogToSocket(logMsg)
+	}
 	if !e.stdoutToSocket && e.clockClassMetric != nil {
 		e.clockClassMetric.With(prometheus.Labels{
 			"process": PTP4lProcessName, "config": cfgName, "node": e.nodeName}).Set(float64(clockClass))
-	}
-	if brokenPipe {
-		e.signalBrokenPipe()
-	}
-}
-
-// signalBrokenPipe sends a non-blocking signal on brokenPipeCh to notify
-// the ProcessEvents loop that the socket connection needs reconnection.
-func (e *EventHandler) signalBrokenPipe() {
-	select {
-	case e.brokenPipeCh <- struct{}{}:
-	default:
-		// Channel already has a pending signal; no need to duplicate.
 	}
 }
 
@@ -815,9 +801,8 @@ func (e *EventHandler) ProcessEvents() {
 							// Stop double emmit
 							cfgName = ""
 						}
-						if brokenPipe := utils.EmitClockClass(e.getConn(), PTP4lProcessName, clkCfgName, clockClass); brokenPipe {
-							glog.Warning("Broken pipe detected in clock class ticker, signaling reconnection")
-							e.signalBrokenPipe()
+						logMsg := utils.GetClockClassLogMessage(PTP4lProcessName, clkCfgName, clockClass)
+						if !e.writeLogToSocket(logMsg) {
 							break
 						}
 					}
@@ -830,10 +815,8 @@ func (e *EventHandler) ProcessEvents() {
 						e.Lock()
 						currentClockClass := e.clockClass
 						e.Unlock()
-						if brokenPipe := utils.EmitClockClass(e.getConn(), PTP4lProcessName, cfgName, currentClockClass); brokenPipe {
-							glog.Warning("Broken pipe detected in clock class ticker, signaling reconnection")
-							e.signalBrokenPipe()
-						}
+						logMsg := utils.GetClockClassLogMessage(PTP4lProcessName, cfgName, currentClockClass)
+						e.writeLogToSocket(logMsg)
 					}
 				}
 			}
@@ -1032,14 +1015,6 @@ func (e *EventHandler) ProcessEvents() {
 						}
 					}
 				}
-			}
-		case <-e.brokenPipeCh:
-			// A background goroutine detected a broken pipe on the event socket.
-			// Clear the broken connection and reconnect.
-			glog.Info("Broken pipe signal received, reconnecting event socket")
-			e.setConn(nil)
-			if !e.reconnectEventSocket() {
-				glog.Warning("Reconnect failed after broken pipe signal; will retry on next event")
 			}
 		case <-e.closeCh:
 			return
@@ -1286,17 +1261,7 @@ func (e *EventHandler) UpdateClockClass(clk ClockClassRequest) {
 		e.Unlock()
 		clockClassOut := utils.GetClockClassLogMessage(PTP4lProcessName, clk.cfgName, clockClass)
 		if e.stdoutToSocket {
-			c := e.getConn()
-			if c != nil {
-				if _, err := c.Write([]byte(clockClassOut)); err != nil {
-					glog.Errorf("failed to write class change event %s", err.Error())
-					if utils.IsBrokenPipe(err) {
-						e.signalBrokenPipe()
-					}
-				}
-			} else {
-				glog.Errorf("failed to write class change event, connection is nil")
-			}
+			e.writeLogToSocket(clockClassOut)
 		} else if e.clockClassMetric != nil {
 			e.clockClassMetric.With(prometheus.Labels{
 				"process": PTP4lProcessName, "config": clk.cfgName, "node": e.nodeName}).Set(float64(clockClass))

--- a/pkg/event/event_socket_test.go
+++ b/pkg/event/event_socket_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	fbprotocol "github.com/facebook/time/ptp/protocol"
 	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/parser"
 	"github.com/stretchr/testify/assert"
 )
@@ -21,7 +22,6 @@ func newTestEventHandler(socketPath string) *EventHandler {
 		stdoutSocket:   socketPath,
 		stdoutToSocket: true,
 		closeCh:        make(chan bool, 1),
-		brokenPipeCh:   make(chan struct{}, 1),
 		clkSyncState:   map[string]*clockSyncState{},
 	}
 }
@@ -181,41 +181,6 @@ func TestGetSetConn_ConcurrentAccess(t *testing.T) {
 	wg.Wait()
 	// No race detector failures = success; use assert to satisfy unused-parameter lint.
 	assert.NotNil(t, e)
-}
-
-// --- signalBrokenPipe ---
-
-func TestSignalBrokenPipe_SendsSignal(t *testing.T) {
-	e := newTestEventHandler("")
-	e.signalBrokenPipe()
-
-	select {
-	case <-e.brokenPipeCh:
-		// expected
-	default:
-		t.Fatal("expected signal on brokenPipeCh")
-	}
-}
-
-func TestSignalBrokenPipe_NonBlocking(t *testing.T) {
-	e := newTestEventHandler("")
-
-	// Fill the channel.
-	e.brokenPipeCh <- struct{}{}
-
-	// Second signal should not block.
-	done := make(chan struct{})
-	go func() {
-		e.signalBrokenPipe()
-		close(done)
-	}()
-
-	select {
-	case <-done:
-		// expected: did not block
-	case <-time.After(1 * time.Second):
-		t.Fatal("signalBrokenPipe blocked when channel was already full")
-	}
 }
 
 // --- writeLogToSocket ---
@@ -600,6 +565,141 @@ done:
 	assert.Equal(t, 2, len(lines), "should have exactly 2 newline-separated lines")
 	for i, line := range lines {
 		assert.Contains(t, line, "T-GM-STATUS", "line %d should contain T-GM-STATUS", i)
+	}
+
+	e.setConn(nil) // cleanup
+}
+
+// --- emitClockClass ---
+
+func TestEmitClockClass_WritesToSocket(t *testing.T) {
+	socketPath := shortSocketPath(t)
+	listener, err := net.Listen("unix", socketPath)
+	assert.NoError(t, err)
+	defer listener.Close()
+
+	received := make(chan string, 10)
+	go acceptAndRead(listener, received)
+
+	e := newTestEventHandler(socketPath)
+	assert.True(t, e.reconnectEventSocket())
+
+	e.emitClockClass(fbprotocol.ClockClass(6), "ptp4l.0.config")
+
+	select {
+	case got := <-received:
+		assert.Contains(t, got, "CLOCK_CLASS_CHANGE 6", "message should contain clock class value")
+		assert.Contains(t, got, "ptp4l.0.config", "message should contain config name")
+		assert.Contains(t, got, "ptp4l", "message should contain process name")
+		assert.True(t, strings.HasSuffix(got, "\n"), "message should end with newline")
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for clock class message")
+	}
+
+	e.setConn(nil) // cleanup
+}
+
+func TestEmitClockClass_NilConnectionNoWrite(_ *testing.T) {
+	e := newTestEventHandler("")
+	// conn is nil by default; should not panic
+	e.emitClockClass(fbprotocol.ClockClass(6), "ptp4l.0.config")
+}
+
+func TestEmitClockClass_ReconnectsOnBrokenPipe(t *testing.T) {
+	socketPath := shortSocketPath(t)
+	listener, err := net.Listen("unix", socketPath)
+	assert.NoError(t, err)
+	defer listener.Close()
+
+	received := make(chan string, 10)
+	go acceptAndRead(listener, received)
+
+	e := newTestEventHandler(socketPath)
+	assert.True(t, e.reconnectEventSocket())
+
+	// Break the connection by closing it
+	e.getConn().Close()
+	e.setConn(nil)
+
+	// Re-establish and verify it can write after reconnection
+	assert.True(t, e.reconnectEventSocket())
+	e.emitClockClass(fbprotocol.ClockClass(248), "ptp4l.7.config")
+
+	select {
+	case got := <-received:
+		assert.Contains(t, got, "CLOCK_CLASS_CHANGE 248")
+		assert.Contains(t, got, "ptp4l.7.config")
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for clock class message after reconnect")
+	}
+
+	e.setConn(nil) // cleanup
+}
+
+// --- EmitClockClass (exported, via clkSyncState) ---
+
+func TestEmitClockClassExported_SkipsWhenNoClkSyncState(t *testing.T) {
+	socketPath := shortSocketPath(t)
+	listener, err := net.Listen("unix", socketPath)
+	assert.NoError(t, err)
+	defer listener.Close()
+
+	received := make(chan string, 10)
+	go acceptAndRead(listener, received)
+
+	e := NewEventHandlerForTests(socketPath)
+	assert.True(t, e.reconnectEventSocket())
+
+	// No clkSyncState entry for this config; EmitClockClass should return early
+	e.EmitClockClass("ptp4l.99.config")
+
+	// Verify nothing was sent
+	select {
+	case got := <-received:
+		t.Fatalf("expected no message but got: %q", got)
+	case <-time.After(200 * time.Millisecond):
+		// expected: no data sent
+	}
+
+	e.setConn(nil) // cleanup
+}
+
+func TestEmitClockClassExported_EmitsStoredClockClass(t *testing.T) {
+	socketPath := shortSocketPath(t)
+	listener, err := net.Listen("unix", socketPath)
+	assert.NoError(t, err)
+	defer listener.Close()
+
+	received := make(chan string, 10)
+	go acceptAndRead(listener, received)
+
+	e := NewEventHandlerForTests(socketPath)
+	assert.True(t, e.reconnectEventSocket())
+
+	// Populate clkSyncState via test helper
+	e.SetClockClass("ptp4l.0.config", 6)
+	e.SetClockClass("ptp4l.1.config", 255)
+
+	// Emit for config 0
+	e.EmitClockClass("ptp4l.0.config")
+
+	select {
+	case got := <-received:
+		assert.Contains(t, got, "CLOCK_CLASS_CHANGE 6")
+		assert.Contains(t, got, "ptp4l.0.config")
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for clock class message")
+	}
+
+	// Emit for config 1
+	e.EmitClockClass("ptp4l.1.config")
+
+	select {
+	case got := <-received:
+		assert.Contains(t, got, "CLOCK_CLASS_CHANGE 255")
+		assert.Contains(t, got, "ptp4l.1.config")
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for clock class message for config 1")
 	}
 
 	e.setConn(nil) // cleanup

--- a/pkg/event/event_tbc.go
+++ b/pkg/event/event_tbc.go
@@ -289,7 +289,6 @@ func (e *EventHandler) updateDownstreamData(cfgName string) {
 }
 
 // EmitClockClass emits the current clock class and accuracy for the specified configuration.
-// Broken pipe errors are handled internally via signalBrokenPipe.
 func (e *EventHandler) EmitClockClass(cfgName string) {
 	e.Lock()
 	state, ok := e.clkSyncState[cfgName]

--- a/pkg/event/event_test_helpers_test.go
+++ b/pkg/event/event_test_helpers_test.go
@@ -1,0 +1,28 @@
+package event
+
+import fbprotocol "github.com/facebook/time/ptp/protocol"
+
+// EventHandlerForTests wraps EventHandler with test-only helpers
+// that access unexported fields. This keeps test utilities out of
+// production code.
+type EventHandlerForTests struct {
+	*EventHandler
+}
+
+// NewEventHandlerForTests creates an EventHandlerForTests wrapping
+// a minimal EventHandler for socket logic tests.
+func NewEventHandlerForTests(socketPath string) *EventHandlerForTests {
+	return &EventHandlerForTests{
+		EventHandler: newTestEventHandler(socketPath),
+	}
+}
+
+// SetClockClass populates the clock sync state for the given config
+// so that EmitClockClass has data to emit.
+func (t *EventHandlerForTests) SetClockClass(cfgName string, clockClass uint8) {
+	t.Lock()
+	defer t.Unlock()
+	t.clkSyncState[cfgName] = &clockSyncState{
+		clockClass: fbprotocol.ClockClass(clockClass),
+	}
+}

--- a/pkg/utils/clock_class_log.go
+++ b/pkg/utils/clock_class_log.go
@@ -1,14 +1,10 @@
 package utils
 
 import (
-	"errors"
 	"fmt"
-	"net"
-	"syscall"
 	"time"
 
 	fbprotocol "github.com/facebook/time/ptp/protocol"
-	"github.com/golang/glog"
 )
 
 // GetClockClassLogMessage formats a clock class change message with timestamp.
@@ -17,50 +13,4 @@ func GetClockClassLogMessage(name, configName string, clockClass fbprotocol.Cloc
 		"%s[%d]:[%s] CLOCK_CLASS_CHANGE %d\n",
 		name, time.Now().Unix(), configName, clockClass,
 	)
-}
-
-// IsBrokenPipe checks if the error indicates a broken pipe or connection issue
-func IsBrokenPipe(err error) bool {
-	if err == nil {
-		return false
-	}
-
-	// Check for common connection errors
-	if errors.Is(err, syscall.EPIPE) || // Broken pipe
-		errors.Is(err, syscall.ECONNRESET) || // Connection reset by peer
-		errors.Is(err, syscall.ECONNREFUSED) || // Connection refused
-		errors.Is(err, syscall.ENOTCONN) { // Not connected
-		return true
-	}
-
-	// Check for net.OpError wrapping these errors
-	var opErr *net.OpError
-	if errors.As(err, &opErr) {
-		return IsBrokenPipe(opErr.Err)
-	}
-
-	return false
-}
-
-// socketWriteTimeout is the maximum time to wait for a write to the event socket.
-const socketWriteTimeout = 5 * time.Second
-
-// EmitClockClass writes a clock class change event to log and the network connection if provided.
-// Returns true if a broken pipe error occurred (caller should reconnect and retry).
-func EmitClockClass(c net.Conn, name string, configName string, clockClass fbprotocol.ClockClass) bool {
-	logMsg := GetClockClassLogMessage(name, configName, clockClass)
-	glog.Info(logMsg)
-	if c == nil {
-		return false
-	}
-
-	if err := c.SetWriteDeadline(time.Now().Add(socketWriteTimeout)); err != nil {
-		glog.Warningf("Failed to set write deadline for clock class event: %v", err)
-	}
-	_, err := c.Write([]byte(logMsg))
-	if err != nil {
-		glog.Errorf("failed to write class change event to socket: %s", err.Error())
-		return IsBrokenPipe(err)
-	}
-	return false
 }

--- a/pkg/utils/reconnect_test.go
+++ b/pkg/utils/reconnect_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"net"
-	"syscall"
 	"testing"
 	"time"
 
@@ -19,30 +18,6 @@ func TestDefaultReconnectConfig(t *testing.T) {
 	assert.Equal(t, utils.DefaultMaxReconnectAttempts, cfg.MaxAttempts)
 	assert.Equal(t, utils.DefaultReconnectBackoffBase, cfg.BackoffBase)
 	assert.Equal(t, utils.DefaultMaxReconnectBackoff, cfg.MaxBackoff)
-}
-
-// --- IsBrokenPipe ---
-
-func TestIsBrokenPipe(t *testing.T) {
-	tests := []struct {
-		name     string
-		err      error
-		expected bool
-	}{
-		{"nil error", nil, false},
-		{"generic error", errors.New("some error"), false},
-		{"EPIPE", syscall.EPIPE, true},
-		{"ECONNRESET", syscall.ECONNRESET, true},
-		{"ECONNREFUSED", syscall.ECONNREFUSED, true},
-		{"ENOTCONN", syscall.ENOTCONN, true},
-		{"wrapped EPIPE in OpError", &net.OpError{Op: "write", Err: syscall.EPIPE}, true},
-		{"wrapped generic in OpError", &net.OpError{Op: "write", Err: errors.New("other")}, false},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.expected, utils.IsBrokenPipe(tt.err))
-		})
-	}
 }
 
 // --- ReconnectWithBackoff ---


### PR DESCRIPTION
When cloud-event-proxy crashes and restarts, clock_class metrics for most ptp4l configs disappear because:

1. EmitClockClassLogs() skipped configs where pmc.parentDS was nil, even though the clock class data was available in clkSyncState. Remove this unnecessary guard since EmitClockClass() already handles missing data gracefully.

2. emitClockClass() used utils.EmitClockClass() which writes directly to the socket without reconnect-and-retry logic. On broken pipe the data was silently lost. Switch to writeLogToSocket() which handles reconnection, consistent with EmitClockSyncLogs, EmitPortRoleLogs, and EmitProcessStatusLog.

3. Clean up now-unused code: utils.EmitClockClass, utils.IsBrokenPipe, signalBrokenPipe, brokenPipeCh, and their associated tests.

This PR also includes a refactor change "Move newline termination logic into writeLogToSocket" from 4.21 https://github.com/openshift/linuxptp-daemon/pull/566/changes/e649fbb7b8782d7481f5057077ed124f0a77893e