### PR TITLE
Fix race condition in writeLogToSocket dropping writes during reconnect

### DIFF
--- a/pkg/event/event.go
+++ b/pkg/event/event.go
@@ -638,6 +638,17 @@ func (e *EventHandler) setClockClassLocked(clockClass fbprotocol.ClockClass, clo
 	e.clockAccuracy = clockAcc
 }
 
+// storeClockClassLocked stores the clock class and accuracy in clkSyncState
+// so that EmitClockClass and the classTicker can re-emit after a reconnect.
+// Caller must hold e.Lock().
+func (e *EventHandler) storeClockClassLocked(cfgName string, clockClass fbprotocol.ClockClass, clockAcc fbprotocol.ClockAccuracy) {
+	if _, ok := e.clkSyncState[cfgName]; !ok {
+		e.clkSyncState[cfgName] = &clockSyncState{}
+	}
+	e.clkSyncState[cfgName].clockClass = clockClass
+	e.clkSyncState[cfgName].clockAccuracy = clockAcc
+}
+
 // emitClockClass writes the clock class to the socket and updates the metric.
 // Must NOT be called while holding e.Lock().
 func (e *EventHandler) emitClockClass(clockClass fbprotocol.ClockClass, cfgName string) {
@@ -696,7 +707,15 @@ func (e *EventHandler) writeLogToSocket(l string) bool {
 	}
 	conn := e.getConn()
 	if conn == nil {
-		return false
+		if !e.reconnectEventSocket() {
+			glog.Warning("Connection is nil and reconnect failed, skipping socket write")
+			return false
+		}
+		conn = e.getConn()
+		if conn == nil {
+			glog.Error("Connection is still nil after successful reconnect, skipping socket write")
+			return false
+		}
 	}
 	if err := conn.SetWriteDeadline(time.Now().Add(socketWriteTimeout)); err != nil {
 		glog.Warningf("Failed to set write deadline: %v", err)
@@ -781,6 +800,7 @@ func (e *EventHandler) ProcessEvents() {
 						e.Lock()
 						e.clockClass = clk.clockClass
 						e.clockAccuracy = clk.clockAccuracy
+						e.storeClockClassLocked(clk.cfgName, clk.clockClass, clk.clockAccuracy)
 						e.Unlock()
 					}
 
@@ -1266,6 +1286,7 @@ func (e *EventHandler) UpdateClockClass(clk ClockClassRequest) {
 		e.Lock()
 		e.clockClass = clockClass
 		e.clockAccuracy = clockAccuracy
+		e.storeClockClassLocked(clk.cfgName, clockClass, clockAccuracy)
 		e.Unlock()
 		clockClassOut := utils.GetClockClassLogMessage(PTP4lProcessName, clk.cfgName, clockClass)
 		if e.stdoutToSocket {

--- a/pkg/event/event_socket_test.go
+++ b/pkg/event/event_socket_test.go
@@ -353,9 +353,19 @@ func TestWriteLogToSocket_WriteAndReconnect(t *testing.T) {
 	// Simulate broken pipe: close the current connection.
 	e.setConn(nil)
 
-	// writeLogToSocket should detect nil conn and return false.
-	result = e.writeLogToSocket("should fail\n")
-	assert.False(t, result)
+	// Accept the reconnection attempt so the write can succeed.
+	go acceptAndRead(listener, received)
+
+	// writeLogToSocket should reconnect and succeed since listener is still up.
+	result = e.writeLogToSocket("test message\n")
+	assert.True(t, result)
+
+	select {
+	case got := <-received:
+		assert.Equal(t, "test message\n", got)
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for reconnected message")
+	}
 
 	e.setConn(nil) // cleanup
 }
@@ -601,7 +611,9 @@ func TestEmitClockClass_WritesToSocket(t *testing.T) {
 
 func TestEmitClockClass_NilConnectionNoWrite(_ *testing.T) {
 	e := newTestEventHandler("")
-	// conn is nil by default; should not panic
+	// conn is nil by default; signal closeCh so reconnect exits immediately
+	e.closeCh <- true
+	// should not panic
 	e.emitClockClass(fbprotocol.ClockClass(6), "ptp4l.0.config")
 }
 
@@ -700,6 +712,82 @@ func TestEmitClockClassExported_EmitsStoredClockClass(t *testing.T) {
 		assert.Contains(t, got, "ptp4l.1.config")
 	case <-time.After(2 * time.Second):
 		t.Fatal("timed out waiting for clock class message for config 1")
+	}
+
+	e.setConn(nil) // cleanup
+}
+
+// --- storeClockClassLocked ---
+
+func TestStoreClockClassLocked_CreatesNewEntry(t *testing.T) {
+	e := newTestEventHandler("")
+	e.Lock()
+	e.storeClockClassLocked("ptp4l.0.config", fbprotocol.ClockClass(6), fbprotocol.ClockAccuracy(0x21))
+	state, ok := e.clkSyncState["ptp4l.0.config"]
+	e.Unlock()
+
+	assert.True(t, ok)
+	assert.Equal(t, fbprotocol.ClockClass(6), state.clockClass)
+	assert.Equal(t, fbprotocol.ClockAccuracy(0x21), state.clockAccuracy)
+}
+
+func TestStoreClockClassLocked_UpdatesExistingEntry(t *testing.T) {
+	e := newTestEventHandler("")
+
+	// Pre-populate with other fields
+	e.clkSyncState["ptp4l.0.config"] = &clockSyncState{
+		state:      PTP_LOCKED,
+		clockClass: fbprotocol.ClockClass(248),
+	}
+
+	e.Lock()
+	e.storeClockClassLocked("ptp4l.0.config", fbprotocol.ClockClass(6), fbprotocol.ClockAccuracy(0x21))
+	state := e.clkSyncState["ptp4l.0.config"]
+	e.Unlock()
+
+	assert.Equal(t, fbprotocol.ClockClass(6), state.clockClass)
+	assert.Equal(t, fbprotocol.ClockAccuracy(0x21), state.clockAccuracy)
+	// Existing field preserved
+	assert.Equal(t, PTP_LOCKED, state.state)
+}
+
+func TestStoreClockClassLocked_MakesEmitClockClassWork(t *testing.T) {
+	socketPath := shortSocketPath(t)
+	listener, err := net.Listen("unix", socketPath)
+	assert.NoError(t, err)
+	defer listener.Close()
+
+	received := make(chan string, 10)
+	go acceptAndRead(listener, received)
+
+	e := newTestEventHandler(socketPath)
+	assert.True(t, e.reconnectEventSocket())
+
+	// Simulate what clockClassRequestCh handler does
+	e.Lock()
+	e.storeClockClassLocked("ptp4l.0.config", fbprotocol.ClockClass(6), fbprotocol.ClockAccuracy(0x21))
+	e.storeClockClassLocked("ptp4l.1.config", fbprotocol.ClockClass(255), fbprotocol.ClockAccuracy(0xFE))
+	e.Unlock()
+
+	// EmitClockClass should now find and emit the stored values
+	e.EmitClockClass("ptp4l.0.config")
+
+	select {
+	case got := <-received:
+		assert.Contains(t, got, "CLOCK_CLASS_CHANGE 6")
+		assert.Contains(t, got, "ptp4l.0.config")
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for clock class message")
+	}
+
+	e.EmitClockClass("ptp4l.1.config")
+
+	select {
+	case got := <-received:
+		assert.Contains(t, got, "CLOCK_CLASS_CHANGE 255")
+		assert.Contains(t, got, "ptp4l.1.config")
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for clock class message")
 	}
 
 	e.setConn(nil) // cleanup

--- a/pkg/event/event_tbc.go
+++ b/pkg/event/event_tbc.go
@@ -293,6 +293,7 @@ func (e *EventHandler) EmitClockClass(cfgName string) {
 	e.Lock()
 	state, ok := e.clkSyncState[cfgName]
 	if !ok {
+		glog.Warningf("EmitClockClass: no clkSyncState entry for %s, skipping", cfgName)
 		e.Unlock()
 		return
 	}


### PR DESCRIPTION
Fixing two issues caused clock_class metrics to be missing after cloud-event-proxy crashed and recovered:

1. writeLogToSocket returned false when conn was nil (set by another
   goroutine handling a broken pipe) without attempting reconnection.
   Concurrent writers like EmitClockClassLogs silently lost data.
   Fix: call reconnectEventSocket when conn is nil, blocking until
   any in-progress reconnection completes.

2. clkSyncState was never populated with clock class values in T-BC/HA
   configurations. The clockClassRequestCh handler and UpdateClockClass
   set e.clockClass (EventHandler level) but not clkSyncState entries.
   EmitClockClass and the classTicker rely on clkSyncState for
   re-emission, so they had nothing to emit.
   Fix: store clock class in clkSyncState when received via
   clockClassRequestCh, via new storeClockClassLocked helper.
