### PR TITLE
refactor: extract ptp4l config parsing into shared pkg/ptp4lconf package (CNF-20999)

### DIFF
--- a/pkg/daemon/config.go
+++ b/pkg/daemon/config.go
@@ -22,13 +22,6 @@ import (
 	ptpv1 "github.com/k8snetworkplumbingwg/ptp-operator/api/v1"
 )
 
-// Predefined config section names, re-exported from ptp4lconf for backward compatibility.
-const (
-	GlobalSectionName  = ptp4lconf.GlobalSectionName
-	NmeaSectionName    = ptp4lconf.NmeaSectionName
-	UnicastSectionName = ptp4lconf.UnicastSectionName
-)
-
 // LinuxPTPUpdate controls whether to update linuxPTP conf
 // and contains linuxPTP conf to be updated. It's rendered
 // and passed to linuxptp instance by daemon.
@@ -77,19 +70,19 @@ func (l *LinuxPTPConfUpdate) GetCurrentPTPProfiles() []string {
 	return profileNames
 }
 
-// Ptp4lConf wraps the shared ptp4lconf.Conf parser with daemon-specific
+// ProfileConfig wraps the shared ptp4lconf.Conf parser with daemon-specific
 // fields (profile name, GNSS serial port) and rendering methods.
-type Ptp4lConf struct {
+type ProfileConfig struct {
 	ptp4lconf.Conf
 	profileName    string
 	gnssSerialPort string
 }
 
-func (conf *Ptp4lConf) getPtp4lConfOptionOrEmptyString(sectionName, key string) (string, bool) {
+func (conf *ProfileConfig) getPtp4lConfOptionOrEmptyString(sectionName, key string) (string, bool) {
 	return conf.GetOption(sectionName, key)
 }
 
-func (conf *Ptp4lConf) setPtp4lConfOption(sectionName, key, value string, overwrite bool) {
+func (conf *ProfileConfig) setPtp4lConfOption(sectionName, key, value string, overwrite bool) {
 	conf.SetOption(sectionName, key, value, overwrite)
 }
 
@@ -176,29 +169,29 @@ func tryToLoadOldConfig(nodeProfilesJSON []byte) ([]ptpv1.PtpProfile, bool) {
 	return []ptpv1.PtpProfile{*ptpConfig}, true
 }
 
-// PopulatePtp4lConf delegates INI parsing and clock-type inference to ptp4lconf.Conf.Populate.
-func (conf *Ptp4lConf) PopulatePtp4lConf(config *string, cliArgs *string) error {
+// PopulatePtp4lConf takes as input a PtpProfile.ProfileConfig string and outputs as ProfileConfig struct
+func (conf *ProfileConfig) PopulatePtp4lConf(config *string, cliArgs *string) error {
 	return conf.Populate(config, cliArgs)
 }
 
 // ExtendGlobalSection extends Ptp4lConf struct with fields not from ptp4lConf
-func (conf *Ptp4lConf) ExtendGlobalSection(profileName string, messageTag string, socketPath string, pProcess string) {
+func (conf *ProfileConfig) ExtendGlobalSection(profileName string, messageTag string, socketPath string, pProcess string) {
 	conf.profileName = profileName
-	conf.setPtp4lConfOption(GlobalSectionName, "message_tag", messageTag, true)
+	conf.setPtp4lConfOption(ptp4lconf.GlobalSectionName, "message_tag", messageTag, true)
 	if socketPath != "" {
-		conf.setPtp4lConfOption(GlobalSectionName, "uds_address", socketPath, true)
+		conf.setPtp4lConfOption(ptp4lconf.GlobalSectionName, "uds_address", socketPath, true)
 	}
-	if gnssSerialPort, ok := conf.getPtp4lConfOptionOrEmptyString(GlobalSectionName, "ts2phc.nmea_serialport"); ok {
+	if gnssSerialPort, ok := conf.getPtp4lConfOptionOrEmptyString(ptp4lconf.GlobalSectionName, "ts2phc.nmea_serialport"); ok {
 		conf.gnssSerialPort = strings.TrimSpace(gnssSerialPort)
-		conf.setPtp4lConfOption(GlobalSectionName, "ts2phc.nmea_serialport", GPSPIPE_SERIALPORT, true)
+		conf.setPtp4lConfOption(ptp4lconf.GlobalSectionName, "ts2phc.nmea_serialport", GPSPIPE_SERIALPORT, true)
 	}
-	if _, ok := conf.getPtp4lConfOptionOrEmptyString(GlobalSectionName, "leapfile"); ok || pProcess == ts2phcProcessName { // not required to check process if leapfile is always included
-		conf.setPtp4lConfOption(GlobalSectionName, "leapfile", fmt.Sprintf("%s/%s", config.DefaultLeapConfigPath, os.Getenv("NODE_NAME")), true)
+	if _, ok := conf.getPtp4lConfOptionOrEmptyString(ptp4lconf.GlobalSectionName, "leapfile"); ok || pProcess == ts2phcProcessName { // not required to check process if leapfile is always included
+		conf.setPtp4lConfOption(ptp4lconf.GlobalSectionName, "leapfile", fmt.Sprintf("%s/%s", config.DefaultLeapConfigPath, os.Getenv("NODE_NAME")), true)
 	}
 }
 
-// AddInterfaceSection adds interface to Ptp4lConf
-func (conf *Ptp4lConf) AddInterfaceSection(iface string) {
+// AddInterfaceSection adds interface to ProfileConfig
+func (conf *ProfileConfig) AddInterfaceSection(iface string) {
 	ifaceSectionName := fmt.Sprintf("[%s]", iface)
 	conf.setPtp4lConfOption(ifaceSectionName, "", "", false)
 }
@@ -220,7 +213,7 @@ func getSource(isTs2phcMaster string) event.EventSource {
 //     (UNTIL next device section).
 //  2. Port section - any other section not starting with < (e.g. [eth0]) is the port section.
 //     Multiple port sections are allowed. Each port participates in SyncE communication.
-func (conf *Ptp4lConf) extractSynceRelations() *synce.Relations {
+func (conf *ProfileConfig) extractSynceRelations() *synce.Relations {
 	var err error
 	r := &synce.Relations{
 		Devices: []*synce.Config{},
@@ -267,7 +260,7 @@ func (conf *Ptp4lConf) extractSynceRelations() *synce.Relations {
 			synceRelationInfo.ExtendedTlv = extendedTlv
 		} else if strings.HasPrefix(sectionName, "[{") {
 			synceRelationInfo.ExternalSource = re.ReplaceAllString(sectionName, "")
-		} else if strings.HasPrefix(sectionName, "[") && sectionName != GlobalSectionName {
+		} else if strings.HasPrefix(sectionName, "[") && sectionName != ptp4lconf.GlobalSectionName {
 			iface := re.ReplaceAllString(sectionName, "")
 			ifaces = append(ifaces, iface)
 		}
@@ -282,14 +275,14 @@ func (conf *Ptp4lConf) extractSynceRelations() *synce.Relations {
 }
 
 // RenderSyncE4lConf outputs synce4l config as string
-func (conf *Ptp4lConf) RenderSyncE4lConf(ptpSettings map[string]string) (configOut string, relations *synce.Relations) {
-	configOut = fmt.Sprintf("#profile: %s\n", conf.profileName)
+func (conf *ProfileConfig) RenderSyncE4lConf(ptpSettings map[string]string) (configOut string, relations *synce.Relations) {
+	configOut = "#profile: " + conf.profileName + "\n"
 	relations = conf.extractSynceRelations()
 	relations.AddClockIds(ptpSettings)
 	deviceIdx := 0
 
 	for i, section := range conf.Sections {
-		configOut = fmt.Sprintf("%s\n%s", configOut, section.SectionName)
+		configOut += "\n" + section.SectionName
 		if strings.HasPrefix(section.SectionName, "[<") {
 			if _, found := conf.getPtp4lConfOptionOrEmptyString(section.SectionName, "clock_id"); !found {
 				conf.setPtp4lConfOption(section.SectionName, "clock_id", relations.Devices[deviceIdx].ClockId, true)
@@ -297,26 +290,26 @@ func (conf *Ptp4lConf) RenderSyncE4lConf(ptpSettings map[string]string) (configO
 			}
 		}
 		for _, option := range conf.Sections[i].Options {
-			configOut = fmt.Sprintf("%s\n%s %s", configOut, option.Key, option.Value)
+			configOut += "\n" + option.Key + " " + option.Value
 		}
 	}
 	return
 }
 
 // RenderPtp4lConf outputs ptp4l config as string
-func (conf *Ptp4lConf) RenderPtp4lConf() (configOut string, ifaces config.IFaces) {
-	configOut = fmt.Sprintf("#profile: %s\n", conf.profileName)
+func (conf *ProfileConfig) RenderPtp4lConf() (configOut string, ifaces config.IFaces) {
+	configOut = "#profile: " + conf.profileName + "\n"
 	var nmea_source event.EventSource
 
 	for _, section := range conf.Sections {
-		configOut = fmt.Sprintf("%s\n%s", configOut, section.SectionName)
+		configOut += "\n" + section.SectionName
 
-		if section.SectionName == NmeaSectionName {
+		if section.SectionName == ptp4lconf.NmeaSectionName {
 			if source, ok := conf.getPtp4lConfOptionOrEmptyString(section.SectionName, "ts2phc.master"); ok {
 				nmea_source = getSource(source)
 			}
 		}
-		if section.SectionName != GlobalSectionName && section.SectionName != NmeaSectionName && section.SectionName != UnicastSectionName {
+		if section.SectionName != ptp4lconf.GlobalSectionName && section.SectionName != ptp4lconf.NmeaSectionName && section.SectionName != ptp4lconf.UnicastSectionName {
 			iface := config.Iface{Name: ptp4lconf.SectionName(section.SectionName)}
 			iface.PhcId = network.GetPhcId(iface.Name)
 
@@ -333,7 +326,7 @@ func (conf *Ptp4lConf) RenderPtp4lConf() (configOut string, ifaces config.IFaces
 			alias.AddInterface(iface.PhcId, iface.Name)
 		}
 		for _, option := range section.Options {
-			configOut = fmt.Sprintf("%s\n%s %s", configOut, option.Key, option.Value)
+			configOut += "\n" + option.Key + " " + option.Value
 		}
 	}
 	alias.CalculateAliases()

--- a/pkg/daemon/config.go
+++ b/pkg/daemon/config.go
@@ -78,6 +78,18 @@ type ProfileConfig struct {
 	gnssSerialPort string
 }
 
+// deriveClockType infers the PTP clock type from parsed port role counts.
+func deriveClockType(roles ptp4lconf.PortRoleSummary) event.ClockType {
+	hasSlaveConfig := roles.SlaveOnlyTrue > 0 || roles.MasterOnlyFalse > 0
+	if !hasSlaveConfig {
+		return event.GM
+	}
+	if roles.TotalPorts > 1 {
+		return event.BC
+	}
+	return event.OC
+}
+
 func NewLinuxPTPConfUpdate() (*LinuxPTPConfUpdate, error) {
 	if _, err := os.Stat(PTP4L_CONF_FILE_PATH); err != nil {
 		if os.IsNotExist(err) {

--- a/pkg/daemon/config.go
+++ b/pkg/daemon/config.go
@@ -78,14 +78,6 @@ type ProfileConfig struct {
 	gnssSerialPort string
 }
 
-func (conf *ProfileConfig) getPtp4lConfOptionOrEmptyString(sectionName, key string) (string, bool) {
-	return conf.GetOption(sectionName, key)
-}
-
-func (conf *ProfileConfig) setPtp4lConfOption(sectionName, key, value string, overwrite bool) {
-	conf.SetOption(sectionName, key, value, overwrite)
-}
-
 func NewLinuxPTPConfUpdate() (*LinuxPTPConfUpdate, error) {
 	if _, err := os.Stat(PTP4L_CONF_FILE_PATH); err != nil {
 		if os.IsNotExist(err) {
@@ -169,31 +161,26 @@ func tryToLoadOldConfig(nodeProfilesJSON []byte) ([]ptpv1.PtpProfile, bool) {
 	return []ptpv1.PtpProfile{*ptpConfig}, true
 }
 
-// PopulatePtp4lConf takes as input a PtpProfile.ProfileConfig string and outputs as ProfileConfig struct
-func (conf *ProfileConfig) PopulatePtp4lConf(config *string, cliArgs *string) error {
-	return conf.Populate(config, cliArgs)
-}
-
-// ExtendGlobalSection extends Ptp4lConf struct with fields not from ptp4lConf
+// ExtendGlobalSection extends ProfileConfig with fields not from ptp4lConf
 func (conf *ProfileConfig) ExtendGlobalSection(profileName string, messageTag string, socketPath string, pProcess string) {
 	conf.profileName = profileName
-	conf.setPtp4lConfOption(ptp4lconf.GlobalSectionName, "message_tag", messageTag, true)
+	conf.SetOption(ptp4lconf.GlobalSectionName, "message_tag", messageTag, true)
 	if socketPath != "" {
-		conf.setPtp4lConfOption(ptp4lconf.GlobalSectionName, "uds_address", socketPath, true)
+		conf.SetOption(ptp4lconf.GlobalSectionName, "uds_address", socketPath, true)
 	}
-	if gnssSerialPort, ok := conf.getPtp4lConfOptionOrEmptyString(ptp4lconf.GlobalSectionName, "ts2phc.nmea_serialport"); ok {
+	if gnssSerialPort, ok := conf.GetOption(ptp4lconf.GlobalSectionName, "ts2phc.nmea_serialport"); ok {
 		conf.gnssSerialPort = strings.TrimSpace(gnssSerialPort)
-		conf.setPtp4lConfOption(ptp4lconf.GlobalSectionName, "ts2phc.nmea_serialport", GPSPIPE_SERIALPORT, true)
+		conf.SetOption(ptp4lconf.GlobalSectionName, "ts2phc.nmea_serialport", GPSPIPE_SERIALPORT, true)
 	}
-	if _, ok := conf.getPtp4lConfOptionOrEmptyString(ptp4lconf.GlobalSectionName, "leapfile"); ok || pProcess == ts2phcProcessName { // not required to check process if leapfile is always included
-		conf.setPtp4lConfOption(ptp4lconf.GlobalSectionName, "leapfile", fmt.Sprintf("%s/%s", config.DefaultLeapConfigPath, os.Getenv("NODE_NAME")), true)
+	if _, ok := conf.GetOption(ptp4lconf.GlobalSectionName, "leapfile"); ok || pProcess == ts2phcProcessName { // not required to check process if leapfile is always included
+		conf.SetOption(ptp4lconf.GlobalSectionName, "leapfile", fmt.Sprintf("%s/%s", config.DefaultLeapConfigPath, os.Getenv("NODE_NAME")), true)
 	}
 }
 
 // AddInterfaceSection adds interface to ProfileConfig
 func (conf *ProfileConfig) AddInterfaceSection(iface string) {
 	ifaceSectionName := fmt.Sprintf("[%s]", iface)
-	conf.setPtp4lConfOption(ifaceSectionName, "", "", false)
+	conf.SetOption(ifaceSectionName, "", "", false)
 }
 
 func getSource(isTs2phcMaster string) event.EventSource {
@@ -246,12 +233,12 @@ func (conf *ProfileConfig) extractSynceRelations() *synce.Relations {
 			extendedTlv, networkOption = synce.ExtendedTLV_DISABLED, synce.SYNCE_NETWORK_OPT_1
 
 			synceRelationInfo.Name = re.ReplaceAllString(sectionName, "")
-			if networkOptionStr, ok := conf.getPtp4lConfOptionOrEmptyString(sectionName, "network_option"); ok {
+			if networkOptionStr, ok := conf.GetOption(sectionName, "network_option"); ok {
 				if networkOption, err = strconv.Atoi(strings.TrimSpace(networkOptionStr)); err != nil {
 					glog.Errorf("error parsing `network_option`, setting network_option to default 1 : %s", err)
 				}
 			}
-			if extendedTlvStr, ok := conf.getPtp4lConfOptionOrEmptyString(sectionName, "extended_tlv"); ok {
+			if extendedTlvStr, ok := conf.GetOption(sectionName, "extended_tlv"); ok {
 				if extendedTlv, err = strconv.Atoi(strings.TrimSpace(extendedTlvStr)); err != nil {
 					glog.Errorf("error parsing `extended_tlv`, setting extended_tlv to default 1 : %s", err)
 				}
@@ -284,8 +271,8 @@ func (conf *ProfileConfig) RenderSyncE4lConf(ptpSettings map[string]string) (con
 	for i, section := range conf.Sections {
 		configOut += "\n" + section.SectionName
 		if strings.HasPrefix(section.SectionName, "[<") {
-			if _, found := conf.getPtp4lConfOptionOrEmptyString(section.SectionName, "clock_id"); !found {
-				conf.setPtp4lConfOption(section.SectionName, "clock_id", relations.Devices[deviceIdx].ClockId, true)
+			if _, found := conf.GetOption(section.SectionName, "clock_id"); !found {
+				conf.SetOption(section.SectionName, "clock_id", relations.Devices[deviceIdx].ClockId, true)
 				deviceIdx++
 			}
 		}
@@ -299,26 +286,26 @@ func (conf *ProfileConfig) RenderSyncE4lConf(ptpSettings map[string]string) (con
 // RenderPtp4lConf outputs ptp4l config as string
 func (conf *ProfileConfig) RenderPtp4lConf() (configOut string, ifaces config.IFaces) {
 	configOut = "#profile: " + conf.profileName + "\n"
-	var nmea_source event.EventSource
+	var nmeaSource event.EventSource
 
 	for _, section := range conf.Sections {
 		configOut += "\n" + section.SectionName
 
 		if section.SectionName == ptp4lconf.NmeaSectionName {
-			if source, ok := conf.getPtp4lConfOptionOrEmptyString(section.SectionName, "ts2phc.master"); ok {
-				nmea_source = getSource(source)
+			if source, ok := conf.GetOption(section.SectionName, "ts2phc.master"); ok {
+				nmeaSource = getSource(source)
 			}
 		}
 		if section.SectionName != ptp4lconf.GlobalSectionName && section.SectionName != ptp4lconf.NmeaSectionName && section.SectionName != ptp4lconf.UnicastSectionName {
 			iface := config.Iface{Name: section.Name()}
 			iface.PhcId = network.GetPhcId(iface.Name)
 
-			if source, ok := conf.getPtp4lConfOptionOrEmptyString(section.SectionName, "ts2phc.master"); ok {
+			if source, ok := conf.GetOption(section.SectionName, "ts2phc.master"); ok {
 				iface.Source = getSource(source)
 			} else {
-				iface.Source = nmea_source
+				iface.Source = nmeaSource
 			}
-			if masterOnly, ok := conf.getPtp4lConfOptionOrEmptyString(section.SectionName, "masterOnly"); ok {
+			if masterOnly, ok := conf.GetOption(section.SectionName, "masterOnly"); ok {
 				// TODO add error handling
 				iface.IsMaster, _ = strconv.ParseBool(strings.TrimSpace(masterOnly))
 			}

--- a/pkg/daemon/config.go
+++ b/pkg/daemon/config.go
@@ -3,7 +3,6 @@ package daemon
 import (
 	"bytes"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"os"
 	"regexp"
@@ -12,6 +11,7 @@ import (
 
 	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/alias"
 	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/network"
+	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/ptp4lconf"
 	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/synce"
 
 	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/config"
@@ -22,15 +22,12 @@ import (
 	ptpv1 "github.com/k8snetworkplumbingwg/ptp-operator/api/v1"
 )
 
-// predefined config section names
+// Predefined config section names, re-exported from ptp4lconf for backward compatibility.
 const (
-	GlobalSectionName  = "[global]"
-	NmeaSectionName    = "[nmea]"
-	UnicastSectionName = "[unicast_master_table]"
+	GlobalSectionName  = ptp4lconf.GlobalSectionName
+	NmeaSectionName    = ptp4lconf.NmeaSectionName
+	UnicastSectionName = ptp4lconf.UnicastSectionName
 )
-
-// cliArgsSlaveFlagsRegex matches --slaveOnly or --clientOnly with value 1 in command-line arguments
-var cliArgsSlaveFlagsRegex = regexp.MustCompile(`--(slaveOnly|clientOnly)(\s+1|=1)(\s|$)`)
 
 // LinuxPTPUpdate controls whether to update linuxPTP conf
 // and contains linuxPTP conf to be updated. It's rendered
@@ -80,75 +77,20 @@ func (l *LinuxPTPConfUpdate) GetCurrentPTPProfiles() []string {
 	return profileNames
 }
 
-type ptp4lConfOption struct {
-	key   string
-	value string
-}
-
-type ptp4lConfSection struct {
-	sectionName string
-	options     []ptp4lConfOption
-}
-
-// Ptp4lConf is a structure to represent a parsed ptpconfig,
-// which can then be rendered to a string again.
+// Ptp4lConf wraps the shared ptp4lconf.Conf parser with daemon-specific
+// fields (profile name, GNSS serial port) and rendering methods.
 type Ptp4lConf struct {
-	sections         []ptp4lConfSection
-	profile_name     string
-	clock_type       event.ClockType
-	gnss_serial_port string // gnss serial port
+	ptp4lconf.Conf
+	profileName    string
+	gnssSerialPort string
 }
 
-func (conf *Ptp4lConf) getPtp4lConfOptionOrEmptyString(sectionName string, key string) (string, bool) {
-	for _, section := range conf.sections {
-		if section.sectionName == sectionName {
-			for _, option := range section.options {
-				if option.key == key {
-					return option.value, true
-				}
-			}
-		}
-	}
-
-	return "", false
+func (conf *Ptp4lConf) getPtp4lConfOptionOrEmptyString(sectionName, key string) (string, bool) {
+	return conf.GetOption(sectionName, key)
 }
 
-func (conf *Ptp4lConf) setPtp4lConfOption(sectionName string, key string, value string, overwrite bool) {
-	var updatedSection ptp4lConfSection
-	index := -1
-	for i, section := range conf.sections {
-		if section.sectionName == sectionName {
-			updatedSection = section
-			index = i
-		}
-	}
-	if index < 0 {
-		newSectionOptions := make([]ptp4lConfOption, 0)
-		updatedSection = ptp4lConfSection{options: newSectionOptions, sectionName: sectionName}
-		index = len(conf.sections)
-		conf.sections = append(conf.sections, updatedSection)
-	}
-
-	//Stop now if initializing section without option
-	if key == "" {
-		return
-	}
-	found := false
-	if overwrite {
-		for i := range updatedSection.options {
-			if updatedSection.options[i].key == key {
-				updatedSection.options[i] = ptp4lConfOption{key: key, value: value}
-				found = true
-			}
-		}
-	}
-	// Append unless already overwrote it.
-	if !found {
-		updatedSection.options = append(updatedSection.options, ptp4lConfOption{key: key, value: value})
-	}
-
-	//Update section in conf
-	conf.sections[index] = updatedSection
+func (conf *Ptp4lConf) setPtp4lConfOption(sectionName, key, value string, overwrite bool) {
+	conf.SetOption(sectionName, key, value, overwrite)
 }
 
 func NewLinuxPTPConfUpdate() (*LinuxPTPConfUpdate, error) {
@@ -234,83 +176,20 @@ func tryToLoadOldConfig(nodeProfilesJSON []byte) ([]ptpv1.PtpProfile, bool) {
 	return []ptpv1.PtpProfile{*ptpConfig}, true
 }
 
-// PopulatePtp4lConf takes as input a PtpProfile.Ptp4lConf string and outputs as ptp4lConf struct
+// PopulatePtp4lConf delegates INI parsing and clock-type inference to ptp4lconf.Conf.Populate.
 func (conf *Ptp4lConf) PopulatePtp4lConf(config *string, cliArgs *string) error {
-	var currentSectionName string
-	conf.sections = make([]ptp4lConfSection, 0)
-	hasSlaveConfigDefined := false
-	if cliArgs != nil {
-		args := *cliArgs
-		// Check for -s flag (short form for slave mode)
-		// Split by spaces and check for exact -s flag to avoid matching substrings like in --slaveOnly
-		for _, arg := range strings.Fields(args) {
-			if arg == "-s" {
-				hasSlaveConfigDefined = true
-				break
-			}
-		}
-		// Check for --slaveOnly or --clientOnly with value 1
-		if cliArgsSlaveFlagsRegex.MatchString(args) {
-			hasSlaveConfigDefined = true
-		}
-	}
-	ifaceCount := 0
-	if config != nil {
-		for _, line := range strings.Split(*config, "\n") {
-			line = strings.TrimSpace(line)
-			// Skip empty lines and comments
-			if line == "" || strings.HasPrefix(line, "#") {
-				continue
-			} else if strings.HasPrefix(line, "[") {
-				currentLine := strings.Split(line, "]")
-				if len(currentLine) < 2 {
-					return errors.New("Section missing closing ']': " + line)
-				}
-				currentSectionName = fmt.Sprintf("%s]", currentLine[0])
-				if currentSectionName != GlobalSectionName && currentSectionName != NmeaSectionName && currentSectionName != UnicastSectionName {
-					ifaceCount++
-				}
-				conf.setPtp4lConfOption(currentSectionName, "", "", false)
-			} else {
-				split := strings.IndexByte(line, ' ')
-				if split > 0 {
-					key := line[:split]
-					value := strings.TrimSpace(line[split:])
-					conf.setPtp4lConfOption(currentSectionName, key, value, false)
-					if (key == "masterOnly" && value == "0" && currentSectionName != GlobalSectionName) ||
-						(key == "serverOnly" && value == "0") ||
-						(key == "slaveOnly" && value == "1") ||
-						(key == "clientOnly" && value == "1") {
-						hasSlaveConfigDefined = true
-					}
-				}
-			}
-		}
-	}
-
-	if !hasSlaveConfigDefined {
-		// No Slave Interfaces defined
-		conf.clock_type = event.GM
-	} else if ifaceCount > 1 {
-		// Multiple interfaces with at least one slave Interface defined
-		conf.clock_type = event.BC
-	} else {
-		// Single slave Interface defined
-		conf.clock_type = event.OC
-	}
-
-	return nil
+	return conf.Populate(config, cliArgs)
 }
 
 // ExtendGlobalSection extends Ptp4lConf struct with fields not from ptp4lConf
 func (conf *Ptp4lConf) ExtendGlobalSection(profileName string, messageTag string, socketPath string, pProcess string) {
-	conf.profile_name = profileName
+	conf.profileName = profileName
 	conf.setPtp4lConfOption(GlobalSectionName, "message_tag", messageTag, true)
 	if socketPath != "" {
 		conf.setPtp4lConfOption(GlobalSectionName, "uds_address", socketPath, true)
 	}
 	if gnssSerialPort, ok := conf.getPtp4lConfOptionOrEmptyString(GlobalSectionName, "ts2phc.nmea_serialport"); ok {
-		conf.gnss_serial_port = strings.TrimSpace(gnssSerialPort)
+		conf.gnssSerialPort = strings.TrimSpace(gnssSerialPort)
 		conf.setPtp4lConfOption(GlobalSectionName, "ts2phc.nmea_serialport", GPSPIPE_SERIALPORT, true)
 	}
 	if _, ok := conf.getPtp4lConfOptionOrEmptyString(GlobalSectionName, "leapfile"); ok || pProcess == ts2phcProcessName { // not required to check process if leapfile is always included
@@ -352,8 +231,8 @@ func (conf *Ptp4lConf) extractSynceRelations() *synce.Relations {
 	synceRelationInfo := synce.Config{}
 
 	var extendedTlv, networkOption int = synce.ExtendedTLV_DISABLED, synce.SYNCE_NETWORK_OPT_1
-	for _, section := range conf.sections {
-		sectionName := section.sectionName
+	for _, section := range conf.Sections {
+		sectionName := section.SectionName
 		if strings.HasPrefix(sectionName, "[<") {
 			if synceRelationInfo.Name != "" {
 				if len(ifaces) > 0 {
@@ -404,68 +283,57 @@ func (conf *Ptp4lConf) extractSynceRelations() *synce.Relations {
 
 // RenderSyncE4lConf outputs synce4l config as string
 func (conf *Ptp4lConf) RenderSyncE4lConf(ptpSettings map[string]string) (configOut string, relations *synce.Relations) {
-	configOut = fmt.Sprintf("#profile: %s\n", conf.profile_name)
+	configOut = fmt.Sprintf("#profile: %s\n", conf.profileName)
 	relations = conf.extractSynceRelations()
 	relations.AddClockIds(ptpSettings)
 	deviceIdx := 0
 
-	for i, section := range conf.sections {
-		configOut = fmt.Sprintf("%s\n%s", configOut, section.sectionName)
-		if strings.HasPrefix(section.sectionName, "[<") {
-			if _, found := conf.getPtp4lConfOptionOrEmptyString(section.sectionName, "clock_id"); !found {
-				conf.setPtp4lConfOption(section.sectionName, "clock_id", relations.Devices[deviceIdx].ClockId, true)
+	for i, section := range conf.Sections {
+		configOut = fmt.Sprintf("%s\n%s", configOut, section.SectionName)
+		if strings.HasPrefix(section.SectionName, "[<") {
+			if _, found := conf.getPtp4lConfOptionOrEmptyString(section.SectionName, "clock_id"); !found {
+				conf.setPtp4lConfOption(section.SectionName, "clock_id", relations.Devices[deviceIdx].ClockId, true)
 				deviceIdx++
 			}
 		}
-		for _, option := range conf.sections[i].options {
-			k := option.key
-			v := option.value
-			configOut = fmt.Sprintf("%s\n%s %s", configOut, k, v)
+		for _, option := range conf.Sections[i].Options {
+			configOut = fmt.Sprintf("%s\n%s %s", configOut, option.Key, option.Value)
 		}
 	}
 	return
 }
 
-func getSectionName(name string) string {
-	name = strings.ReplaceAll(name, "[", "")
-	name = strings.ReplaceAll(name, "]", "")
-	return name
-}
-
 // RenderPtp4lConf outputs ptp4l config as string
 func (conf *Ptp4lConf) RenderPtp4lConf() (configOut string, ifaces config.IFaces) {
-	configOut = fmt.Sprintf("#profile: %s\n", conf.profile_name)
+	configOut = fmt.Sprintf("#profile: %s\n", conf.profileName)
 	var nmea_source event.EventSource
 
-	for _, section := range conf.sections {
-		configOut = fmt.Sprintf("%s\n%s", configOut, section.sectionName)
+	for _, section := range conf.Sections {
+		configOut = fmt.Sprintf("%s\n%s", configOut, section.SectionName)
 
-		if section.sectionName == NmeaSectionName {
-			if source, ok := conf.getPtp4lConfOptionOrEmptyString(section.sectionName, "ts2phc.master"); ok {
+		if section.SectionName == NmeaSectionName {
+			if source, ok := conf.getPtp4lConfOptionOrEmptyString(section.SectionName, "ts2phc.master"); ok {
 				nmea_source = getSource(source)
 			}
 		}
-		if section.sectionName != GlobalSectionName && section.sectionName != NmeaSectionName && section.sectionName != UnicastSectionName {
-			iface := config.Iface{Name: getSectionName(section.sectionName)}
+		if section.SectionName != GlobalSectionName && section.SectionName != NmeaSectionName && section.SectionName != UnicastSectionName {
+			iface := config.Iface{Name: ptp4lconf.SectionName(section.SectionName)}
 			iface.PhcId = network.GetPhcId(iface.Name)
 
-			if source, ok := conf.getPtp4lConfOptionOrEmptyString(section.sectionName, "ts2phc.master"); ok {
+			if source, ok := conf.getPtp4lConfOptionOrEmptyString(section.SectionName, "ts2phc.master"); ok {
 				iface.Source = getSource(source)
 			} else {
-				// if not defined here, use source defined at nmea section
 				iface.Source = nmea_source
 			}
-			if masterOnly, ok := conf.getPtp4lConfOptionOrEmptyString(section.sectionName, "masterOnly"); ok {
+			if masterOnly, ok := conf.getPtp4lConfOptionOrEmptyString(section.SectionName, "masterOnly"); ok {
 				// TODO add error handling
 				iface.IsMaster, _ = strconv.ParseBool(strings.TrimSpace(masterOnly))
 			}
 			ifaces = append(ifaces, iface)
 			alias.AddInterface(iface.PhcId, iface.Name)
 		}
-		for _, option := range section.options {
-			k := option.key
-			v := option.value
-			configOut = fmt.Sprintf("%s\n%s %s", configOut, k, v)
+		for _, option := range section.Options {
+			configOut = fmt.Sprintf("%s\n%s %s", configOut, option.Key, option.Value)
 		}
 	}
 	alias.CalculateAliases()

--- a/pkg/daemon/config.go
+++ b/pkg/daemon/config.go
@@ -310,7 +310,7 @@ func (conf *ProfileConfig) RenderPtp4lConf() (configOut string, ifaces config.IF
 			}
 		}
 		if section.SectionName != ptp4lconf.GlobalSectionName && section.SectionName != ptp4lconf.NmeaSectionName && section.SectionName != ptp4lconf.UnicastSectionName {
-			iface := config.Iface{Name: ptp4lconf.SectionName(section.SectionName)}
+			iface := config.Iface{Name: section.Name()}
 			iface.PhcId = network.GetPhcId(iface.Name)
 
 			if source, ok := conf.getPtp4lConfOptionOrEmptyString(section.SectionName, "ts2phc.master"); ok {

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -899,7 +899,7 @@ func (dn *Daemon) applyNodePtpProfile(runID int, nodeProfile *ptpv1.PtpProfile) 
 		// Parsing ptp4l needs to be done here to get the fallback clock type.
 		// Needs to be done outside the loop as we need to guarantee clockType
 		// set before the ts2phcProcessName case where it is used.
-		err = ptp4lOutput.PopulatePtp4lConf(nodeProfile.Ptp4lConf, nodeProfile.Ptp4lOpts)
+		err = ptp4lOutput.Populate(nodeProfile.Ptp4lConf, nodeProfile.Ptp4lOpts)
 		if err != nil {
 			printNodeProfile(nodeProfile)
 			return err
@@ -986,7 +986,7 @@ func (dn *Daemon) applyNodePtpProfile(runID int, nodeProfile *ptpv1.PtpProfile) 
 		}
 
 		output := &ProfileConfig{}
-		err = output.PopulatePtp4lConf(configInput, nil) // cli args not need as we already have clock type from ptp4l
+		err = output.Populate(configInput, nil) // cli args not needed as we already have clock type from ptp4l
 		if err != nil {
 			printNodeProfile(nodeProfile)
 			return err
@@ -1008,7 +1008,7 @@ func (dn *Daemon) applyNodePtpProfile(runID int, nodeProfile *ptpv1.PtpProfile) 
 		if pProcess != chronydProcessName {
 			output.ExtendGlobalSection(*nodeProfile.Name, messageTag, socketPath, pProcess)
 		} else {
-			output.setPtp4lConfOption("", "bindcmdaddress", ChronydSocketPath, true)
+			output.SetOption("", "bindcmdaddress", ChronydSocketPath, true)
 			output.profileName = *nodeProfile.Name
 		}
 

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -895,7 +895,7 @@ func (dn *Daemon) applyNodePtpProfile(runID int, nodeProfile *ptpv1.PtpProfile) 
 
 	// If unset default to clock type inferred from ptp4l
 	if clockType == event.ClockUnset {
-		ptp4lOutput := &Ptp4lConf{}
+		ptp4lOutput := &ProfileConfig{}
 		// Parsing ptp4l needs to be done here to get the fallback clock type.
 		// Needs to be done outside the loop as we need to guarantee clockType
 		// set before the ts2phcProcessName case where it is used.
@@ -985,7 +985,7 @@ func (dn *Daemon) applyNodePtpProfile(runID int, nodeProfile *ptpv1.PtpProfile) 
 			messageTag = fmt.Sprintf("[chronyd.%d.config]", runID)
 		}
 
-		output := &Ptp4lConf{}
+		output := &ProfileConfig{}
 		err = output.PopulatePtp4lConf(configInput, nil) // cli args not need as we already have clock type from ptp4l
 		if err != nil {
 			printNodeProfile(nodeProfile)

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -904,7 +904,7 @@ func (dn *Daemon) applyNodePtpProfile(runID int, nodeProfile *ptpv1.PtpProfile) 
 			printNodeProfile(nodeProfile)
 			return err
 		}
-		clockType = ptp4lOutput.clock_type
+		clockType = ptp4lOutput.ClockType
 	}
 
 	for _, pProcess := range ptpProcesses {
@@ -1009,7 +1009,7 @@ func (dn *Daemon) applyNodePtpProfile(runID int, nodeProfile *ptpv1.PtpProfile) 
 			output.ExtendGlobalSection(*nodeProfile.Name, messageTag, socketPath, pProcess)
 		} else {
 			output.setPtp4lConfOption("", "bindcmdaddress", ChronydSocketPath, true)
-			output.profile_name = *nodeProfile.Name
+			output.profileName = *nodeProfile.Name
 		}
 
 		//output, messageTag, socketPath, GPSPIPE_SERIALPORT, update_leapfile, os.Getenv("NODE_NAME")
@@ -1115,8 +1115,8 @@ func (dn *Daemon) applyNodePtpProfile(runID int, nodeProfile *ptpv1.PtpProfile) 
 			}
 		} else if pProcess == ts2phcProcessName { //& if the x plugin is enabled
 			if clockType == event.GM {
-				if output.gnss_serial_port == "" {
-					output.gnss_serial_port = GPSPIPE_SERIALPORT
+				if output.gnssSerialPort == "" {
+					output.gnssSerialPort = GPSPIPE_SERIALPORT
 				}
 				// TODO: move this to plugin or call it from hwplugin or leave it here and remove Hardcoded
 				gmInterface := dprocess.ifaces.GetLeadingInterface().Name
@@ -1125,7 +1125,7 @@ func (dn *Daemon) applyNodePtpProfile(runID int, nodeProfile *ptpv1.PtpProfile) 
 					name:        GPSD_PROCESSNAME,
 					execMutex:   sync.Mutex{},
 					cmd:         nil,
-					serialPort:  output.gnss_serial_port,
+					serialPort:  output.gnssSerialPort,
 					exitCh:      make(chan struct{}),
 					gmInterface: gmInterface,
 					stopped:     false,

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -896,15 +896,12 @@ func (dn *Daemon) applyNodePtpProfile(runID int, nodeProfile *ptpv1.PtpProfile) 
 	// If unset default to clock type inferred from ptp4l
 	if clockType == event.ClockUnset {
 		ptp4lOutput := &ProfileConfig{}
-		// Parsing ptp4l needs to be done here to get the fallback clock type.
-		// Needs to be done outside the loop as we need to guarantee clockType
-		// set before the ts2phcProcessName case where it is used.
-		err = ptp4lOutput.Populate(nodeProfile.Ptp4lConf, nodeProfile.Ptp4lOpts)
+		err = ptp4lOutput.Populate(nodeProfile.Ptp4lConf)
 		if err != nil {
 			printNodeProfile(nodeProfile)
 			return err
 		}
-		clockType = ptp4lOutput.ClockType
+		clockType = deriveClockType(ptp4lOutput.PortRoles)
 	}
 
 	for _, pProcess := range ptpProcesses {
@@ -986,7 +983,7 @@ func (dn *Daemon) applyNodePtpProfile(runID int, nodeProfile *ptpv1.PtpProfile) 
 		}
 
 		output := &ProfileConfig{}
-		err = output.Populate(configInput, nil) // cli args not needed as we already have clock type from ptp4l
+		err = output.Populate(configInput)
 		if err != nil {
 			printNodeProfile(nodeProfile)
 			return err

--- a/pkg/daemon/daemon_internal_test.go
+++ b/pkg/daemon/daemon_internal_test.go
@@ -1778,7 +1778,7 @@ func TestPtp4lConf_PopulatePtp4lConf_ClockTypeWithCliArgs(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			conf := &Ptp4lConf{}
+			conf := &ProfileConfig{}
 			err := conf.PopulatePtp4lConf(&tt.config, tt.cliArgs)
 
 			assert.NoError(t, err, "PopulatePtp4lConf should not return error")

--- a/pkg/daemon/daemon_internal_test.go
+++ b/pkg/daemon/daemon_internal_test.go
@@ -1779,9 +1779,9 @@ func TestPtp4lConf_PopulatePtp4lConf_ClockTypeWithCliArgs(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			conf := &ProfileConfig{}
-			err := conf.PopulatePtp4lConf(&tt.config, tt.cliArgs)
+			err := conf.Populate(&tt.config, tt.cliArgs)
 
-			assert.NoError(t, err, "PopulatePtp4lConf should not return error")
+			assert.NoError(t, err, "Populate should not return error")
 			assert.Equal(t, tt.expectedClockType, conf.ClockType,
 				"Clock type mismatch: expected %v, got %v - %s",
 				tt.expectedClockType, conf.ClockType, tt.description)

--- a/pkg/daemon/daemon_internal_test.go
+++ b/pkg/daemon/daemon_internal_test.go
@@ -1782,9 +1782,9 @@ func TestPtp4lConf_PopulatePtp4lConf_ClockTypeWithCliArgs(t *testing.T) {
 			err := conf.PopulatePtp4lConf(&tt.config, tt.cliArgs)
 
 			assert.NoError(t, err, "PopulatePtp4lConf should not return error")
-			assert.Equal(t, tt.expectedClockType, conf.clock_type,
+			assert.Equal(t, tt.expectedClockType, conf.ClockType,
 				"Clock type mismatch: expected %v, got %v - %s",
-				tt.expectedClockType, conf.clock_type, tt.description)
+				tt.expectedClockType, conf.ClockType, tt.description)
 		})
 	}
 }

--- a/pkg/daemon/daemon_internal_test.go
+++ b/pkg/daemon/daemon_internal_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/event"
 	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/hardwareconfig"
 	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/leap"
+	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/ptp4lconf"
 	ptpv1 "github.com/k8snetworkplumbingwg/ptp-operator/api/v1"
 	ptpv2alpha1 "github.com/k8snetworkplumbingwg/ptp-operator/api/v2alpha1"
 	"github.com/stretchr/testify/assert"
@@ -1569,222 +1570,160 @@ func TestTBCDualUpstream_ActiveTRPort_Helper(t *testing.T) {
 	})
 }
 
-// TestPtp4lConf_PopulatePtp4lConf_ClockTypeWithCliArgs tests clock_type detection with cliArgs parameter
-func TestPtp4lConf_PopulatePtp4lConf_ClockTypeWithCliArgs(t *testing.T) {
+// TestPtp4lConf_PopulatePtp4lConf_PortRoleSummary tests port role counting from config
+func TestPtp4lConf_PopulatePtp4lConf_PortRoleSummary(t *testing.T) {
 	tests := []struct {
 		name              string
 		config            string
-		cliArgs           *string
 		expectedClockType event.ClockType
 		description       string
 	}{
 		{
-			name:              "OC with -s flag",
-			config:            "[global]\n",
-			cliArgs:           stringPointer("-s -f /etc/ptp4l.conf"),
-			expectedClockType: event.OC,
-			description:       "CLI args contain -s flag, should result in OC",
-		},
-		{
-			name:              "OC with -s and single interface",
-			config:            "[global]\n[ens1f0]\n",
-			cliArgs:           stringPointer("-s"),
-			expectedClockType: event.OC,
-			description:       "CLI -s with single interface should result in OC",
-		},
-		{
-			name:              "BC with -s and multiple interfaces",
-			config:            "[global]\n[ens1f0]\nmasterOnly 0\n[ens1f1]\nmasterOnly 1",
-			cliArgs:           stringPointer("-s"),
-			expectedClockType: event.BC,
-			description:       "CLI -s with multiple interfaces (one slave) should result in BC",
-		},
-		{
-			name:              "GM with masterOnly interfaces",
-			config:            "[global]\n[ens1f0]\nmasterOnly 1\n[ens1f1]\nmasterOnly 1",
-			cliArgs:           stringPointer("-f /etc/ptp4l.conf"),
-			expectedClockType: event.GM,
-			description:       "masterOnly interfaces should result in GM",
-		},
-		{
 			name:              "OC with slaveOnly config",
 			config:            "[global]\nslaveOnly 1\n",
-			cliArgs:           nil,
 			expectedClockType: event.OC,
-			description:       "slaveOnly in config should result in OC",
+			description:       "slaveOnly in global config should result in OC",
 		},
 		{
 			name:              "GM with masterOnly config",
 			config:            "[global]\n[ens1f0]\nmasterOnly 1\n",
-			cliArgs:           nil,
 			expectedClockType: event.GM,
 			description:       "masterOnly config should result in GM",
 		},
 		{
-			name:              "OC with -s in middle of args",
-			config:            "[global]\n",
-			cliArgs:           stringPointer("-f /etc/ptp4l.conf -s -m"),
-			expectedClockType: event.OC,
-			description:       "CLI -s flag in middle of args should be detected for OC",
-		},
-		{
-			name:              "OC with both -s and slaveOnly",
-			config:            "[global]\nslaveOnly 1\n",
-			cliArgs:           stringPointer("-s"),
-			expectedClockType: event.OC,
-			description:       "Both CLI -s and slaveOnly in config should result in OC",
-		},
-		{
-			name:              "GM with empty cliArgs",
-			config:            "[global]\n[ens1f0]\nmasterOnly 1\n",
-			cliArgs:           stringPointer(""),
+			name:              "GM with all masterOnly interfaces",
+			config:            "[global]\n[ens1f0]\nmasterOnly 1\n[ens1f1]\nmasterOnly 1",
 			expectedClockType: event.GM,
-			description:       "Empty CLI args string with masterOnly should result in GM",
+			description:       "all masterOnly interfaces should result in GM",
 		},
 		{
-			name:              "BC with serverOnly 0",
+			name:              "BC with serverOnly 0 and masterOnly 1",
 			config:            "[global]\n[ens1f0]\nserverOnly 0\n[ens1f1]\nmasterOnly 1\n",
-			cliArgs:           nil,
 			expectedClockType: event.BC,
 			description:       "serverOnly 0 with multiple interfaces should result in BC",
 		},
 		{
 			name:              "OC with clientOnly 1",
 			config:            "[global]\n[ens1f0]\nclientOnly 1\n",
-			cliArgs:           nil,
 			expectedClockType: event.OC,
 			description:       "clientOnly 1 should be detected as OC",
 		},
 		{
 			name:              "BC with mixed masterOnly",
 			config:            "[global]\n[ens1f0]\nmasterOnly 0\n[ens1f1]\nmasterOnly 1\n",
-			cliArgs:           nil,
 			expectedClockType: event.BC,
 			description:       "Multiple interfaces with mixed masterOnly should result in BC",
 		},
 		{
-			name:              "OC with -s and serverOnly 0",
-			config:            "[global]\n[ens1f0]\nserverOnly 0\n",
-			cliArgs:           stringPointer("-s"),
-			expectedClockType: event.OC,
-			description:       "CLI -s with serverOnly 0 and single interface should result in OC",
-		},
-		{
-			name:              "OC with -s and clientOnly 1",
-			config:            "[global]\n[ens1f0]\nclientOnly 1\n",
-			cliArgs:           stringPointer("-s"),
-			expectedClockType: event.OC,
-			description:       "CLI -s with clientOnly 1 should result in OC",
-		},
-		{
 			name:              "GM with no slave configuration",
 			config:            "[global]\n[ens1f0]\n[ens1f1]\n",
-			cliArgs:           stringPointer("-f /etc/ptp4l.conf -m"),
 			expectedClockType: event.GM,
-			description:       "Multiple interfaces with no explicit master/slave settings should result in GM",
-		},
-		{
-			name:              "OC with --slaveOnly 1",
-			config:            "[global]\n",
-			cliArgs:           stringPointer("--slaveOnly 1 -f /etc/ptp4l.conf"),
-			expectedClockType: event.OC,
-			description:       "CLI --slaveOnly 1 should result in OC",
-		},
-		{
-			name:              "OC with --slaveOnly=1",
-			config:            "[global]\n",
-			cliArgs:           stringPointer("--slaveOnly=1 -f /etc/ptp4l.conf"),
-			expectedClockType: event.OC,
-			description:       "CLI --slaveOnly=1 should result in OC",
-		},
-		{
-			name:              "GM with --slaveOnly 0",
-			config:            "[global]\n[ens1f0]\n",
-			cliArgs:           stringPointer("--slaveOnly 0 -f /etc/ptp4l.conf"),
-			expectedClockType: event.GM,
-			description:       "CLI --slaveOnly 0 should result in GM",
-		},
-		{
-			name:              "GM with --slaveOnly=0",
-			config:            "[global]\n[ens1f0]\n",
-			cliArgs:           stringPointer("--slaveOnly=0 -f /etc/ptp4l.conf"),
-			expectedClockType: event.GM,
-			description:       "CLI --slaveOnly=0 should result in GM",
-		},
-		{
-			name:              "OC with --clientOnly 1",
-			config:            "[global]\n",
-			cliArgs:           stringPointer("--clientOnly 1 -f /etc/ptp4l.conf"),
-			expectedClockType: event.OC,
-			description:       "CLI --clientOnly 1 should result in OC",
-		},
-		{
-			name:              "OC with --clientOnly=1",
-			config:            "[global]\n",
-			cliArgs:           stringPointer("--clientOnly=1 -f /etc/ptp4l.conf"),
-			expectedClockType: event.OC,
-			description:       "CLI --clientOnly=1 should result in OC",
-		},
-		{
-			name:              "GM with --clientOnly 0",
-			config:            "[global]\n[ens1f0]\n",
-			cliArgs:           stringPointer("--clientOnly 0 -f /etc/ptp4l.conf"),
-			expectedClockType: event.GM,
-			description:       "CLI --clientOnly 0 should result in GM",
-		},
-		{
-			name:              "GM with --clientOnly=0",
-			config:            "[global]\n[ens1f0]\n",
-			cliArgs:           stringPointer("--clientOnly=0 -f /etc/ptp4l.conf"),
-			expectedClockType: event.GM,
-			description:       "CLI --clientOnly=0 should result in GM",
-		},
-		{
-			name:              "OC with --slaveOnly and multiple spaces",
-			config:            "[global]\n",
-			cliArgs:           stringPointer("--slaveOnly  1 -f /etc/ptp4l.conf"),
-			expectedClockType: event.OC,
-			description:       "CLI --slaveOnly with multiple spaces should result in OC",
-		},
-		{
-			name:              "OC with --clientOnly and multiple spaces",
-			config:            "[global]\n",
-			cliArgs:           stringPointer("--clientOnly   1 -f /etc/ptp4l.conf"),
-			expectedClockType: event.OC,
-			description:       "CLI --clientOnly with multiple spaces should result in OC",
-		},
-		{
-			name:              "OC with -s at end of args",
-			config:            "[global]\n",
-			cliArgs:           stringPointer("-f /etc/ptp4l.conf -s"),
-			expectedClockType: event.OC,
-			description:       "CLI -s at end of args should result in OC",
-		},
-		{
-			name:              "OC with -s at start of args",
-			config:            "[global]\n",
-			cliArgs:           stringPointer("-s -f /etc/ptp4l.conf"),
-			expectedClockType: event.OC,
-			description:       "CLI -s at start of args should result in OC",
-		},
-		{
-			name:              "OC with only -s flag",
-			config:            "[global]\n",
-			cliArgs:           stringPointer("-s"),
-			expectedClockType: event.OC,
-			description:       "CLI with only -s flag should result in OC",
+			description:       "Multiple interfaces with no role settings should result in GM",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			conf := &ProfileConfig{}
-			err := conf.Populate(&tt.config, tt.cliArgs)
-
+			err := conf.Populate(&tt.config)
 			assert.NoError(t, err, "Populate should not return error")
-			assert.Equal(t, tt.expectedClockType, conf.ClockType,
+
+			clockType := deriveClockType(conf.PortRoles)
+			assert.Equal(t, tt.expectedClockType, clockType,
 				"Clock type mismatch: expected %v, got %v - %s",
-				tt.expectedClockType, conf.ClockType, tt.description)
+				tt.expectedClockType, clockType, tt.description)
+		})
+	}
+}
+
+func TestDeriveClockType(t *testing.T) {
+	tests := []struct {
+		name     string
+		roles    ptp4lconf.PortRoleSummary
+		expected event.ClockType
+	}{
+		{
+			name:     "empty summary defaults to GM",
+			roles:    ptp4lconf.PortRoleSummary{},
+			expected: event.GM,
+		},
+		{
+			name:     "nil config (no ports, no slave) is GM",
+			roles:    ptp4lconf.PortRoleSummary{TotalPorts: 0},
+			expected: event.GM,
+		},
+		{
+			name:     "all masterOnly true is GM",
+			roles:    ptp4lconf.PortRoleSummary{MasterOnlyTrue: 2, SlaveOnlyDefault: 2, TotalPorts: 2},
+			expected: event.GM,
+		},
+		{
+			name:     "ports with no role settings is GM",
+			roles:    ptp4lconf.PortRoleSummary{MasterOnlyDefault: 2, SlaveOnlyDefault: 2, TotalPorts: 2},
+			expected: event.GM,
+		},
+		{
+			name:     "single port masterOnly false is OC",
+			roles:    ptp4lconf.PortRoleSummary{MasterOnlyFalse: 1, SlaveOnlyDefault: 1, TotalPorts: 1},
+			expected: event.OC,
+		},
+		{
+			name:     "single port slaveOnly true is OC",
+			roles:    ptp4lconf.PortRoleSummary{SlaveOnlyTrue: 1, MasterOnlyDefault: 1, TotalPorts: 1},
+			expected: event.OC,
+		},
+		{
+			name:     "global slaveOnly true with no ports is OC",
+			roles:    ptp4lconf.PortRoleSummary{SlaveOnlyTrue: 1, TotalPorts: 0},
+			expected: event.OC,
+		},
+		{
+			name:     "two ports one masterOnly false is BC",
+			roles:    ptp4lconf.PortRoleSummary{MasterOnlyTrue: 1, MasterOnlyFalse: 1, SlaveOnlyDefault: 2, TotalPorts: 2},
+			expected: event.BC,
+		},
+		{
+			name:     "two ports one slaveOnly true is BC",
+			roles:    ptp4lconf.PortRoleSummary{SlaveOnlyTrue: 1, SlaveOnlyDefault: 1, MasterOnlyDefault: 2, TotalPorts: 2},
+			expected: event.BC,
+		},
+		{
+			name:     "three ports mixed roles is BC",
+			roles:    ptp4lconf.PortRoleSummary{MasterOnlyTrue: 2, MasterOnlyFalse: 1, SlaveOnlyDefault: 3, TotalPorts: 3},
+			expected: event.BC,
+		},
+		{
+			name:     "masterOnly false without slaveOnly true triggers slave detection",
+			roles:    ptp4lconf.PortRoleSummary{MasterOnlyFalse: 1, TotalPorts: 1},
+			expected: event.OC,
+		},
+		{
+			name:     "slaveOnly true without masterOnly false triggers slave detection",
+			roles:    ptp4lconf.PortRoleSummary{SlaveOnlyTrue: 1, TotalPorts: 1},
+			expected: event.OC,
+		},
+		{
+			name:     "both slaveOnly true and masterOnly false is still OC with single port",
+			roles:    ptp4lconf.PortRoleSummary{SlaveOnlyTrue: 1, MasterOnlyFalse: 1, TotalPorts: 1},
+			expected: event.OC,
+		},
+		{
+			name:     "slaveOnly false alone does not trigger slave detection",
+			roles:    ptp4lconf.PortRoleSummary{SlaveOnlyFalse: 1, MasterOnlyDefault: 1, TotalPorts: 1},
+			expected: event.GM,
+		},
+		{
+			name:     "masterOnly true alone does not trigger slave detection",
+			roles:    ptp4lconf.PortRoleSummary{MasterOnlyTrue: 1, SlaveOnlyDefault: 1, TotalPorts: 1},
+			expected: event.GM,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := deriveClockType(tt.roles)
+			assert.Equal(t, tt.expected, result,
+				"deriveClockType returned %v, expected %v", result, tt.expected)
 		})
 	}
 }

--- a/pkg/daemon/daemon_test.go
+++ b/pkg/daemon/daemon_test.go
@@ -901,7 +901,7 @@ func initPopulateAndRenderPtp4lConfTestCase() []populateAndRenderPtp4lConfTestCa
 func TestDaemon_PopulateAndRenderPtp4lConf(t *testing.T) {
 	testCases := initPopulateAndRenderPtp4lConfTestCase()
 	for _, tc := range testCases {
-		conf := &daemon.Ptp4lConf{}
+		conf := &daemon.ProfileConfig{}
 		conf.PopulatePtp4lConf(&tc.testConf, nil)
 		if tc.iface != "" {
 			conf.AddInterfaceSection(tc.iface)

--- a/pkg/daemon/daemon_test.go
+++ b/pkg/daemon/daemon_test.go
@@ -902,7 +902,7 @@ func TestDaemon_PopulateAndRenderPtp4lConf(t *testing.T) {
 	testCases := initPopulateAndRenderPtp4lConfTestCase()
 	for _, tc := range testCases {
 		conf := &daemon.ProfileConfig{}
-		conf.PopulatePtp4lConf(&tc.testConf, nil)
+		conf.Populate(&tc.testConf, nil)
 		if tc.iface != "" {
 			conf.AddInterfaceSection(tc.iface)
 		}

--- a/pkg/daemon/daemon_test.go
+++ b/pkg/daemon/daemon_test.go
@@ -902,7 +902,7 @@ func TestDaemon_PopulateAndRenderPtp4lConf(t *testing.T) {
 	testCases := initPopulateAndRenderPtp4lConfTestCase()
 	for _, tc := range testCases {
 		conf := &daemon.ProfileConfig{}
-		conf.Populate(&tc.testConf, nil)
+		conf.Populate(&tc.testConf)
 		if tc.iface != "" {
 			conf.AddInterfaceSection(tc.iface)
 		}

--- a/pkg/daemon/metrics.go
+++ b/pkg/daemon/metrics.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/alias"
+	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/ptp4lconf"
 	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/synce"
 
 	"github.com/golang/glog"
@@ -701,7 +702,7 @@ func extractPTP4lEventState(output string) (portId int, role ptpPortRole) {
 	return
 }
 
-func addFlagsForMonitor(process string, configOpts *string, conf *Ptp4lConf, stdoutToSocket bool) {
+func addFlagsForMonitor(process string, configOpts *string, conf *ProfileConfig, stdoutToSocket bool) {
 	switch process {
 	case "ptp4l":
 		// If output doesn't exist we add it for the prometheus exporter
@@ -712,9 +713,9 @@ func addFlagsForMonitor(process string, configOpts *string, conf *Ptp4lConf, std
 			}
 
 			if !strings.Contains(*configOpts, "--summary_interval") {
-				_, exist := conf.getPtp4lConfOptionOrEmptyString(GlobalSectionName, "summary_interval")
+				_, exist := conf.getPtp4lConfOptionOrEmptyString(ptp4lconf.GlobalSectionName, "summary_interval")
 				if !exist {
-					conf.setPtp4lConfOption(GlobalSectionName, "summary_interval", "1", true)
+					conf.setPtp4lConfOption(ptp4lconf.GlobalSectionName, "summary_interval", "1", true)
 				}
 			}
 		}

--- a/pkg/daemon/metrics.go
+++ b/pkg/daemon/metrics.go
@@ -713,9 +713,9 @@ func addFlagsForMonitor(process string, configOpts *string, conf *ProfileConfig,
 			}
 
 			if !strings.Contains(*configOpts, "--summary_interval") {
-				_, exist := conf.getPtp4lConfOptionOrEmptyString(ptp4lconf.GlobalSectionName, "summary_interval")
+				_, exist := conf.GetOption(ptp4lconf.GlobalSectionName, "summary_interval")
 				if !exist {
-					conf.setPtp4lConfOption(ptp4lconf.GlobalSectionName, "summary_interval", "1", true)
+					conf.SetOption(ptp4lconf.GlobalSectionName, "summary_interval", "1", true)
 				}
 			}
 		}

--- a/pkg/hardwareconfig/clockchain_resolution.go
+++ b/pkg/hardwareconfig/clockchain_resolution.go
@@ -74,7 +74,7 @@ func extractUpstreamPortsFromPtpProfile(ptpProfile *ptpv1.PtpProfile) []string {
 			continue
 		}
 		if val, ok := conf.GetOption(name, "masterOnly"); ok && strings.TrimSpace(val) == "0" {
-			upstreamPorts = append(upstreamPorts, ptp4lconf.SectionName(name))
+			upstreamPorts = append(upstreamPorts, section.Name())
 		}
 	}
 

--- a/pkg/hardwareconfig/clockchain_resolution.go
+++ b/pkg/hardwareconfig/clockchain_resolution.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/golang/glog"
 	ptpnetwork "github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/network"
+	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/ptp4lconf"
 	ptpv1 "github.com/k8snetworkplumbingwg/ptp-operator/api/v1"
 	ptpv2alpha1 "github.com/k8snetworkplumbingwg/ptp-operator/api/v2alpha1"
 	"sigs.k8s.io/yaml"
@@ -60,33 +61,20 @@ func extractUpstreamPortsFromPtpProfile(ptpProfile *ptpv1.PtpProfile) []string {
 		return nil
 	}
 
+	conf := &ptp4lconf.Conf{}
+	if err := conf.Populate(ptpProfile.Ptp4lConf, nil); err != nil {
+		glog.Errorf("failed to parse ptp4l config for upstream port extraction: %v", err)
+		return nil
+	}
+
 	var upstreamPorts []string
-	var currentSection string
-
-	for _, line := range strings.Split(*ptpProfile.Ptp4lConf, "\n") {
-		line = strings.TrimSpace(line)
-
-		// Skip empty lines and comments
-		if line == "" || strings.HasPrefix(line, "#") {
+	for _, section := range conf.Sections {
+		name := section.SectionName
+		if name == ptp4lconf.GlobalSectionName || name == ptp4lconf.NmeaSectionName || name == ptp4lconf.UnicastSectionName {
 			continue
 		}
-
-		// Check for section header (e.g., [eno2] or [global])
-		if strings.HasPrefix(line, "[") && strings.HasSuffix(line, "]") {
-			currentSection = strings.Trim(line, "[]")
-			// Skip global and other non-interface sections
-			if currentSection == "global" || currentSection == "nmea" || currentSection == "unicast" {
-				currentSection = ""
-			}
-			continue
-		}
-
-		// Check for masterOnly=0 in current section
-		if currentSection != "" {
-			parts := strings.Fields(line)
-			if len(parts) >= 2 && parts[0] == "masterOnly" && parts[1] == "0" {
-				upstreamPorts = append(upstreamPorts, currentSection)
-			}
+		if val, ok := conf.GetOption(name, "masterOnly"); ok && strings.TrimSpace(val) == "0" {
+			upstreamPorts = append(upstreamPorts, ptp4lconf.SectionName(name))
 		}
 	}
 

--- a/pkg/hardwareconfig/clockchain_resolution.go
+++ b/pkg/hardwareconfig/clockchain_resolution.go
@@ -62,7 +62,7 @@ func extractUpstreamPortsFromPtpProfile(ptpProfile *ptpv1.PtpProfile) []string {
 	}
 
 	conf := &ptp4lconf.Conf{}
-	if err := conf.Populate(ptpProfile.Ptp4lConf, nil); err != nil {
+	if err := conf.Populate(ptpProfile.Ptp4lConf); err != nil {
 		glog.Errorf("failed to parse ptp4l config for upstream port extraction: %v", err)
 		return nil
 	}

--- a/pkg/ptp4lconf/ptp4lconf.go
+++ b/pkg/ptp4lconf/ptp4lconf.go
@@ -151,19 +151,9 @@ func (c *Conf) Populate(config *string, cliArgs *string) error {
 	return nil
 }
 
-// SectionName strips bracket characters from a section name header,
-// returning the bare name (e.g. "[ens1f0]" -> "ens1f0").
-func SectionName(name string) string {
-	name = strings.ReplaceAll(name, "[", "")
-	name = strings.ReplaceAll(name, "]", "")
-	return name
-}
-
-// RenderOptions renders all options in a section as newline-separated "key value" lines.
-func RenderOptions(s Section) string {
-	var out string
-	for _, opt := range s.Options {
-		out += "\n" + opt.Key + " " + opt.Value
-	}
-	return out
+// Name returns the section name without brackets (e.g. "[ens1f0]" -> "ens1f0").
+func (s Section) Name() string {
+	n := strings.ReplaceAll(s.SectionName, "[", "")
+	n = strings.ReplaceAll(n, "]", "")
+	return n
 }

--- a/pkg/ptp4lconf/ptp4lconf.go
+++ b/pkg/ptp4lconf/ptp4lconf.go
@@ -2,10 +2,7 @@ package ptp4lconf
 
 import (
 	"errors"
-	"regexp"
 	"strings"
-
-	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/event"
 )
 
 // Predefined ptp4l config section names.
@@ -14,8 +11,6 @@ const (
 	NmeaSectionName    = "[nmea]"
 	UnicastSectionName = "[unicast_master_table]"
 )
-
-var cliArgsSlaveFlagsRegex = regexp.MustCompile(`--(slaveOnly|clientOnly)(\s+1|=1)(\s|$)`)
 
 // Option is a single key-value pair within a ptp4l config section.
 type Option struct {
@@ -29,10 +24,23 @@ type Section struct {
 	Options     []Option
 }
 
+// PortRoleSummary counts how many interface ports have explicit
+// master/server or slave/client role settings.
+// "Default" means the key was absent for that port.
+type PortRoleSummary struct {
+	MasterOnlyTrue    int // ports with masterOnly=1 or serverOnly=1
+	MasterOnlyFalse   int // ports with masterOnly=0 or serverOnly=0
+	MasterOnlyDefault int // ports with no masterOnly/serverOnly set
+	SlaveOnlyTrue     int // ports with slaveOnly=1 or clientOnly=1
+	SlaveOnlyFalse    int // ports with slaveOnly=0 or clientOnly=0
+	SlaveOnlyDefault  int // ports with no slaveOnly/clientOnly set
+	TotalPorts        int // total interface sections (excludes global, nmea, unicast)
+}
+
 // Conf represents a parsed ptp4l configuration (section-based, space-delimited key-value format).
 type Conf struct {
 	Sections  []Section
-	ClockType event.ClockType
+	PortRoles PortRoleSummary
 }
 
 // GetOption returns the value for a given key in the named section.
@@ -86,64 +94,80 @@ func (c *Conf) SetOption(sectionName, key, value string, overwrite bool) {
 	c.Sections[index] = updatedSection
 }
 
-// Populate parses a ptp4l config string and optional CLI args into sections/options
-// and infers the clock type.
-func (c *Conf) Populate(config *string, cliArgs *string) error {
+// Populate parses a ptp4l config string into sections/options
+// and collects per-port role summary counts.
+func (c *Conf) Populate(config *string) error {
 	var currentSectionName string
 	c.Sections = make([]Section, 0)
-	hasSlaveConfigDefined := false
+	c.PortRoles = PortRoleSummary{}
 
-	if cliArgs != nil {
-		args := *cliArgs
-		for _, arg := range strings.Fields(args) {
-			if arg == "-s" {
-				hasSlaveConfigDefined = true
-				break
-			}
-		}
-		if cliArgsSlaveFlagsRegex.MatchString(args) {
-			hasSlaveConfigDefined = true
-		}
+	if config == nil {
+		return nil
 	}
 
-	ifaceCount := 0
-	if config != nil {
-		for _, line := range strings.Split(*config, "\n") {
-			line = strings.TrimSpace(line)
-			if line == "" || strings.HasPrefix(line, "#") {
-				continue
-			} else if strings.HasPrefix(line, "[") {
-				if !strings.HasSuffix(line, "]") {
-					return errors.New("Section missing closing ']': " + line)
-				}
-				currentSectionName = line
-				if currentSectionName != GlobalSectionName && currentSectionName != NmeaSectionName && currentSectionName != UnicastSectionName {
-					ifaceCount++
-				}
-				c.SetOption(currentSectionName, "", "", false)
-			} else {
-				split := strings.IndexAny(line, " \t")
-				if split > 0 {
-					key := line[:split]
-					value := strings.TrimSpace(line[split:])
-					c.SetOption(currentSectionName, key, value, false)
-					if (key == "masterOnly" && value == "0" && currentSectionName != GlobalSectionName) ||
-						(key == "serverOnly" && value == "0") ||
-						(key == "slaveOnly" && value == "1") ||
-						(key == "clientOnly" && value == "1") {
-						hasSlaveConfigDefined = true
+	type portFlags struct {
+		hasMaster bool
+		hasSlave  bool
+	}
+	portFlagMap := make(map[string]*portFlags)
+
+	for _, line := range strings.Split(*config, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		} else if strings.HasPrefix(line, "[") {
+			if !strings.HasSuffix(line, "]") {
+				return errors.New("Section missing closing ']': " + line)
+			}
+			currentSectionName = line
+			if currentSectionName != GlobalSectionName && currentSectionName != NmeaSectionName && currentSectionName != UnicastSectionName {
+				c.PortRoles.TotalPorts++
+				portFlagMap[currentSectionName] = &portFlags{}
+			}
+			c.SetOption(currentSectionName, "", "", false)
+		} else {
+			split := strings.IndexAny(line, " \t")
+			if split > 0 {
+				key := line[:split]
+				value := strings.TrimSpace(line[split:])
+				c.SetOption(currentSectionName, key, value, false)
+
+				pf, isPort := portFlagMap[currentSectionName]
+				if !isPort {
+					// global-level slaveOnly/clientOnly still counts
+					if currentSectionName == GlobalSectionName {
+						if (key == "slaveOnly" && value == "1") || (key == "clientOnly" && value == "1") {
+							c.PortRoles.SlaveOnlyTrue++
+						}
 					}
+					continue
+				}
+
+				switch {
+				case (key == "masterOnly" || key == "serverOnly") && value == "1":
+					c.PortRoles.MasterOnlyTrue++
+					pf.hasMaster = true
+				case (key == "masterOnly" || key == "serverOnly") && value == "0":
+					c.PortRoles.MasterOnlyFalse++
+					pf.hasMaster = true
+				case (key == "slaveOnly" || key == "clientOnly") && value == "1":
+					c.PortRoles.SlaveOnlyTrue++
+					pf.hasSlave = true
+				case (key == "slaveOnly" || key == "clientOnly") && value == "0":
+					c.PortRoles.SlaveOnlyFalse++
+					pf.hasSlave = true
 				}
 			}
 		}
 	}
 
-	if !hasSlaveConfigDefined {
-		c.ClockType = event.GM
-	} else if ifaceCount > 1 {
-		c.ClockType = event.BC
-	} else {
-		c.ClockType = event.OC
+	for _, pf := range portFlagMap {
+		if !pf.hasMaster {
+			c.PortRoles.MasterOnlyDefault++
+		}
+		if !pf.hasSlave {
+			c.PortRoles.SlaveOnlyDefault++
+		}
 	}
 
 	return nil

--- a/pkg/ptp4lconf/ptp4lconf.go
+++ b/pkg/ptp4lconf/ptp4lconf.go
@@ -1,0 +1,170 @@
+package ptp4lconf
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/event"
+)
+
+// Predefined ptp4l config section names.
+const (
+	GlobalSectionName  = "[global]"
+	NmeaSectionName    = "[nmea]"
+	UnicastSectionName = "[unicast_master_table]"
+)
+
+var cliArgsSlaveFlagsRegex = regexp.MustCompile(`--(slaveOnly|clientOnly)(\s+1|=1)(\s|$)`)
+
+// Option is a single key-value pair within a ptp4l config section.
+type Option struct {
+	Key   string
+	Value string
+}
+
+// Section is a named group of options in a ptp4l INI-style config (e.g. "[global]").
+type Section struct {
+	SectionName string
+	Options     []Option
+}
+
+// Conf represents a parsed ptp4l INI-style configuration
+// that can be queried, mutated, and rendered back to text.
+type Conf struct {
+	Sections  []Section
+	ClockType event.ClockType
+}
+
+// GetOption returns the value for a given key in the named section.
+// The bool indicates whether the key was found.
+func (c *Conf) GetOption(sectionName, key string) (string, bool) {
+	for _, section := range c.Sections {
+		if section.SectionName == sectionName {
+			for _, opt := range section.Options {
+				if opt.Key == key {
+					return opt.Value, true
+				}
+			}
+		}
+	}
+	return "", false
+}
+
+// SetOption inserts or (if overwrite is true) updates an option in the named section.
+// If the section does not exist it is created. If key is empty, only the section is created.
+func (c *Conf) SetOption(sectionName, key, value string, overwrite bool) {
+	var updatedSection Section
+	index := -1
+	for i, section := range c.Sections {
+		if section.SectionName == sectionName {
+			updatedSection = section
+			index = i
+		}
+	}
+	if index < 0 {
+		updatedSection = Section{Options: make([]Option, 0), SectionName: sectionName}
+		index = len(c.Sections)
+		c.Sections = append(c.Sections, updatedSection)
+	}
+
+	if key == "" {
+		return
+	}
+
+	found := false
+	if overwrite {
+		for i := range updatedSection.Options {
+			if updatedSection.Options[i].Key == key {
+				updatedSection.Options[i] = Option{Key: key, Value: value}
+				found = true
+			}
+		}
+	}
+	if !found {
+		updatedSection.Options = append(updatedSection.Options, Option{Key: key, Value: value})
+	}
+	c.Sections[index] = updatedSection
+}
+
+// Populate parses a ptp4l INI-style config string and optional CLI args,
+// populating the Conf struct with sections, options, and inferred clock type.
+func (c *Conf) Populate(config *string, cliArgs *string) error {
+	var currentSectionName string
+	c.Sections = make([]Section, 0)
+	hasSlaveConfigDefined := false
+
+	if cliArgs != nil {
+		args := *cliArgs
+		for _, arg := range strings.Fields(args) {
+			if arg == "-s" {
+				hasSlaveConfigDefined = true
+				break
+			}
+		}
+		if cliArgsSlaveFlagsRegex.MatchString(args) {
+			hasSlaveConfigDefined = true
+		}
+	}
+
+	ifaceCount := 0
+	if config != nil {
+		for _, line := range strings.Split(*config, "\n") {
+			line = strings.TrimSpace(line)
+			if line == "" || strings.HasPrefix(line, "#") {
+				continue
+			} else if strings.HasPrefix(line, "[") {
+				currentLine := strings.Split(line, "]")
+				if len(currentLine) < 2 {
+					return errors.New("Section missing closing ']': " + line)
+				}
+				currentSectionName = fmt.Sprintf("%s]", currentLine[0])
+				if currentSectionName != GlobalSectionName && currentSectionName != NmeaSectionName && currentSectionName != UnicastSectionName {
+					ifaceCount++
+				}
+				c.SetOption(currentSectionName, "", "", false)
+			} else {
+				split := strings.IndexByte(line, ' ')
+				if split > 0 {
+					key := line[:split]
+					value := strings.TrimSpace(line[split:])
+					c.SetOption(currentSectionName, key, value, false)
+					if (key == "masterOnly" && value == "0" && currentSectionName != GlobalSectionName) ||
+						(key == "serverOnly" && value == "0") ||
+						(key == "slaveOnly" && value == "1") ||
+						(key == "clientOnly" && value == "1") {
+						hasSlaveConfigDefined = true
+					}
+				}
+			}
+		}
+	}
+
+	if !hasSlaveConfigDefined {
+		c.ClockType = event.GM
+	} else if ifaceCount > 1 {
+		c.ClockType = event.BC
+	} else {
+		c.ClockType = event.OC
+	}
+
+	return nil
+}
+
+// SectionName strips bracket characters from a section name header,
+// returning the bare name (e.g. "[ens1f0]" -> "ens1f0").
+func SectionName(name string) string {
+	name = strings.ReplaceAll(name, "[", "")
+	name = strings.ReplaceAll(name, "]", "")
+	return name
+}
+
+// RenderOptions renders all options in a section as newline-separated "key value" lines.
+func RenderOptions(s Section) string {
+	var out string
+	for _, opt := range s.Options {
+		out = fmt.Sprintf("%s\n%s %s", out, opt.Key, opt.Value)
+	}
+	return out
+}

--- a/pkg/ptp4lconf/ptp4lconf.go
+++ b/pkg/ptp4lconf/ptp4lconf.go
@@ -30,8 +30,7 @@ type Section struct {
 	Options     []Option
 }
 
-// Conf represents a parsed ptp4l INI-style configuration
-// that can be queried, mutated, and rendered back to text.
+// Conf represents a parsed ptp4l configuration (section-based, space-delimited key-value format).
 type Conf struct {
 	Sections  []Section
 	ClockType event.ClockType
@@ -88,8 +87,8 @@ func (c *Conf) SetOption(sectionName, key, value string, overwrite bool) {
 	c.Sections[index] = updatedSection
 }
 
-// Populate parses a ptp4l INI-style config string and optional CLI args,
-// populating the Conf struct with sections, options, and inferred clock type.
+// Populate parses a ptp4l config string and optional CLI args into sections/options
+// and infers the clock type.
 func (c *Conf) Populate(config *string, cliArgs *string) error {
 	var currentSectionName string
 	c.Sections = make([]Section, 0)
@@ -125,7 +124,7 @@ func (c *Conf) Populate(config *string, cliArgs *string) error {
 				}
 				c.SetOption(currentSectionName, "", "", false)
 			} else {
-				split := strings.IndexByte(line, ' ')
+				split := strings.IndexAny(line, " \t")
 				if split > 0 {
 					key := line[:split]
 					value := strings.TrimSpace(line[split:])
@@ -164,7 +163,7 @@ func SectionName(name string) string {
 func RenderOptions(s Section) string {
 	var out string
 	for _, opt := range s.Options {
-		out = fmt.Sprintf("%s\n%s %s", out, opt.Key, opt.Value)
+		out += "\n" + opt.Key + " " + opt.Value
 	}
 	return out
 }

--- a/pkg/ptp4lconf/ptp4lconf.go
+++ b/pkg/ptp4lconf/ptp4lconf.go
@@ -2,7 +2,6 @@ package ptp4lconf
 
 import (
 	"errors"
-	"fmt"
 	"regexp"
 	"strings"
 
@@ -114,11 +113,10 @@ func (c *Conf) Populate(config *string, cliArgs *string) error {
 			if line == "" || strings.HasPrefix(line, "#") {
 				continue
 			} else if strings.HasPrefix(line, "[") {
-				currentLine := strings.Split(line, "]")
-				if len(currentLine) < 2 {
+				if !strings.HasSuffix(line, "]") {
 					return errors.New("Section missing closing ']': " + line)
 				}
-				currentSectionName = fmt.Sprintf("%s]", currentLine[0])
+				currentSectionName = line
 				if currentSectionName != GlobalSectionName && currentSectionName != NmeaSectionName && currentSectionName != UnicastSectionName {
 					ifaceCount++
 				}

--- a/pkg/ptp4lconf/ptp4lconf_test.go
+++ b/pkg/ptp4lconf/ptp4lconf_test.go
@@ -203,8 +203,8 @@ func TestConf_Populate_SkipsComments(t *testing.T) {
 	assert.Equal(t, "24", val)
 }
 
-func TestSectionName(t *testing.T) {
-	assert.Equal(t, "ens1f0", SectionName("[ens1f0]"))
-	assert.Equal(t, "global", SectionName("[global]"))
-	assert.Equal(t, "", SectionName("[]"))
+func TestSection_Name(t *testing.T) {
+	assert.Equal(t, "ens1f0", Section{SectionName: "[ens1f0]"}.Name())
+	assert.Equal(t, "global", Section{SectionName: "[global]"}.Name())
+	assert.Equal(t, "", Section{SectionName: "[]"}.Name())
 }

--- a/pkg/ptp4lconf/ptp4lconf_test.go
+++ b/pkg/ptp4lconf/ptp4lconf_test.go
@@ -1,0 +1,210 @@
+package ptp4lconf
+
+import (
+	"testing"
+
+	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/event"
+	"github.com/stretchr/testify/assert"
+)
+
+func stringPtr(s string) *string { return &s }
+
+func TestConf_Populate_ClockType(t *testing.T) {
+	tests := []struct {
+		name              string
+		config            string
+		cliArgs           *string
+		expectedClockType event.ClockType
+	}{
+		{
+			name:              "OC with -s flag",
+			config:            "[global]\n",
+			cliArgs:           stringPtr("-s -f /etc/ptp4l.conf"),
+			expectedClockType: event.OC,
+		},
+		{
+			name:              "OC with -s and single interface",
+			config:            "[global]\n[ens1f0]\n",
+			cliArgs:           stringPtr("-s"),
+			expectedClockType: event.OC,
+		},
+		{
+			name:              "BC with -s and multiple interfaces",
+			config:            "[global]\n[ens1f0]\nmasterOnly 0\n[ens1f1]\nmasterOnly 1",
+			cliArgs:           stringPtr("-s"),
+			expectedClockType: event.BC,
+		},
+		{
+			name:              "GM with masterOnly interfaces",
+			config:            "[global]\n[ens1f0]\nmasterOnly 1\n[ens1f1]\nmasterOnly 1",
+			cliArgs:           stringPtr("-f /etc/ptp4l.conf"),
+			expectedClockType: event.GM,
+		},
+		{
+			name:              "OC with slaveOnly config",
+			config:            "[global]\nslaveOnly 1\n",
+			cliArgs:           nil,
+			expectedClockType: event.OC,
+		},
+		{
+			name:              "GM with masterOnly config",
+			config:            "[global]\n[ens1f0]\nmasterOnly 1\n",
+			cliArgs:           nil,
+			expectedClockType: event.GM,
+		},
+		{
+			name:              "BC with serverOnly 0",
+			config:            "[global]\n[ens1f0]\nserverOnly 0\n[ens1f1]\nmasterOnly 1\n",
+			cliArgs:           nil,
+			expectedClockType: event.BC,
+		},
+		{
+			name:              "OC with clientOnly 1",
+			config:            "[global]\n[ens1f0]\nclientOnly 1\n",
+			cliArgs:           nil,
+			expectedClockType: event.OC,
+		},
+		{
+			name:              "OC with --slaveOnly 1",
+			config:            "[global]\n",
+			cliArgs:           stringPtr("--slaveOnly 1 -f /etc/ptp4l.conf"),
+			expectedClockType: event.OC,
+		},
+		{
+			name:              "OC with --slaveOnly=1",
+			config:            "[global]\n",
+			cliArgs:           stringPtr("--slaveOnly=1 -f /etc/ptp4l.conf"),
+			expectedClockType: event.OC,
+		},
+		{
+			name:              "GM with --slaveOnly 0",
+			config:            "[global]\n[ens1f0]\n",
+			cliArgs:           stringPtr("--slaveOnly 0 -f /etc/ptp4l.conf"),
+			expectedClockType: event.GM,
+		},
+		{
+			name:              "OC with --clientOnly 1",
+			config:            "[global]\n",
+			cliArgs:           stringPtr("--clientOnly 1 -f /etc/ptp4l.conf"),
+			expectedClockType: event.OC,
+		},
+		{
+			name:              "OC with --clientOnly=1",
+			config:            "[global]\n",
+			cliArgs:           stringPtr("--clientOnly=1 -f /etc/ptp4l.conf"),
+			expectedClockType: event.OC,
+		},
+		{
+			name:              "GM with --clientOnly 0",
+			config:            "[global]\n[ens1f0]\n",
+			cliArgs:           stringPtr("--clientOnly 0 -f /etc/ptp4l.conf"),
+			expectedClockType: event.GM,
+		},
+		{
+			name:              "GM with no slave configuration",
+			config:            "[global]\n[ens1f0]\n[ens1f1]\n",
+			cliArgs:           stringPtr("-f /etc/ptp4l.conf -m"),
+			expectedClockType: event.GM,
+		},
+		{
+			name:              "OC with -s at end of args",
+			config:            "[global]\n",
+			cliArgs:           stringPtr("-f /etc/ptp4l.conf -s"),
+			expectedClockType: event.OC,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			conf := &Conf{}
+			err := conf.Populate(&tt.config, tt.cliArgs)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expectedClockType, conf.ClockType,
+				"Clock type mismatch: expected %v, got %v", tt.expectedClockType, conf.ClockType)
+		})
+	}
+}
+
+func TestConf_Populate_Parsing(t *testing.T) {
+	config := "[global]\ndomainNumber 24\n[ens1f0]\nmasterOnly 1\n[ens1f1]\nmasterOnly 0"
+	conf := &Conf{}
+	err := conf.Populate(&config, nil)
+	assert.NoError(t, err)
+	assert.Len(t, conf.Sections, 3)
+
+	val, ok := conf.GetOption("[global]", "domainNumber")
+	assert.True(t, ok)
+	assert.Equal(t, "24", val)
+
+	val, ok = conf.GetOption("[ens1f0]", "masterOnly")
+	assert.True(t, ok)
+	assert.Equal(t, "1", val)
+
+	val, ok = conf.GetOption("[ens1f1]", "masterOnly")
+	assert.True(t, ok)
+	assert.Equal(t, "0", val)
+}
+
+func TestConf_SetOption(t *testing.T) {
+	conf := &Conf{}
+	conf.Sections = make([]Section, 0)
+
+	conf.SetOption("[global]", "domainNumber", "24", false)
+	val, ok := conf.GetOption("[global]", "domainNumber")
+	assert.True(t, ok)
+	assert.Equal(t, "24", val)
+
+	conf.SetOption("[global]", "domainNumber", "48", true)
+	val, ok = conf.GetOption("[global]", "domainNumber")
+	assert.True(t, ok)
+	assert.Equal(t, "48", val)
+
+	conf.SetOption("[global]", "domainNumber", "99", false)
+	val, ok = conf.GetOption("[global]", "domainNumber")
+	assert.True(t, ok)
+	assert.Equal(t, "48", val, "without overwrite, first match should be returned")
+}
+
+func TestConf_GetOption_NotFound(t *testing.T) {
+	conf := &Conf{}
+	conf.Sections = make([]Section, 0)
+	conf.SetOption("[global]", "domainNumber", "24", false)
+
+	_, ok := conf.GetOption("[global]", "nonexistent")
+	assert.False(t, ok)
+
+	_, ok = conf.GetOption("[nonexistent]", "domainNumber")
+	assert.False(t, ok)
+}
+
+func TestConf_Populate_Error(t *testing.T) {
+	badConfig := "[global\ndomainNumber 24"
+	conf := &Conf{}
+	err := conf.Populate(&badConfig, nil)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "Section missing closing ']'")
+}
+
+func TestConf_Populate_NilConfig(t *testing.T) {
+	conf := &Conf{}
+	err := conf.Populate(nil, nil)
+	assert.NoError(t, err)
+	assert.Equal(t, event.GM, conf.ClockType)
+}
+
+func TestConf_Populate_SkipsComments(t *testing.T) {
+	config := "[global]\n# this is a comment\ndomainNumber 24"
+	conf := &Conf{}
+	err := conf.Populate(&config, nil)
+	assert.NoError(t, err)
+
+	val, ok := conf.GetOption("[global]", "domainNumber")
+	assert.True(t, ok)
+	assert.Equal(t, "24", val)
+}
+
+func TestSectionName(t *testing.T) {
+	assert.Equal(t, "ens1f0", SectionName("[ens1f0]"))
+	assert.Equal(t, "global", SectionName("[global]"))
+	assert.Equal(t, "", SectionName("[]"))
+}

--- a/pkg/ptp4lconf/ptp4lconf_test.go
+++ b/pkg/ptp4lconf/ptp4lconf_test.go
@@ -3,123 +3,117 @@ package ptp4lconf
 import (
 	"testing"
 
-	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/event"
 	"github.com/stretchr/testify/assert"
-	"k8s.io/utils/ptr"
 )
 
-func TestConf_Populate_ClockType(t *testing.T) {
+func TestConf_Populate_PortRoleSummary(t *testing.T) {
 	tests := []struct {
-		name              string
-		config            string
-		cliArgs           *string
-		expectedClockType event.ClockType
+		name          string
+		config        string
+		expectedRoles PortRoleSummary
 	}{
 		{
-			name:              "OC with -s flag",
-			config:            "[global]\n",
-			cliArgs:           ptr.To("-s -f /etc/ptp4l.conf"),
-			expectedClockType: event.OC,
+			name:   "global slaveOnly 1",
+			config: "[global]\nslaveOnly 1\n",
+			expectedRoles: PortRoleSummary{
+				SlaveOnlyTrue: 1,
+			},
 		},
 		{
-			name:              "OC with -s and single interface",
-			config:            "[global]\n[ens1f0]\n",
-			cliArgs:           ptr.To("-s"),
-			expectedClockType: event.OC,
+			name:   "global clientOnly 1",
+			config: "[global]\nclientOnly 1\n",
+			expectedRoles: PortRoleSummary{
+				SlaveOnlyTrue: 1,
+			},
 		},
 		{
-			name:              "BC with -s and multiple interfaces",
-			config:            "[global]\n[ens1f0]\nmasterOnly 0\n[ens1f1]\nmasterOnly 1",
-			cliArgs:           ptr.To("-s"),
-			expectedClockType: event.BC,
+			name:   "single port with masterOnly 1",
+			config: "[global]\n[ens1f0]\nmasterOnly 1\n",
+			expectedRoles: PortRoleSummary{
+				MasterOnlyTrue:   1,
+				SlaveOnlyDefault: 1,
+				TotalPorts:       1,
+			},
 		},
 		{
-			name:              "GM with masterOnly interfaces",
-			config:            "[global]\n[ens1f0]\nmasterOnly 1\n[ens1f1]\nmasterOnly 1",
-			cliArgs:           ptr.To("-f /etc/ptp4l.conf"),
-			expectedClockType: event.GM,
+			name:   "single port with masterOnly 0",
+			config: "[global]\n[ens1f0]\nmasterOnly 0\n",
+			expectedRoles: PortRoleSummary{
+				MasterOnlyFalse:  1,
+				SlaveOnlyDefault: 1,
+				TotalPorts:       1,
+			},
 		},
 		{
-			name:              "OC with slaveOnly config",
-			config:            "[global]\nslaveOnly 1\n",
-			cliArgs:           nil,
-			expectedClockType: event.OC,
+			name:   "single port with clientOnly 1",
+			config: "[global]\n[ens1f0]\nclientOnly 1\n",
+			expectedRoles: PortRoleSummary{
+				SlaveOnlyTrue:     1,
+				MasterOnlyDefault: 1,
+				TotalPorts:        1,
+			},
 		},
 		{
-			name:              "GM with masterOnly config",
-			config:            "[global]\n[ens1f0]\nmasterOnly 1\n",
-			cliArgs:           nil,
-			expectedClockType: event.GM,
+			name:   "two ports all masterOnly 1",
+			config: "[global]\n[ens1f0]\nmasterOnly 1\n[ens1f1]\nmasterOnly 1",
+			expectedRoles: PortRoleSummary{
+				MasterOnlyTrue:   2,
+				SlaveOnlyDefault: 2,
+				TotalPorts:       2,
+			},
 		},
 		{
-			name:              "BC with serverOnly 0",
-			config:            "[global]\n[ens1f0]\nserverOnly 0\n[ens1f1]\nmasterOnly 1\n",
-			cliArgs:           nil,
-			expectedClockType: event.BC,
+			name:   "two ports mixed masterOnly",
+			config: "[global]\n[ens1f0]\nmasterOnly 0\n[ens1f1]\nmasterOnly 1",
+			expectedRoles: PortRoleSummary{
+				MasterOnlyTrue:   1,
+				MasterOnlyFalse:  1,
+				SlaveOnlyDefault: 2,
+				TotalPorts:       2,
+			},
 		},
 		{
-			name:              "OC with clientOnly 1",
-			config:            "[global]\n[ens1f0]\nclientOnly 1\n",
-			cliArgs:           nil,
-			expectedClockType: event.OC,
+			name:   "serverOnly 0 and masterOnly 1",
+			config: "[global]\n[ens1f0]\nserverOnly 0\n[ens1f1]\nmasterOnly 1\n",
+			expectedRoles: PortRoleSummary{
+				MasterOnlyTrue:   1,
+				MasterOnlyFalse:  1,
+				SlaveOnlyDefault: 2,
+				TotalPorts:       2,
+			},
 		},
 		{
-			name:              "OC with --slaveOnly 1",
-			config:            "[global]\n",
-			cliArgs:           ptr.To("--slaveOnly 1 -f /etc/ptp4l.conf"),
-			expectedClockType: event.OC,
+			name:   "two ports no role settings",
+			config: "[global]\n[ens1f0]\n[ens1f1]\n",
+			expectedRoles: PortRoleSummary{
+				MasterOnlyDefault: 2,
+				SlaveOnlyDefault:  2,
+				TotalPorts:        2,
+			},
 		},
 		{
-			name:              "OC with --slaveOnly=1",
-			config:            "[global]\n",
-			cliArgs:           ptr.To("--slaveOnly=1 -f /etc/ptp4l.conf"),
-			expectedClockType: event.OC,
+			name:          "no ports",
+			config:        "[global]\ndomainNumber 24\n",
+			expectedRoles: PortRoleSummary{},
 		},
 		{
-			name:              "GM with --slaveOnly 0",
-			config:            "[global]\n[ens1f0]\n",
-			cliArgs:           ptr.To("--slaveOnly 0 -f /etc/ptp4l.conf"),
-			expectedClockType: event.GM,
-		},
-		{
-			name:              "OC with --clientOnly 1",
-			config:            "[global]\n",
-			cliArgs:           ptr.To("--clientOnly 1 -f /etc/ptp4l.conf"),
-			expectedClockType: event.OC,
-		},
-		{
-			name:              "OC with --clientOnly=1",
-			config:            "[global]\n",
-			cliArgs:           ptr.To("--clientOnly=1 -f /etc/ptp4l.conf"),
-			expectedClockType: event.OC,
-		},
-		{
-			name:              "GM with --clientOnly 0",
-			config:            "[global]\n[ens1f0]\n",
-			cliArgs:           ptr.To("--clientOnly 0 -f /etc/ptp4l.conf"),
-			expectedClockType: event.GM,
-		},
-		{
-			name:              "GM with no slave configuration",
-			config:            "[global]\n[ens1f0]\n[ens1f1]\n",
-			cliArgs:           ptr.To("-f /etc/ptp4l.conf -m"),
-			expectedClockType: event.GM,
-		},
-		{
-			name:              "OC with -s at end of args",
-			config:            "[global]\n",
-			cliArgs:           ptr.To("-f /etc/ptp4l.conf -s"),
-			expectedClockType: event.OC,
+			name:   "port with slaveOnly 0",
+			config: "[global]\n[ens1f0]\nslaveOnly 0\n",
+			expectedRoles: PortRoleSummary{
+				SlaveOnlyFalse:    1,
+				MasterOnlyDefault: 1,
+				TotalPorts:        1,
+			},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			conf := &Conf{}
-			err := conf.Populate(&tt.config, tt.cliArgs)
+			err := conf.Populate(&tt.config)
 			assert.NoError(t, err)
-			assert.Equal(t, tt.expectedClockType, conf.ClockType,
-				"Clock type mismatch: expected %v, got %v", tt.expectedClockType, conf.ClockType)
+			assert.Equal(t, tt.expectedRoles, conf.PortRoles,
+				"PortRoleSummary mismatch")
 		})
 	}
 }
@@ -127,7 +121,7 @@ func TestConf_Populate_ClockType(t *testing.T) {
 func TestConf_Populate_Parsing(t *testing.T) {
 	config := "[global]\ndomainNumber 24\n[ens1f0]\nmasterOnly 1\n[ens1f1]\nmasterOnly 0"
 	conf := &Conf{}
-	err := conf.Populate(&config, nil)
+	err := conf.Populate(&config)
 	assert.NoError(t, err)
 	assert.Len(t, conf.Sections, 3)
 
@@ -179,22 +173,22 @@ func TestConf_GetOption_NotFound(t *testing.T) {
 func TestConf_Populate_Error(t *testing.T) {
 	badConfig := "[global\ndomainNumber 24"
 	conf := &Conf{}
-	err := conf.Populate(&badConfig, nil)
+	err := conf.Populate(&badConfig)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "Section missing closing ']'")
 }
 
 func TestConf_Populate_NilConfig(t *testing.T) {
 	conf := &Conf{}
-	err := conf.Populate(nil, nil)
+	err := conf.Populate(nil)
 	assert.NoError(t, err)
-	assert.Equal(t, event.GM, conf.ClockType)
+	assert.Equal(t, PortRoleSummary{}, conf.PortRoles)
 }
 
 func TestConf_Populate_SkipsComments(t *testing.T) {
 	config := "[global]\n# this is a comment\ndomainNumber 24"
 	conf := &Conf{}
-	err := conf.Populate(&config, nil)
+	err := conf.Populate(&config)
 	assert.NoError(t, err)
 
 	val, ok := conf.GetOption("[global]", "domainNumber")

--- a/pkg/ptp4lconf/ptp4lconf_test.go
+++ b/pkg/ptp4lconf/ptp4lconf_test.go
@@ -5,9 +5,8 @@ import (
 
 	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/event"
 	"github.com/stretchr/testify/assert"
+	"k8s.io/utils/ptr"
 )
-
-func stringPtr(s string) *string { return &s }
 
 func TestConf_Populate_ClockType(t *testing.T) {
 	tests := []struct {
@@ -19,25 +18,25 @@ func TestConf_Populate_ClockType(t *testing.T) {
 		{
 			name:              "OC with -s flag",
 			config:            "[global]\n",
-			cliArgs:           stringPtr("-s -f /etc/ptp4l.conf"),
+			cliArgs:           ptr.To("-s -f /etc/ptp4l.conf"),
 			expectedClockType: event.OC,
 		},
 		{
 			name:              "OC with -s and single interface",
 			config:            "[global]\n[ens1f0]\n",
-			cliArgs:           stringPtr("-s"),
+			cliArgs:           ptr.To("-s"),
 			expectedClockType: event.OC,
 		},
 		{
 			name:              "BC with -s and multiple interfaces",
 			config:            "[global]\n[ens1f0]\nmasterOnly 0\n[ens1f1]\nmasterOnly 1",
-			cliArgs:           stringPtr("-s"),
+			cliArgs:           ptr.To("-s"),
 			expectedClockType: event.BC,
 		},
 		{
 			name:              "GM with masterOnly interfaces",
 			config:            "[global]\n[ens1f0]\nmasterOnly 1\n[ens1f1]\nmasterOnly 1",
-			cliArgs:           stringPtr("-f /etc/ptp4l.conf"),
+			cliArgs:           ptr.To("-f /etc/ptp4l.conf"),
 			expectedClockType: event.GM,
 		},
 		{
@@ -67,49 +66,49 @@ func TestConf_Populate_ClockType(t *testing.T) {
 		{
 			name:              "OC with --slaveOnly 1",
 			config:            "[global]\n",
-			cliArgs:           stringPtr("--slaveOnly 1 -f /etc/ptp4l.conf"),
+			cliArgs:           ptr.To("--slaveOnly 1 -f /etc/ptp4l.conf"),
 			expectedClockType: event.OC,
 		},
 		{
 			name:              "OC with --slaveOnly=1",
 			config:            "[global]\n",
-			cliArgs:           stringPtr("--slaveOnly=1 -f /etc/ptp4l.conf"),
+			cliArgs:           ptr.To("--slaveOnly=1 -f /etc/ptp4l.conf"),
 			expectedClockType: event.OC,
 		},
 		{
 			name:              "GM with --slaveOnly 0",
 			config:            "[global]\n[ens1f0]\n",
-			cliArgs:           stringPtr("--slaveOnly 0 -f /etc/ptp4l.conf"),
+			cliArgs:           ptr.To("--slaveOnly 0 -f /etc/ptp4l.conf"),
 			expectedClockType: event.GM,
 		},
 		{
 			name:              "OC with --clientOnly 1",
 			config:            "[global]\n",
-			cliArgs:           stringPtr("--clientOnly 1 -f /etc/ptp4l.conf"),
+			cliArgs:           ptr.To("--clientOnly 1 -f /etc/ptp4l.conf"),
 			expectedClockType: event.OC,
 		},
 		{
 			name:              "OC with --clientOnly=1",
 			config:            "[global]\n",
-			cliArgs:           stringPtr("--clientOnly=1 -f /etc/ptp4l.conf"),
+			cliArgs:           ptr.To("--clientOnly=1 -f /etc/ptp4l.conf"),
 			expectedClockType: event.OC,
 		},
 		{
 			name:              "GM with --clientOnly 0",
 			config:            "[global]\n[ens1f0]\n",
-			cliArgs:           stringPtr("--clientOnly 0 -f /etc/ptp4l.conf"),
+			cliArgs:           ptr.To("--clientOnly 0 -f /etc/ptp4l.conf"),
 			expectedClockType: event.GM,
 		},
 		{
 			name:              "GM with no slave configuration",
 			config:            "[global]\n[ens1f0]\n[ens1f1]\n",
-			cliArgs:           stringPtr("-f /etc/ptp4l.conf -m"),
+			cliArgs:           ptr.To("-f /etc/ptp4l.conf -m"),
 			expectedClockType: event.GM,
 		},
 		{
 			name:              "OC with -s at end of args",
 			config:            "[global]\n",
-			cliArgs:           stringPtr("-f /etc/ptp4l.conf -s"),
+			cliArgs:           ptr.To("-f /etc/ptp4l.conf -s"),
 			expectedClockType: event.OC,
 		},
 	}


### PR DESCRIPTION
## Extract ptp4l config parsing into shared `pkg/ptp4lconf` package

- Extract ptp4l config parsing (types, `Populate`, `GetOption`, `SetOption`, clock-type inference) from `pkg/daemon/config.go` into a new shared `pkg/ptp4lconf` package. This eliminates the duplicated ad-hoc parser in `pkg/hardwareconfig/clockchain_resolution.go` and breaks the layering constraint that prevented `hardwareconfig` from reusing daemon's parser due to an import cycle. 
- Decouple clock type inference from ptp4l config parsing

**Motivation:** ptp4l config parsing was implemented independently in three places (daemon, hardwareconfig, and ptp-operator webhook) because the import graph `daemon -> hardwareconfig` prevented sharing. Extracting it to a leaf package lets both consume the same parser, reducing maintenance burden and behavioral inconsistency.
Addressing [CNF-20999](https://redhat.atlassian.net/browse/CNF-20999)


****_Assisted by Cursor_.****
