### PR TITLE
add coverage gate to block PRs with decreasing coverage

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -19,21 +19,10 @@ jobs:
         with:
           go-version-file: go.mod
 
+      - name: Coverage Gate
+        if: github.event_name == 'pull_request'
+        run: make coverage-gate BASE_REF=${{ github.event.pull_request.base.sha }}
+
       - name: Generate Coverage
+        if: github.event_name == 'push'
         run: make test
-
-      - name: Generate Base Coverage
-        if: github.event_name == 'pull_request'
-        run: |
-          git checkout ${{ github.event.pull_request.base.sha }}
-          make test
-          go run github.com/vladopajic/go-test-coverage/v2@v2.17.1 -p coverage.out --breakdown-file-name base-coverage.json
-          git checkout ${{ github.sha }}
-
-      - name: Check Coverage Regressions
-        if: github.event_name == 'pull_request'
-        uses: vladopajic/go-test-coverage@v2
-        with:
-          profile: coverage.out
-          base-breakdown-file: base-coverage.json
-          diff-threshold: 0

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,39 @@
+name: "Coverage Quality Gate"
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  coverage:
+    if: "!contains(github.event.pull_request.labels.*.name, 'skip-coverage')"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+
+      - name: Generate Coverage
+        run: make test
+
+      - name: Generate Base Coverage
+        if: github.event_name == 'pull_request'
+        run: |
+          git checkout ${{ github.event.pull_request.base.sha }}
+          make test
+          go run github.com/vladopajic/go-test-coverage/v2@v2.17.1 -p coverage.out --breakdown-file-name base-coverage.json
+          git checkout ${{ github.sha }}
+
+      - name: Check Coverage Regressions
+        if: github.event_name == 'pull_request'
+        uses: vladopajic/go-test-coverage@v2
+        with:
+          profile: coverage.out
+          base-breakdown-file: base-coverage.json
+          diff-threshold: 0

--- a/Makefile
+++ b/Makefile
@@ -23,9 +23,10 @@ fmt:
 	./hack/gofmt.sh
 
 test:
-	SKIP_GNSS_MONITORING=1 go test ./... --tags=unittests -coverprofile=coverage.raw.out
-	# Filter out generated code and mocks
-	grep -vE "zz_generated|\.pb\.go|mock_" coverage.raw.out > coverage.out
+	./hack/unit-test.sh
+
+coverage-gate:
+	./hack/coverage-gate.sh $(BASE_REF)
 
 lint:
 	golangci-lint run

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,9 @@ fmt:
 	./hack/gofmt.sh
 
 test:
-	SKIP_GNSS_MONITORING=1 go test ./... --tags=unittests -coverprofile=coverage.out
+	SKIP_GNSS_MONITORING=1 go test ./... --tags=unittests -coverprofile=coverage.raw.out
+	# Filter out generated code and mocks
+	grep -vE "zz_generated|\.pb\.go|mock_" coverage.raw.out > coverage.out
 
 lint:
 	golangci-lint run

--- a/README.md
+++ b/README.md
@@ -87,3 +87,27 @@ $ kubectl get pods -n openshift-ptp
 NAME                    READY   STATUS    RESTARTS   AGE
 linuxptp-daemon-txmpn   1/1     Running   0          105m
 ```
+
+## Test Coverage
+
+Run `make coverage-gate` to compare test coverage of your branch against the upstream main branch. The script auto-detects the upstream remote and its tracking branch.
+
+```sh
+$ make coverage-gate
+
+Base coverage (up-main): 45.4%
+Current coverage:            45.4%
+Difference:                  0%
+✅ Coverage unchanged.
+```
+
+You can also compare against a specific branch:
+
+```sh
+$ BASE_REF=release-4.20 make coverage-gate
+
+Base coverage (release-4.20): 40.9%
+Current coverage:            45.4%
+Difference:                  4.5%
+🎉 Coverage increased by 4.5%, good job!
+```

--- a/hack/coverage-gate.sh
+++ b/hack/coverage-gate.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+# Compare test coverage of the current branch against a base ref.
+# Usage: hack/coverage-gate.sh [base-ref]
+# When base-ref is omitted, auto-detects the local branch tracking
+# the upstream k8snetworkplumbingwg remote's default branch.
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+resolve_base_ref() {
+  if [ -n "$1" ]; then
+    echo "$1"
+    return
+  fi
+
+  # Find the remote pointing to k8snetworkplumbingwg
+  UPSTREAM_REMOTE=$(git remote -v | grep 'k8snetworkplumbingwg/.*fetch' | awk '{print $1}' | head -1)
+  if [ -z "${UPSTREAM_REMOTE}" ]; then
+    echo "main"
+    return
+  fi
+
+  git fetch "${UPSTREAM_REMOTE}" --quiet
+
+  # Find the default branch of the upstream remote
+  UPSTREAM_HEAD=$(git remote show "${UPSTREAM_REMOTE}" | sed -n '/HEAD branch/s/.*: //p')
+  UPSTREAM_REF="${UPSTREAM_REMOTE}/${UPSTREAM_HEAD}"
+
+  # Find or create a local branch tracking this remote branch
+  LOCAL_BRANCH=$(git branch --list --format='%(refname:short) %(upstream:short)' | grep " ${UPSTREAM_REF}$" | awk '{print $1}' | head -1)
+  if [ -z "${LOCAL_BRANCH}" ]; then
+    LOCAL_BRANCH="up-${UPSTREAM_HEAD}"
+    echo "==> Creating tracking branch '${LOCAL_BRANCH}' for '${UPSTREAM_REF}'..." >&2
+    git branch "${LOCAL_BRANCH}" "${UPSTREAM_REF}" --quiet
+    git branch --set-upstream-to="${UPSTREAM_REF}" "${LOCAL_BRANCH}" --quiet >/dev/null
+  fi
+
+  # Update tracking branch to latest without checkout
+  git branch -f "${LOCAL_BRANCH}" "${UPSTREAM_REF}" --quiet
+
+  echo "${LOCAL_BRANCH}"
+}
+
+BASE_REF=$(resolve_base_ref "$1")
+
+echo "==> Running tests on current branch..."
+"${SCRIPT_DIR}/unit-test.sh"
+CURRENT_COV=$(go tool cover -func=coverage.out | grep ^total | awk '{print $3}' | tr -d '%')
+
+echo "==> Running tests on base ref '${BASE_REF}'..."
+CURRENT_BRANCH=$(git symbolic-ref --short HEAD 2>/dev/null || git rev-parse HEAD)
+TMPTEST=$(mktemp)
+cp "${SCRIPT_DIR}/unit-test.sh" "${TMPTEST}"
+STASHED=false
+if ! git diff --quiet || ! git diff --cached --quiet; then
+  git stash --quiet
+  STASHED=true
+fi
+git checkout "${BASE_REF}" --quiet
+bash "${TMPTEST}"
+rm -f "${TMPTEST}"
+BASE_COV=$(go tool cover -func=coverage.out | grep ^total | awk '{print $3}' | tr -d '%')
+git checkout "${CURRENT_BRANCH}" --quiet
+if [ "${STASHED}" = true ]; then
+  git stash pop --quiet
+fi
+
+DIFF=$(echo "${CURRENT_COV} - ${BASE_COV}" | bc)
+echo ""
+echo "Base coverage (${BASE_REF}): ${BASE_COV}%"
+echo "Current coverage:            ${CURRENT_COV}%"
+echo "Difference:                  ${DIFF}%"
+
+if (( $(echo "${DIFF} < 0" | bc -l) )); then
+  echo "❌ FAIL: Coverage decreased by ${DIFF}%"
+  exit 1
+elif (( $(echo "${DIFF} > 0" | bc -l) )); then
+  echo "🎉 Coverage increased by ${DIFF}%, good job!"
+else
+  echo "✅ Coverage unchanged."
+fi

--- a/hack/unit-test.sh
+++ b/hack/unit-test.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# Run unit tests and generate filtered coverage profile.
+set -e
+SKIP_GNSS_MONITORING=1 go test ./... --tags=unittests -coverprofile=coverage.raw.out
+grep -vE "zz_generated|\.pb\.go|mock_" coverage.raw.out > coverage.out


### PR DESCRIPTION
Add a GitHub Action to enforce code coverage standards.

- Executes tests with SKIP_GNSS_MONITORING=1 and --tags=unittests.
- Filters out auto-generated Kubernetes code (zz_generated),
  protobuf (.pb.go), and mocks to ensure high-signal metrics.
- On PRs, generates baseline coverage from the base branch and
  blocks if coverage decreases relative to that baseline.
- Supports skip-coverage label to bypass the check when needed.