### PR TITLE
Skip CI workflows for non-production changes

### DIFF
--- a/.github/workflows/aws-ci.yaml
+++ b/.github/workflows/aws-ci.yaml
@@ -10,7 +10,29 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.head.repo.full_name }}-${{ github.event.pull_request.head.ref }}
   cancel-in-progress: true
 jobs:
+  check-changes:
+    runs-on: ubuntu-latest
+    outputs:
+      has-code-changes: ${{ steps.filter.outputs.has-code-changes }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Check for production code changes
+        id: filter
+        run: |
+          BASE=${{ github.event.pull_request.base.sha }}
+          HEAD=${{ github.event.pull_request.head.sha }}
+          CHANGED=$(git diff --name-only "$BASE" "$HEAD" | grep -cvE '^\.(github/|gitignore)|^docs/|\.md$' || true)
+          if [ "$CHANGED" -gt 0 ]; then
+            echo "has-code-changes=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has-code-changes=false" >> "$GITHUB_OUTPUT"
+          fi
+
   deploy-ec2:
+    needs: check-changes
+    if: needs.check-changes.outputs.has-code-changes == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 115
     steps:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -14,8 +14,16 @@ name: "CodeQL Advanced"
 on:
   push:
     branches: [ "main" ]
+    paths-ignore:
+      - '.github/**'
+      - 'docs/**'
+      - '**.md'
   pull_request:
     branches: [ "main" ]
+    paths-ignore:
+      - '.github/**'
+      - 'docs/**'
+      - '**.md'
   schedule:
     - cron: '20 21 * * 4'
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,16 @@
 name: Test
 
-on: [push, pull_request]
+on:
+  push:
+    paths-ignore:
+      - '.github/**'
+      - 'docs/**'
+      - '**.md'
+  pull_request:
+    paths-ignore:
+      - '.github/**'
+      - 'docs/**'
+      - '**.md'
 
 jobs:
   build:


### PR DESCRIPTION
Add paths-ignore filters to CodeQL and Test workflows so they are
not triggered when only workflow files, docs, or markdown are changed.

For aws-ci, pull_request_target does not support paths filters, so
add a check-changes job that diffs the PR and skips deploy-ec2 if
only non-production files were modified.