### PR TITLE
OCPBUGS-83706: Add E825 T-BC input pin configuration

### DIFF
--- a/addons/intel/e825.go
+++ b/addons/intel/e825.go
@@ -40,6 +40,9 @@ var bcDpllPeriods = frqSet{
 	"2 0 0 0 1000000",
 }
 
+// bcDpllInputPins lists the DPLL input pin package labels to enable for T-BC
+var bcDpllInputPins = []string{"REF0P", "REF0N"}
+
 // E825Opts is the options structure for e825 plugin
 type E825Opts struct {
 	PluginOpts
@@ -50,7 +53,8 @@ type E825Opts struct {
 // E825PluginData is the data structure for e825 plugin
 type E825PluginData struct {
 	PluginData
-	dpllPins []*dpll_netlink.PinInfo
+	dpllPins    []*dpll_netlink.PinInfo
+	dpllDevices []*dpll_netlink.DoDeviceGetReply
 }
 
 func tbcConfigured(nodeProfile *ptpv1.PtpProfile) bool {
@@ -156,13 +160,16 @@ func OnPTPConfigChangeE825(data *interface{}, nodeProfile *ptpv1.PtpProfile) err
 				if err != nil {
 					glog.Errorf("Could not apply BC pin reset to %s: %s", device, err)
 				}
+				if inputPinErr := pluginData.setupDpllInputPins(); inputPinErr != nil {
+					glog.Errorf("Could not enable DPLL input pins for T-BC: %s", inputPinErr)
+				}
 			}
 		}
 	}
 	return nil
 }
 
-// populateDpllPins creates a list of all known DPLL pins
+// populateDpllPins creates a list of all known DPLL pins and caches DPLL devices
 func (d *E825PluginData) populateDpllPins() error {
 	conn, err := dpll_netlink.Dial(nil)
 	if err != nil {
@@ -172,6 +179,10 @@ func (d *E825PluginData) populateDpllPins() error {
 	d.dpllPins, err = conn.DumpPinGet()
 	if err != nil {
 		return fmt.Errorf("failed to dump DPLL pins: %w", err)
+	}
+	d.dpllDevices, err = getAllDpllDevices()
+	if err != nil {
+		return fmt.Errorf("failed to dump DPLL devices: %w", err)
 	}
 	return nil
 }
@@ -193,6 +204,30 @@ func pinCmdSetState(pin *dpll_netlink.PinInfo, connectable bool) dpll_netlink.Pi
 		})
 	}
 	return command
+}
+
+// pinCmdSetStatePPS constructs a command to set the PPS parent device state only,
+// resolving the PPS parent dynamically by matching device type and ClockID.
+func pinCmdSetStatePPS(pin *dpll_netlink.PinInfo, state uint32, devices []*dpll_netlink.DoDeviceGetReply) (dpll_netlink.PinParentDeviceCtl, bool) {
+	for _, p := range pin.ParentDevice {
+		if p.Direction != dpll_netlink.PinDirectionInput {
+			continue
+		}
+		for _, dev := range devices {
+			if dev.ID == p.ParentID && dev.ClockID == pin.ClockID && dpll_netlink.GetDpllType(dev.Type) == "pps" {
+				return dpll_netlink.PinParentDeviceCtl{
+					ID: pin.ID,
+					PinParentCtl: []dpll_netlink.PinControl{
+						{
+							PinParentID: p.ParentID,
+							State:       &state,
+						},
+					},
+				}, true
+			}
+		}
+	}
+	return dpll_netlink.PinParentDeviceCtl{}, false
 }
 
 // setupGnss configures the GNSS-to-DPLL binding
@@ -223,6 +258,48 @@ func (d *E825PluginData) setupGnss(gnss GnssOptions) error {
 		return errors.New("no GNSS pins found")
 	}
 	glog.Infof("Will %s %d GNSS pins: %v", action, len(commands), affectedPins)
+	return BatchPinSet(commands)
+}
+
+// setupDpllInputPins enables DPLL input pins for T-BC by setting their PPS parent to selectable
+func (d *E825PluginData) setupDpllInputPins() error {
+	if len(d.dpllPins) == 0 {
+		err := d.populateDpllPins()
+		if err != nil {
+			return fmt.Errorf("could not detect any DPLL pins: %w", err)
+		}
+	}
+	commands := []dpll_netlink.PinParentDeviceCtl{}
+	affectedPins := []string{}
+	for _, packageLabel := range bcDpllInputPins {
+		found := false
+		for _, pin := range d.dpllPins {
+			if pin.PackageLabel != packageLabel {
+				continue
+			}
+			if pin.Capabilities&dpll_netlink.PinCapState == 0 {
+				glog.Warningf("DPLL input pin %s (id=%d) lacks state-change capability, skipping", packageLabel, pin.ID)
+				continue
+			}
+			state := uint32(dpll_netlink.PinStateSelectable)
+			cmd, ok := pinCmdSetStatePPS(pin, state, d.dpllDevices)
+			if !ok {
+				glog.Warningf("DPLL input pin %s (id=%d) has no valid PPS input parent, skipping", packageLabel, pin.ID)
+				continue
+			}
+			commands = append(commands, cmd)
+			affectedPins = append(affectedPins, fmt.Sprintf("%s(%s)", pin.BoardLabel, packageLabel))
+			found = true
+		}
+		if !found {
+			glog.Warningf("Could not locate DPLL input pin with packageLabel %s", packageLabel)
+		}
+	}
+	if len(commands) == 0 {
+		glog.Warningf("No DPLL input pins found to enable for T-BC (looked for %v)", bcDpllInputPins)
+		return nil
+	}
+	glog.Infof("Will enable %d DPLL input pins for T-BC (PPS parent only): %v", len(commands), affectedPins)
 	return BatchPinSet(commands)
 }
 

--- a/addons/intel/e825_test.go
+++ b/addons/intel/e825_test.go
@@ -280,23 +280,178 @@ func Test_setupGnss(t *testing.T) {
 	}
 }
 
-func Test_OnPTPConfigChangeE825(t *testing.T) {
+func makeRefPins(ref0p, ref0n bool) []*dpll.PinInfo {
+	pins := []*dpll.PinInfo{}
+	if ref0p {
+		pins = append(pins, &dpll.PinInfo{
+			ID: 0, ClockID: testClockID, PackageLabel: "REF0P", BoardLabel: "ETH01_SDP_TIMESYNC_2",
+			Capabilities: dpll.PinCapState,
+			ParentDevice: []dpll.PinParentDevice{
+				{ParentID: 1, Direction: dpll.PinDirectionInput},
+				{ParentID: 2, Direction: dpll.PinDirectionInput},
+			},
+		})
+	}
+	if ref0n {
+		pins = append(pins, &dpll.PinInfo{
+			ID: 1, ClockID: testClockID, PackageLabel: "REF0N", BoardLabel: "ETH01_SDP_TIMESYNC_0",
+			Capabilities: dpll.PinCapState,
+			ParentDevice: []dpll.PinParentDevice{
+				{ParentID: 1, Direction: dpll.PinDirectionInput},
+				{ParentID: 2, Direction: dpll.PinDirectionInput},
+			},
+		})
+	}
+	return pins
+}
+
+func Test_setupDpllInputPins(t *testing.T) {
+	defaultDevices := testDpllDevices()
 	tcs := []struct {
-		name            string
-		profile         string
-		editProfile     func(*ptpv1.PtpProfile)
-		expectError     bool
-		expectedPinSets int
-		expectedPinFrqs int
+		name             string
+		dpllPins         []*dpll.PinInfo
+		dpllDevices      []*dpll.DoDeviceGetReply
+		expectedCmdCount int
+		expectPPSOnly    bool
 	}{
 		{
-			name:    "TGM Profile",
-			profile: "./testdata/e825-tgm.yaml",
+			name:             "Both REF0P and REF0N present",
+			dpllPins:         makeRefPins(true, true),
+			dpllDevices:      defaultDevices,
+			expectedCmdCount: 2,
+			expectPPSOnly:    true,
 		},
 		{
-			name:            "TBC Profile",
-			profile:         "./testdata/e825-tbc.yaml",
-			expectedPinSets: 2,
+			name:             "Only REF0P present",
+			dpllPins:         makeRefPins(true, false),
+			dpllDevices:      defaultDevices,
+			expectedCmdCount: 1,
+			expectPPSOnly:    true,
+		},
+		{
+			name: "No matching pins",
+			dpllPins: []*dpll.PinInfo{
+				{ID: 99, PackageLabel: "REF4P", Capabilities: dpll.PinCapState},
+			},
+			dpllDevices:      defaultDevices,
+			expectedCmdCount: 0,
+		},
+		{
+			name: "Pin lacks PinCapState",
+			dpllPins: []*dpll.PinInfo{
+				{
+					ID: 1, ClockID: testClockID, PackageLabel: "REF0P",
+					Capabilities: dpll.PinCapPrio,
+					ParentDevice: []dpll.PinParentDevice{
+						{ParentID: 1, Direction: dpll.PinDirectionInput},
+						{ParentID: 2, Direction: dpll.PinDirectionInput},
+					},
+				},
+			},
+			dpllDevices:      defaultDevices,
+			expectedCmdCount: 0,
+		},
+		{
+			name: "PPS parent is output direction",
+			dpllPins: []*dpll.PinInfo{
+				{
+					ID: 1, ClockID: testClockID, PackageLabel: "REF0P",
+					Capabilities: dpll.PinCapState,
+					ParentDevice: []dpll.PinParentDevice{
+						{ParentID: 1, Direction: dpll.PinDirectionInput},
+						{ParentID: 2, Direction: dpll.PinDirectionOutput},
+					},
+				},
+			},
+			dpllDevices:      defaultDevices,
+			expectedCmdCount: 0,
+		},
+		{
+			name: "No PPS device in devices list",
+			dpllPins: []*dpll.PinInfo{
+				{
+					ID: 1, ClockID: testClockID, PackageLabel: "REF0P",
+					Capabilities: dpll.PinCapState,
+					ParentDevice: []dpll.PinParentDevice{
+						{ParentID: 1, Direction: dpll.PinDirectionInput},
+						{ParentID: 2, Direction: dpll.PinDirectionInput},
+					},
+				},
+			},
+			dpllDevices: []*dpll.DoDeviceGetReply{
+				{ID: 1, ClockID: testClockID, Type: dpll.DpllTypeEEC},
+				{ID: 2, ClockID: testClockID, Type: dpll.DpllTypeEEC},
+			},
+			expectedCmdCount: 0,
+		},
+		{
+			name: "ClockID mismatch between pin and device",
+			dpllPins: []*dpll.PinInfo{
+				{
+					ID: 1, ClockID: 9999, PackageLabel: "REF0P",
+					Capabilities: dpll.PinCapState,
+					ParentDevice: []dpll.PinParentDevice{
+						{ParentID: 1, Direction: dpll.PinDirectionInput},
+						{ParentID: 2, Direction: dpll.PinDirectionInput},
+					},
+				},
+			},
+			dpllDevices:      defaultDevices,
+			expectedCmdCount: 0,
+		},
+		{
+			name: "Pin has only EEC parent, no PPS parent",
+			dpllPins: []*dpll.PinInfo{
+				{
+					ID: 1, ClockID: testClockID, PackageLabel: "REF0P",
+					Capabilities: dpll.PinCapState,
+					ParentDevice: []dpll.PinParentDevice{
+						{ParentID: 1, Direction: dpll.PinDirectionInput},
+					},
+				},
+			},
+			dpllDevices:      defaultDevices,
+			expectedCmdCount: 0,
+		},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.name, func(tt *testing.T) {
+			mockPinSet, restorePinSet := setupBatchPinSetMock()
+			defer restorePinSet()
+			data := E825PluginData{dpllPins: tc.dpllPins, dpllDevices: tc.dpllDevices}
+			err := data.setupDpllInputPins()
+			assert.NoError(tt, err)
+			assert.Equal(tt, tc.expectedCmdCount, len(mockPinSet.commands))
+			if tc.expectPPSOnly {
+				for _, cmd := range mockPinSet.commands {
+					assert.Len(tt, cmd.PinParentCtl, 1, "must target PPS parent only")
+					assert.Equal(tt, uint32(dpll.PinStateSelectable), *cmd.PinParentCtl[0].State)
+				}
+			}
+		})
+	}
+}
+
+func Test_OnPTPConfigChangeE825(t *testing.T) {
+	tcs := []struct {
+		name             string
+		profile          string
+		editProfile      func(*ptpv1.PtpProfile)
+		expectError      bool
+		expectedPinSets  int
+		expectedPinFrqs  int
+		expectedDpllCmds int
+	}{
+		{
+			name:             "TGM Profile",
+			profile:          "./testdata/e825-tgm.yaml",
+			expectedDpllCmds: 1,
+		},
+		{
+			name:             "TBC Profile",
+			profile:          "./testdata/e825-tbc.yaml",
+			expectedPinSets:  2,
+			expectedDpllCmds: 3,
 		},
 		{
 			name:    "TBC with no leadingInterface",
@@ -335,7 +490,7 @@ func Test_OnPTPConfigChangeE825(t *testing.T) {
 				assert.NoError(tt, err)
 				assert.Equal(tt, tc.expectedPinSets, mockPins.actualPinSetCount)
 				assert.Equal(tt, tc.expectedPinFrqs, mockPins.actualPinFrqCount)
-				assert.Equal(tt, 1, len(mockDpllPinset.commands))
+				assert.Equal(tt, tc.expectedDpllCmds, len(mockDpllPinset.commands))
 			}
 		})
 	}

--- a/addons/intel/mock_test.go
+++ b/addons/intel/mock_test.go
@@ -303,18 +303,31 @@ func mockClockIDsFromProfile(mfs *MockFileSystem, profile *ptpv1.PtpProfile) {
 	}
 }
 
+// testClockID is the ClockID used across test mock pins and devices
+const testClockID = uint64(1000)
+
+// testDpllDevices returns a standard set of mock DPLL devices (EEC id=1, PPS id=2)
+func testDpllDevices() []*dpll.DoDeviceGetReply {
+	return []*dpll.DoDeviceGetReply{
+		{ID: 1, ClockID: testClockID, Type: dpll.DpllTypeEEC},
+		{ID: 2, ClockID: testClockID, Type: dpll.DpllTypePPS},
+	}
+}
+
 func setupGNSSMocks(data *E825PluginData) (*mockBatchPinSet, func()) {
-	// Setup Mock gnss dpll pin data
+	// Setup Mock gnss dpll pin data (includes GNSS pin + REF0P/REF0N for T-BC input pin tests)
 	data.dpllPins = []*dpll.PinInfo{
 		{
 			ID:           1,
 			BoardLabel:   "SkipMe",
+			ClockID:      testClockID,
 			Type:         dpll.PinTypeEXT,
 			Capabilities: dpll.PinCapPrio,
 		},
 		{
 			BoardLabel:   "GNSS_1PPS_IN",
 			ID:           2,
+			ClockID:      testClockID,
 			Type:         dpll.PinTypeGNSS,
 			Capabilities: dpll.PinCapPrio | dpll.PinCapState,
 			ParentDevice: []dpll.PinParentDevice{
@@ -328,7 +341,32 @@ func setupGNSSMocks(data *E825PluginData) (*mockBatchPinSet, func()) {
 				},
 			},
 		},
+		{
+			ID:           10,
+			ClockID:      testClockID,
+			BoardLabel:   "ETH01_SDP_TIMESYNC_2",
+			PackageLabel: "REF0P",
+			Type:         dpll.PinTypeEXT,
+			Capabilities: dpll.PinCapState,
+			ParentDevice: []dpll.PinParentDevice{
+				{ParentID: uint32(1), Direction: dpll.PinDirectionInput},
+				{ParentID: uint32(2), Direction: dpll.PinDirectionInput},
+			},
+		},
+		{
+			ID:           11,
+			ClockID:      testClockID,
+			BoardLabel:   "ETH01_SDP_TIMESYNC_0",
+			PackageLabel: "REF0N",
+			Type:         dpll.PinTypeEXT,
+			Capabilities: dpll.PinCapState,
+			ParentDevice: []dpll.PinParentDevice{
+				{ParentID: uint32(1), Direction: dpll.PinDirectionInput},
+				{ParentID: uint32(2), Direction: dpll.PinDirectionInput},
+			},
+		},
 	}
+	data.dpllDevices = testDpllDevices()
 	// Mock pin-set logic
 	return setupBatchPinSetMock()
 }

--- a/docs/features/e825-tbc-dpll-input-pins/spec.md
+++ b/docs/features/e825-tbc-dpll-input-pins/spec.md
@@ -1,0 +1,122 @@
+# Feature Spec: E825 T-BC DPLL Input Pin Enablement
+
+## Status: Implemented
+
+## Problem Statement
+
+The E825 plugin does not automatically enable DPLL input pins when configured as a Telecom Boundary Clock (T-BC). Currently, the plugin only manages GNSS pins (disabling for T-BC, enabling for T-GM) and PHC SDP pins (SDP0/SDP2 for the PHY-to-DPLL sync path). The DPLL input pins REF0P and REF0N, which receive SDP timing signals from the NAC, remain in `disconnected` state after system reset. Without enabling these pins, the DPLL cannot lock to the upstream PTP timing signal forwarded through the SDP path.
+
+## Current Behavior Analysis
+
+### What the E825 plugin does today for T-BC (`OnPTPConfigChangeE825`):
+1. Sets `e825Opts.Gnss.Disabled = true` (disables GNSS input)
+2. Calls `setupGnss()` which finds GNSS-type pins (`PinTypeGNSS`) and sets them to `disconnected`
+3. Validates `upstreamPort` and `leadingInterface` are configured
+4. Applies `bcDpllPinReset` to disable SDP0 and SDP2 PHC pins on the leading interface
+
+### What the E825 plugin does on sync events (`AfterRunPTPCommandE825`):
+- `tbc-ho-exit` (sync achieved): Enables SDP0/SDP2 as outputs via `bcDpllPinSetup` and configures frequencies via `bcDpllPeriods`
+- `tbc-ho-entry` (sync lost): Disables SDP0/SDP2 via `bcDpllPinReset`
+
+### What is missing:
+The DPLL input pins REF0P and REF0N are never configured. They remain `disconnected` out of reset on all known platforms.
+
+## Platform Evidence
+
+### Dell Platform — DPLL input pins out of reset:
+| ID | Board Label | Package Label | EEC Prio | PPS Prio | EEC State | PPS State |
+|----|---|---|---|---|---|---|
+| 0 | ETH01_SDP_TIMESYNC_2 | REF0P | 14 | 6 | disconnected | disconnected |
+| 1 | ETH01_SDP_TIMESYNC_0 | REF0N | 14 | 7 | disconnected | disconnected |
+| 7 | GNSS_1PPS_IN | REF4P | 0 | 0 | connected | connected |
+
+### HPE Platform — DPLL input pins out of reset:
+| ID | Board Label | Package Label | EEC Prio | PPS Prio | EEC State | PPS State |
+|----|---|---|---|---|---|---|
+| 0 | 1PPS_IN1 | REF0P | 14 | 6 | disconnected | disconnected |
+| 1 | 1PPS_IN0 | REF0N | 14 | 7 | disconnected | disconnected |
+| 7 | GNSS_1PPS_IN | REF4P | 0 | 0 | connected | connected |
+
+### Key Observation:
+- **Board labels differ** between platforms (Dell: `ETH01_SDP_TIMESYNC_2`/`ETH01_SDP_TIMESYNC_0`, HPE: `1PPS_IN1`/`1PPS_IN0`)
+- **Package labels are identical** across platforms: `REF0P` and `REF0N`
+- Both platforms show these pins as `disconnected` with high (disabled) priority values out of reset
+- The GNSS pin (REF4P / `GNSS_1PPS_IN`) is `connected` out of reset — this is what `setupGnss` currently toggles
+
+## Requirements
+
+### REQ-1: Enable REF0P and REF0N DPLL input pins for T-BC
+
+When the E825 plugin detects a T-BC configuration (`clockType == "T-BC"`), it must set the DPLL input pins with package labels `REF0P` and `REF0N` to `selectable` state on the **PPS parent device only**.
+
+#### REQ-1.1: Pin identification by package label
+Pins must be identified by their `PackageLabel` field (not `BoardLabel`), since board labels vary across platforms while package labels are consistent.
+
+#### REQ-1.2: Target pins
+The following DPLL input pins must be set to `selectable`:
+- `REF0P` — PPS parent device state: `selectable`
+- `REF0N` — PPS parent device state: `selectable`
+
+#### REQ-1.3: PPS parent only
+Only the PPS parent device state should be changed to `selectable`. The PPS parent is identified dynamically by looking up the DPLL device matching the pin's `ParentID` and `ClockID` with `GetDpllType(dev.Type) == "pps"`. The EEC parent device state should remain unchanged (`disconnected`).
+
+#### REQ-1.4: Timing of pin enablement
+The DPLL input pins must be enabled during `OnPTPConfigChangeE825`, alongside the existing GNSS pin configuration and `bcDpllPinReset` application. This ensures the DPLL input path is ready before PTP synchronization begins.
+
+#### REQ-1.5: Pin direction and type filter
+Only pins matching ALL of the following criteria should be affected:
+- `PackageLabel` matches `REF0P` or `REF0N`
+- Pin direction is `input` (on at least the PPS parent device)
+- Pin has `PinCapState` capability (state can be changed)
+
+#### REQ-1.6: Error handling
+- If REF0P or REF0N pins cannot be found, log a warning but do not fail the plugin initialization (the T-BC may still function if SDP inputs are pre-configured by firmware)
+- If setting pin state fails, log an error but continue with remaining pin operations
+
+### REQ-2: No impact on T-GM or other clock types
+
+The DPLL input pin enablement must only occur when `clockType == "T-BC"`. T-GM and other clock type configurations must not be affected.
+
+## Technical Design Notes
+
+### Pin state model
+Each DPLL pin has parent devices (typically EEC and PPS). The PPS parent is resolved dynamically at runtime by matching the pin's `ParentID` against cached DPLL devices, filtering by `ClockID` and device type (`"pps"`). This follows the same pattern as `DpllConfig.ActivePhaseOffsetPin` in `pkg/dpll/dpll.go`.
+
+### Data structures
+
+Target pin package labels for T-BC DPLL input pin setup:
+```go
+var bcDpllInputPins = []string{"REF0P", "REF0N"}
+```
+
+DPLL devices are cached in `E825PluginData.dpllDevices` alongside the existing `dpllPins` cache, populated via `getAllDpllDevices` during `populateDpllPins`.
+
+### Integration point
+The logic is called in `OnPTPConfigChangeE825`, within the `if tbcConfigured(nodeProfile)` block, after `bcDpllPinReset` application.
+
+### DPLL netlink command structure
+For each target pin, a `PinParentDeviceCtl` command is constructed:
+- Pin ID: resolved from the fetched DPLL pin list by package label
+- PPS parent: identified dynamically by matching `ParentID` to a device with `ClockID == pin.ClockID` and `GetDpllType(dev.Type) == "pps"`; state set to `PinStateSelectable` (value 3)
+- EEC parent: unchanged (not included in command)
+
+## Out of Scope
+
+- Changing REF0P/REF0N priority values (they retain their default priorities from reset)
+- Enabling REF0P/REF0N on the EEC parent device
+- Disabling REF0P/REF0N on `tbc-ho-entry` (they should remain selectable; the DPLL auto-selects based on priority)
+- Supporting platforms with different package labels for SDP input pins (only REF0P/REF0N are supported)
+- Configuration of REF0P/REF0N via user-specified plugin options (this is automatic behavior)
+
+## Testing Requirements
+
+### Unit Tests
+1. Verify that `OnPTPConfigChangeE825` with a T-BC profile calls the new pin enablement logic
+2. Verify that REF0P and REF0N are set to `selectable` on PPS parent only
+3. Verify that EEC parent state is not modified
+4. Verify that T-GM profiles do not trigger DPLL input pin enablement
+5. Verify graceful handling when REF0P/REF0N pins are not found in the DPLL pin dump
+
+### Integration Verification
+- On Dell platform: confirm pins `ETH01_SDP_TIMESYNC_2` (REF0P) and `ETH01_SDP_TIMESYNC_0` (REF0N) transition from `disconnected` to `selectable` on PPS parent when T-BC is configured
+- On HPE platform: confirm pins `1PPS_IN1` (REF0P) and `1PPS_IN0` (REF0N) transition similarly


### PR DESCRIPTION
Implemented functionality to enable REF0P and REF0N DPLL input pins when configured as T-BC. This includes the addition of tests for various scenarios, ensuring proper handling of pin capabilities and parent device relationships. Updated related structures and methods to support the new functionality.

Applicable to T-BC without holdover on GNR-D. Covers both Dell and HPE. Tested on Dell.
/cc @lack @nocturnalastro 
