### PR TITLE
Add DMI/SMBIOS system and baseboard info to NodePtpDevice status

### DIFF
--- a/pkg/daemon/ptpdev.go
+++ b/pkg/daemon/ptpdev.go
@@ -115,6 +115,14 @@ func GetDevStatusUpdate(nodePTPDev *ptpv1.NodePtpDevice) (*ptpv1.NodePtpDevice, 
 	ptpnetwork.LogDeviceChanges(nodePTPDev.Status.Devices, newDevices)
 
 	nodePTPDev.Status.Devices = newDevices
+
+	// Populate system and baseboard DMI/SMBIOS info only once (static per-node data).
+	if nodePTPDev.Status.SystemInfo == nil || nodePTPDev.Status.BaseBoardInfo == nil {
+		nodePTPDev.Status.SystemInfo = ptpnetwork.GetSystemInfo()
+		nodePTPDev.Status.BaseBoardInfo = ptpnetwork.GetBaseBoardInfo()
+		ptpnetwork.LogDMIInfo(nodePTPDev.Status.SystemInfo, nodePTPDev.Status.BaseBoardInfo)
+	}
+
 	return nodePTPDev, nil
 }
 

--- a/pkg/network/dmi_info.go
+++ b/pkg/network/dmi_info.go
@@ -1,0 +1,108 @@
+package network
+
+import (
+	"sync"
+
+	"github.com/golang/glog"
+	"github.com/jaypipes/ghw"
+	"github.com/jaypipes/ghw/pkg/util"
+	ptpv1 "github.com/k8snetworkplumbingwg/ptp-operator/api/v1"
+)
+
+var (
+	cachedSystemInfo    *ptpv1.SystemInfo
+	cachedBaseBoardInfo *ptpv1.BaseBoardInfo
+	dmiOnce             sync.Once
+)
+
+// cleanDMIValue returns an empty string for ghw's "unknown" sentinel value
+func cleanDMIValue(val string) string {
+	if val == util.UNKNOWN {
+		return ""
+	}
+	return val
+}
+
+// loadDMIInfo collects DMI/SMBIOS information once and caches the results
+func loadDMIInfo() {
+	dmiOnce.Do(func() {
+		productInfo, err := ghw.Product(ghw.WithNullAlerter())
+		if err != nil {
+			glog.Warningf("Failed to get system product info from DMI: %v", err)
+		} else {
+			cachedSystemInfo = &ptpv1.SystemInfo{
+				Manufacturer: cleanDMIValue(productInfo.Vendor),
+				ProductName:  cleanDMIValue(productInfo.Name),
+				Version:      cleanDMIValue(productInfo.Version),
+				SerialNumber: cleanDMIValue(productInfo.SerialNumber),
+				SKUNumber:    cleanDMIValue(productInfo.SKU),
+				Family:       cleanDMIValue(productInfo.Family),
+			}
+		}
+
+		boardInfo, err := ghw.Baseboard(ghw.WithNullAlerter())
+		if err != nil {
+			glog.Warningf("Failed to get baseboard info from DMI: %v", err)
+		} else {
+			cachedBaseBoardInfo = &ptpv1.BaseBoardInfo{
+				Manufacturer: cleanDMIValue(boardInfo.Vendor),
+				ProductName:  cleanDMIValue(boardInfo.Product),
+				Version:      cleanDMIValue(boardInfo.Version),
+				SerialNumber: cleanDMIValue(boardInfo.SerialNumber),
+			}
+		}
+	})
+}
+
+// GetSystemInfo returns cached system-level DMI/SMBIOS information (Type 1)
+func GetSystemInfo() *ptpv1.SystemInfo {
+	loadDMIInfo()
+	return cachedSystemInfo
+}
+
+// GetBaseBoardInfo returns cached base board DMI/SMBIOS information (Type 2)
+func GetBaseBoardInfo() *ptpv1.BaseBoardInfo {
+	loadDMIInfo()
+	return cachedBaseBoardInfo
+}
+
+// LogDMIInfo logs system and baseboard information
+func LogDMIInfo(sysInfo *ptpv1.SystemInfo, bbInfo *ptpv1.BaseBoardInfo) {
+	if sysInfo != nil {
+		glog.Infof("System Information:")
+		if sysInfo.Manufacturer != "" {
+			glog.Infof("  Manufacturer:   %s", sysInfo.Manufacturer)
+		}
+		if sysInfo.ProductName != "" {
+			glog.Infof("  Product Name:   %s", sysInfo.ProductName)
+		}
+		if sysInfo.Version != "" {
+			glog.Infof("  Version:        %s", sysInfo.Version)
+		}
+		if sysInfo.SerialNumber != "" {
+			glog.Infof("  Serial Number:  %s", sysInfo.SerialNumber)
+		}
+		if sysInfo.SKUNumber != "" {
+			glog.Infof("  SKU Number:     %s", sysInfo.SKUNumber)
+		}
+		if sysInfo.Family != "" {
+			glog.Infof("  Family:         %s", sysInfo.Family)
+		}
+	}
+
+	if bbInfo != nil {
+		glog.Infof("Base Board Information:")
+		if bbInfo.Manufacturer != "" {
+			glog.Infof("  Manufacturer:   %s", bbInfo.Manufacturer)
+		}
+		if bbInfo.ProductName != "" {
+			glog.Infof("  Product Name:   %s", bbInfo.ProductName)
+		}
+		if bbInfo.Version != "" {
+			glog.Infof("  Version:        %s", bbInfo.Version)
+		}
+		if bbInfo.SerialNumber != "" {
+			glog.Infof("  Serial Number:  %s", bbInfo.SerialNumber)
+		}
+	}
+}


### PR DESCRIPTION
## Overview

This PR adds DMI/SMBIOS hardware identification to the `NodePtpDevice` status, exposing system-level (Type 1) and baseboard-level (Type 2) information. This enables the PTP operator and HardwareConfig controller to identify the physical platform (manufacturer, product name, serial number, etc.) without requiring manual node labeling or out-of-band discovery. [CNF-21832](https://redhat.atlassian.net/browse/CNF-21832)

## Impact

This is a **new feature** that enriches the `NodePtpDevice` CRD status with static per-node hardware metadata. It enables hardware-aware PTP configuration matching (e.g., applying different pin configs based on baseboard manufacturer). No existing APIs or workflows are modified; this is purely additive. The DMI data is read once and cached via `sync.Once`, so there is no recurring sysfs overhead.

## Files Changed

| File Changed | Explanation |
| :--- | :--- |
| `pkg/daemon/ptpdev.go` | Populates `SystemInfo` and `BaseBoardInfo` on the `NodePtpDevice` status during device update, guarded by a nil check to avoid redundant reads. Logs DMI info on each update cycle. |
| `pkg/network/dmi_info.go` | New file. Uses `ghw` to read DMI/SMBIOS system and baseboard data from sysfs, caches results with `sync.Once`, sanitizes unknown sentinel values, and provides structured logging. |

## Technical Implementation

**Logic:**
- DMI/SMBIOS data is loaded once per daemon lifetime via `sync.Once` and cached in package-level variables.
- `ghw.Product()` reads SMBIOS Type 1 (System Information); `ghw.Baseboard()` reads Type 2 (Base Board Information).
- The `ghw` "unknown" sentinel value is cleaned to an empty string to avoid misleading output in the CRD status.
- The `NodePtpDevice` status fields `SystemInfo` and `BaseBoardInfo` are populated only when nil (first run or after CRD recreation).

**Infrastructure:**
- Depends on `github.com/jaypipes/ghw` (already vendored) for cross-platform hardware introspection.
- Depends on `ptpv1.SystemInfo` and `ptpv1.BaseBoardInfo` types from the ptp-operator API.
