### PR TITLE
[WIP] Do Not Merge: Remove stdoutToSocket flag

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -118,14 +117,6 @@ func main() {
 		return
 	}
 
-	// The name of NodePtpDevice CR for this node is equal to the node name
-	var stdoutToSocket = false
-	if val, ok := os.LookupEnv("LOGS_TO_SOCKET"); ok && val != "" {
-		if ret, err := strconv.ParseBool(val); err == nil {
-			stdoutToSocket = ret
-		}
-	}
-
 	plugins := make([]string, 0)
 
 	if val, ok := os.LookupEnv("PLUGINS"); ok && val != "" {
@@ -180,7 +171,6 @@ func main() {
 	daemonInstance := daemon.New(
 		nodeName,
 		daemon.PtpNamespace,
-		stdoutToSocket,
 		kubeClient,
 		ptpClient,
 		ptpConfUpdate,
@@ -200,12 +190,7 @@ func main() {
 	sigCh := make(chan os.Signal, 1)
 	signal.Notify(sigCh, syscall.SIGHUP, syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT)
 
-	// by default metrics is hosted here,if LOGS_TO_SOCKET variable is set then metrics are disabled
-	if !stdoutToSocket { // if not sending metrics (log) out to a socket then host metrics here
-		daemon.StartMetricsServer("0.0.0.0:9091")
-	}
-
-	daemon.StartReadyServer("0.0.0.0:8081", tracker, stdoutToSocket)
+	daemon.StartReadyServer("0.0.0.0:8081", tracker)
 
 	// Wait for one ticker interval before loading the profile
 	// This allows linuxptp-daemon connection to the cloud-event-proxy container to

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -113,8 +113,8 @@ var vTbcHasHardwareConfig = false
 
 const socketDialTimeout = 5 * time.Second
 
-func dialSocket() (net.Conn, error) {
-	c, err := net.DialTimeout("unix", eventSocket, socketDialTimeout)
+func (p *ptpProcess) dialSocket() (net.Conn, error) {
+	c, err := net.DialTimeout("unix", p.outSocketPath, socketDialTimeout)
 	if err != nil {
 		glog.Errorf("error trying to connect to event socket")
 		time.Sleep(connectionRetryInterval)
@@ -190,7 +190,7 @@ func (p *ProcessManager) SetTestData(name, msgTag string, ifaces config.IFaces) 
 	p.process[0].messageTag = msgTag
 	p.process[0].ifaces = ifaces
 	p.process[0].logParser = getParser(name)
-	p.process[0].handler = event.Init("test", false, eventSocket, eventChannel, closeManager, Offset, ClockState, ClockClassMetrics)
+	p.process[0].handler = event.Init("test", eventSocket, eventChannel, closeManager, Offset, ClockState, ClockClassMetrics)
 	// Reset aliases for each test to avoid cross-case collisions.
 	alias.ClearAliases()
 	// Calculate aliases for the test interfaces to ensure proper aliasing
@@ -292,26 +292,28 @@ func (t *tBCProcessAttributes) allPortsLost() bool {
 }
 
 type ptpProcess struct {
-	name                  string
-	ifaces                config.IFaces
-	processSocketPath     string
-	processConfigPath     string
-	configName            string
-	messageTag            string
-	eventCh               chan event.EventChannel
-	exitCh                chan bool
-	execMutex             sync.Mutex
-	stopped               bool
-	logFilters            []*logfilter.LogFilter // List of filters to apply to logs
-	cmd                   *exec.Cmd
-	depProcess            []process // these are list of dependent process which needs to be started/stopped if the parent process is starts/stops
-	nodeProfile           ptpv1.PtpProfile
-	logParser             parser.MetricsExtractor
-	clockType             event.ClockType
-	ptpClockThreshold     *ptpv1.PtpClockThreshold
-	haProfile             map[string][]string // stores list of interface name for each profile
-	syncERelations        *synce.Relations
-	c                     net.Conn
+	name              string
+	ifaces            config.IFaces
+	processSocketPath string
+	processConfigPath string
+	configName        string
+	messageTag        string
+	eventCh           chan event.EventChannel
+	exitCh            chan bool
+	execMutex         sync.Mutex
+	stopped           bool
+	logFilters        []*logfilter.LogFilter // List of filters to apply to logs
+	cmd               *exec.Cmd
+	depProcess        []process // these are list of dependent process which needs to be started/stopped if the parent process is starts/stops
+	nodeProfile       ptpv1.PtpProfile
+	logParser         parser.MetricsExtractor
+	clockType         event.ClockType
+	ptpClockThreshold *ptpv1.PtpClockThreshold
+	haProfile         map[string][]string // stores list of interface name for each profile
+	syncERelations    *synce.Relations
+	outSocketPath     string
+	// outSocket carries process stdout lines and status messages to the cloud-event-proxy sidecar
+	outSocket             net.Conn
 	hasCollectedMetrics   bool
 	tBCAttributes         tBCProcessAttributes
 	GrandmasterClockClass uint8
@@ -349,8 +351,6 @@ type Daemon struct {
 	// node name where daemon is running
 	nodeName  string
 	namespace string
-	// write logs to socket, this will also send metrics to the socket
-	stdoutToSocket bool
 
 	// kubeClient allows interaction with Kubernetes, including the node we are running on.
 	kubeClient *kubernetes.Clientset
@@ -457,7 +457,6 @@ func (dn *Daemon) getInterfacesFromHardwareConfig(nodeProfile *ptpv1.PtpProfile)
 func New(
 	nodeName string,
 	namespace string,
-	stdoutToSocket bool,
 	kubeClient *kubernetes.Clientset,
 	ptpClient *ptpclient.Clientset,
 	ptpUpdate *LinuxPTPConfUpdate,
@@ -469,16 +468,13 @@ func New(
 	pmcPollInterval int,
 	tracker *ReadyTracker,
 ) *Daemon {
-	if !stdoutToSocket {
-		RegisterMetrics(nodeName)
-	}
 	InitializeOffsetMaps()
 	pluginManager, unknownPlugins := registerPlugins(plugins)
 	eventChannel := make(chan event.EventChannel, 100)
 	pm := &ProcessManager{
 		process:         nil,
 		eventChannel:    eventChannel,
-		ptpEventHandler: event.Init(nodeName, stdoutToSocket, eventSocket, eventChannel, closeManager, Offset, ClockState, ClockClassMetrics),
+		ptpEventHandler: event.Init(nodeName, eventSocket, eventChannel, closeManager, Offset, ClockState, ClockClassMetrics),
 	}
 	tracker.processManager = pm
 
@@ -504,7 +500,6 @@ func New(
 	return &Daemon{
 		nodeName:              nodeName,
 		namespace:             namespace,
-		stdoutToSocket:        stdoutToSocket,
 		kubeClient:            kubeClient,
 		ptpClient:             ptpClient,
 		ptpUpdate:             ptpUpdate,
@@ -743,13 +738,13 @@ func (dn *Daemon) applyNodePTPProfiles() error {
 			p.eventCh = dn.processManager.eventChannel
 			// start ptp4l process early , it doesn't have
 			if p.depProcess == nil {
-				go p.cmdRun(dn.stdoutToSocket, &dn.pluginManager)
+				go p.cmdRun(&dn.pluginManager)
 			} else {
 				for _, d := range p.depProcess {
 					if d != nil {
 						time.Sleep(3 * time.Second)
 						glog.Infof("Starting %s", d.Name())
-						go d.CmdRun(false)
+						go d.CmdRun()
 						time.Sleep(3 * time.Second)
 						dn.pluginManager.AfterRunPTPCommand(&p.nodeProfile, d.Name())
 						d.MonitorProcess(config.ProcessConfig{
@@ -766,7 +761,7 @@ func (dn *Daemon) applyNodePTPProfiles() error {
 						glog.Infof("enabling dep process %s with Max %d Min %d Holdover %d", d.Name(), p.ptpClockThreshold.MaxOffsetThreshold, p.ptpClockThreshold.MinOffsetThreshold, p.ptpClockThreshold.HoldOverTimeout)
 					}
 				}
-				go p.cmdRun(dn.stdoutToSocket, &dn.pluginManager)
+				go p.cmdRun(&dn.pluginManager)
 			}
 			dn.pluginManager.AfterRunPTPCommand(&p.nodeProfile, p.name)
 		}
@@ -1015,7 +1010,7 @@ func (dn *Daemon) applyNodePtpProfile(runID int, nodeProfile *ptpv1.PtpProfile) 
 		//output, messageTag, socketPath, GPSPIPE_SERIALPORT, update_leapfile, os.Getenv("NODE_NAME")
 
 		// This adds the flags needed for monitor
-		addFlagsForMonitor(pProcess, configOpts, output, dn.stdoutToSocket)
+		addFlagsForMonitor(pProcess, configOpts, output)
 		var configOutput string
 		var relations *synce.Relations
 		var ifaces config.IFaces
@@ -1047,6 +1042,7 @@ func (dn *Daemon) applyNodePtpProfile(runID int, nodeProfile *ptpv1.PtpProfile) 
 			ifaces:            ifaces,
 			processConfigPath: configPath,
 			processSocketPath: socketPath,
+			outSocketPath:     eventSocket,
 			configName:        configFile,
 			messageTag:        messageTag,
 			exitCh:            make(chan bool),
@@ -1522,17 +1518,17 @@ func (p *ptpProcess) processTBCTransitionLegacy(output string, pm *plugin.Plugin
 // cmdRun runs given ptpProcess and restarts on errors
 //
 //nolint:gocyclo // complexity is acceptable for this function
-func (p *ptpProcess) cmdRun(stdoutToSocket bool, pm *plugin.PluginManager) {
+func (p *ptpProcess) cmdRun(pm *plugin.PluginManager) {
 	cmd := p.cmd
 	stopped := p.getAndSetStopped(false)
 	if !stopped {
 		glog.Infof("%s is already running", p.name)
 		return
 	}
-	doneCh := make(chan struct{}) // Done setting up logging.  Go ahead and wait for process
+	doneCh := make(chan struct{})
 	defer func() {
-		if stdoutToSocket && p.c != nil {
-			if err := p.c.Close(); err != nil {
+		if p.outSocket != nil {
+			if err := p.outSocket.Close(); err != nil {
 				glog.Errorf("closing connection returned error %s", err)
 			}
 		}
@@ -1556,100 +1552,69 @@ func (p *ptpProcess) cmdRun(stdoutToSocket bool, pm *plugin.PluginManager) {
 		// don't discard process stderr output
 		cmd.Stderr = cmd.Stdout
 
-		if !stdoutToSocket {
+		go func() {
+		connect:
+			select {
+			case <-p.exitCh:
+				doneCh <- struct{}{}
+				return
+			default:
+				p.outSocket, err = p.dialSocket()
+				if err != nil {
+					goto connect
+				}
+			}
 			scanner := bufio.NewScanner(cmdReader)
-			processStatus(nil, p.name, p.messageTag, PtpProcessUp)
-			go func() {
-				for scanner.Scan() {
-					output := scanner.Text()
-					if p.name == chronydProcessName {
-						output = fmt.Sprintf("%s[%d]%s: %s", chronydProcessName, p.cmd.Process.Pid, p.messageTag, output)
-					}
-					output = pm.ProcessLog(p.name, output)
-					// for ts2phc from 4.2 onwards replace /dev/ptpX by actual interface
-					output = p.replaceClockID(output)
-					printWhenNotEmpty(logfilter.FilterOutput(p.logFilters, output))
-					p.processPTPMetrics(output)
-					if p.name == ptp4lProcessName {
-						if profileClockType == TBC {
-							p.tBCTransitionCheck(output, pm)
-						}
-					} else if p.name == phc2sysProcessName && len(p.haProfile) > 0 {
-						p.announceHAFailOver(nil, output) // do not use go routine since order of execution is important here
-					}
+			processStatus(p.outSocket, p.name, p.messageTag, PtpProcessUp)
+			for _, d := range p.depProcess {
+				if d != nil {
+					d.ProcessStatus(p.outSocket, PtpProcessUp)
 				}
-				doneCh <- struct{}{}
-			}()
-		} else {
-			go func() {
-			connect:
-				select {
-				case <-p.exitCh:
-					doneCh <- struct{}{}
-				default:
-					p.c, err = dialSocket()
-					if err != nil {
-						goto connect
-					}
-				}
-				scanner := bufio.NewScanner(cmdReader)
-				processStatus(p.c, p.name, p.messageTag, PtpProcessUp)
-				for _, d := range p.depProcess {
-					if d != nil {
-						d.ProcessStatus(p.c, PtpProcessUp)
-					}
-				}
+			}
 
-				for scanner.Scan() {
-					output := scanner.Text()
-					if p.name == chronydProcessName {
-						output = fmt.Sprintf("%s[%d]%s: %s", chronydProcessName, p.cmd.Process.Pid, p.messageTag, output)
-					}
-					output = pm.ProcessLog(p.name, output)
-					// for ts2phc from 4.2 onwards replace /dev/ptpX by actual interface
-					output = p.replaceClockID(output)
-					printWhenNotEmpty(logfilter.FilterOutput(p.logFilters, output))
-
-					// for ts2phc, we need to extract metrics to identify GM state
-					p.processPTPMetrics(output)
-					if p.name == ptp4lProcessName {
-						if profileClockType == TBC {
-							p.tBCTransitionCheck(output, pm)
-						}
-					} else if p.name == phc2sysProcessName && len(p.haProfile) > 0 {
-						p.announceHAFailOver(p.c, output) // do not use go routine since order of execution is important here
-					}
-					line := removeMessageSuffix(output) + "\n"
-					_, err2 := p.c.Write([]byte(line))
-					if err2 != nil {
-						glog.Errorf("Write %s error %s:", output, err2)
-						goto connect
-					}
+			for scanner.Scan() {
+				output := scanner.Text()
+				if p.name == chronydProcessName {
+					output = fmt.Sprintf("%s[%d]%s: %s", chronydProcessName, p.cmd.Process.Pid, p.messageTag, output)
 				}
-				doneCh <- struct{}{}
-			}()
-		}
+				output = pm.ProcessLog(p.name, output)
+				output = p.replaceClockID(output)
+				printWhenNotEmpty(logfilter.FilterOutput(p.logFilters, output))
+				p.processPTPMetrics(output)
+				if p.name == ptp4lProcessName {
+					if profileClockType == TBC {
+						p.tBCTransitionCheck(output, pm)
+					}
+				} else if p.name == phc2sysProcessName && len(p.haProfile) > 0 {
+					p.announceHAFailOver(p.outSocket, output) // do not use go routine since order of execution is important here
+				}
+				line := removeMessageSuffix(output) + "\n"
+				_, err2 := p.outSocket.Write([]byte(line))
+				if err2 != nil {
+					glog.Errorf("Write %s error %s:", output, err2)
+					goto connect
+				}
+			}
+			doneCh <- struct{}{}
+		}()
+
 		// Don't restart after termination
 		if !p.Stopped() {
 			glog.Infof("starting %s...", p.name)
 			p.cmd = cmd
-			err = cmd.Start() // this is asynchronous call,
+			err = cmd.Start() // this is asynchronous call
 			if err != nil {
 				glog.Errorf("CmdRun() error starting %s: %v", p.name, err)
 			}
 
-			<-doneCh // goroutine is done
+			<-doneCh
 			err = cmd.Wait()
 
 			glog.Infof("done waiting for %s...", p.name)
 			if err != nil {
 				glog.Errorf("CmdRun() error waiting for %s: %v", p.name, err)
 			}
-			if stdoutToSocket && p.c != nil {
-				processStatus(p.c, p.name, p.messageTag, PtpProcessDown)
-			} else {
-				processStatus(nil, p.name, p.messageTag, PtpProcessDown)
-			}
+			processStatus(p.outSocket, p.name, p.messageTag, PtpProcessDown)
 			p.updateGMStatusOnProcessDown(p.name)
 		}
 
@@ -1666,8 +1631,8 @@ func (p *ptpProcess) cmdRun(stdoutToSocket bool, pm *plugin.PluginManager) {
 			newCmd := exec.Command(cmd.Args[0], cmd.Args[1:]...)
 			cmd = newCmd
 		}
-		if stdoutToSocket && p.c != nil {
-			if err2 := p.c.Close(); err2 != nil {
+		if p.outSocket != nil {
+			if err2 := p.outSocket.Close(); err2 != nil {
 				glog.Errorf("closing connection returned error %s", err2)
 			}
 		}
@@ -1687,7 +1652,7 @@ func (p *ptpProcess) processPTPMetrics(output string) {
 		logEntry := synce.ParseLog(output)
 		p.ProcessSynceEvents(logEntry)
 	} else {
-		configName, source, ptpOffset, clockState, iface := extractMetrics(p.messageTag, p.name, p.ifaces, output, p.c == nil)
+		configName, source, ptpOffset, clockState, iface := extractMetrics(p.messageTag, p.name, p.ifaces, output, false)
 		p.hasCollectedMetrics = true
 		p.offset = ptpOffset
 		if iface != "" { // for ptp4l/phc2sys this function only update metrics
@@ -1751,10 +1716,10 @@ func (p *ptpProcess) cmdSetEnabled(enabled bool) {
 	case "chronyd":
 		if enabled {
 			_, _ = exec.Command("chronyc", "-h", ChronydSocketPath, "online").Output()
-			processStatus(p.c, p.name, p.messageTag, PtpProcessUp)
+			processStatus(p.outSocket, p.name, p.messageTag, PtpProcessUp)
 		} else {
 			_, _ = exec.Command("chronyc", "-h", ChronydSocketPath, "offline").Output()
-			processStatus(p.c, p.name, p.messageTag, PtpProcessDown)
+			processStatus(p.outSocket, p.name, p.messageTag, PtpProcessDown)
 		}
 	case "phc2sys":
 		if enabled {
@@ -1762,7 +1727,7 @@ func (p *ptpProcess) cmdSetEnabled(enabled bool) {
 				cmd := p.cmd
 				newCmd := exec.Command(cmd.Args[0], cmd.Args[1:]...)
 				p.cmd = newCmd
-				go p.cmdRun(p.dn.stdoutToSocket, &(p.dn.pluginManager))
+				go p.cmdRun(&p.dn.pluginManager)
 			}
 		} else {
 			p.cmdStop()
@@ -1831,8 +1796,8 @@ func (p *ptpProcess) ProcessTs2PhcEvents(ptpOffset float64, source string, iface
 		if iface != "" && iface != clockRealTime {
 			iface = alias.GetAlias(iface)
 		}
-		if p.c != nil {
-			return // no metrics when socket is used
+		if p.outSocket != nil {
+			return
 		}
 		switch ptpState {
 		case event.PTP_LOCKED:
@@ -2090,7 +2055,7 @@ func (p *ptpProcess) ProcessSynceEvents(logEntry synce.LogEntry) {
 					ExtendedSSM: 0,
 				})
 				state = sDeviceConfig.LastClockState
-				if p.c == nil { // only update metrics if no socket is used
+				if p.outSocket == nil {
 					UpdateSynceQLMetrics(syncEProcessName, p.configName, iface, sDeviceConfig.NetworkOption, sDeviceConfig.Name, "SSM", logEntry.QL)
 					UpdateSynceQLMetrics(syncEProcessName, p.configName, iface, sDeviceConfig.NetworkOption, sDeviceConfig.Name, "Extended SSM", synce.QL_DEFAULT_ENHSSM)
 					UpdateSynceClockQlMetrics(syncEProcessName, p.configName, iface, sDeviceConfig.NetworkOption, sDeviceConfig.Name, int(logEntry.QL)+int(synce.QL_DEFAULT_ENHSSM))
@@ -2118,7 +2083,7 @@ func (p *ptpProcess) ProcessSynceEvents(logEntry synce.LogEntry) {
 						ExtendedSSM: lastQLState.ExtendedSSM,
 						Priority:    0,
 					})
-					if p.c == nil {
+					if p.outSocket == nil {
 						UpdateSynceQLMetrics(syncEProcessName, p.configName, iface, sDeviceConfig.NetworkOption, sDeviceConfig.Name, "SSM", lastQLState.SSM)
 						UpdateSynceQLMetrics(syncEProcessName, p.configName, iface, sDeviceConfig.NetworkOption, sDeviceConfig.Name, "Extended SSM", logEntry.ExtQl)
 						UpdateSynceClockQlMetrics(syncEProcessName, p.configName, iface, sDeviceConfig.NetworkOption, sDeviceConfig.Name, int(lastQLState.SSM)+int(logEntry.ExtQl))

--- a/pkg/daemon/daemon_internal_test.go
+++ b/pkg/daemon/daemon_internal_test.go
@@ -129,7 +129,6 @@ func applyTestProfile(t *testing.T, profile *ptpv1.PtpProfile) {
 	dn := New(
 		"test-node-name",
 		"openshift-ptp",
-		false,
 		nil,
 		nil,
 		&LinuxPTPConfUpdate{
@@ -216,7 +215,6 @@ func Test_applyProfile_TBC(t *testing.T) {
 	dn := New(
 		"test-node-name",
 		"openshift-ptp",
-		false,
 		nil,
 		nil,
 		&LinuxPTPConfUpdate{
@@ -1794,7 +1792,7 @@ func TestEmitClockClassLogs_EmitsWithNilParentDS(t *testing.T) {
 	// tests already cover the socket write path via EmitClockClass).
 	eventChannel := make(chan event.EventChannel)
 	closeCh := make(chan bool, 1)
-	handler := event.Init("testnode", false, "", eventChannel, closeCh, nil, nil, nil)
+	handler := event.Init("testnode", "", eventChannel, closeCh, nil, nil, nil)
 
 	// Create a PMC process with parentDS = nil (the bug condition).
 	// Before the fix, EmitClockClassLogs skipped the call when parentDS was nil.

--- a/pkg/daemon/gpsd.go
+++ b/pkg/daemon/gpsd.go
@@ -172,7 +172,7 @@ func (g *GPSD) ProcessStatus(c net.Conn, status int64) {
 }
 
 // CmdRun ... run GPSD
-func (g *GPSD) CmdRun(stdoutToSocket bool) {
+func (g *GPSD) CmdRun() {
 	defer func() {
 		if g.subscriber != nil {
 			g.unRegisterSubscriber()

--- a/pkg/daemon/gpspipe.go
+++ b/pkg/daemon/gpspipe.go
@@ -143,7 +143,7 @@ func (gp *gpspipe) ProcessStatus(c net.Conn, status int64) {
 }
 
 // CmdRun ... run gpspipe
-func (gp *gpspipe) CmdRun(stdoutToSocket bool) {
+func (gp *gpspipe) CmdRun() {
 	defer func() {
 		select {
 		case gp.exitCh <- struct{}{}:

--- a/pkg/daemon/metrics.go
+++ b/pkg/daemon/metrics.go
@@ -701,10 +701,9 @@ func extractPTP4lEventState(output string) (portId int, role ptpPortRole) {
 	return
 }
 
-func addFlagsForMonitor(process string, configOpts *string, conf *Ptp4lConf, stdoutToSocket bool) {
+func addFlagsForMonitor(process string, configOpts *string, conf *Ptp4lConf) {
 	switch process {
 	case "ptp4l":
-		// If output doesn't exist we add it for the prometheus exporter
 		if configOpts != nil {
 			if !strings.Contains(*configOpts, "-m") {
 				glog.Info("adding -m to print messages to stdout for ptp4l to use prometheus exporter")
@@ -719,24 +718,17 @@ func addFlagsForMonitor(process string, configOpts *string, conf *Ptp4lConf, std
 			}
 		}
 	case "phc2sys":
-		// If output doesn't exist we add it for the prometheus exporter
 		if configOpts != nil && *configOpts != "" {
 			if !strings.Contains(*configOpts, "-m") {
 				glog.Info("adding -m to print messages to stdout for phc2sys to use prometheus exporter")
 				*configOpts = fmt.Sprintf("%s -m", *configOpts)
 			}
-			// stdoutToSocket is for sidecar to consume events, -u  will not generate logs with offset and clock state.
-			// disable -u for  events
-			if stdoutToSocket && strings.Contains(*configOpts, "-u") {
-				glog.Error("-u option will not generate clock state events,  remove -u option")
-			} else if !stdoutToSocket && !strings.Contains(*configOpts, "-u") {
-				glog.Info("adding -u 1 to print summary messages to stdout for phc2sys to use prometheus exporter")
-				*configOpts = fmt.Sprintf("%s -u 1", *configOpts)
+			if strings.Contains(*configOpts, "-u") {
+				glog.Error("-u option will not generate clock state events, remove -u option")
 			}
 		}
 	case "ts2phc":
 	}
-
 }
 
 // StartMetricsServer runs the prometheus listner so that metrics can be collected

--- a/pkg/daemon/pmc.go
+++ b/pkg/daemon/pmc.go
@@ -32,6 +32,7 @@ func NewPMCProcess(runID int, eventHandler *event.EventHandler, clockType string
 		parentDSCh:           make(chan protocol.ParentDataSet, 10),
 		eventHandler:         eventHandler,
 		clockType:            clockType,
+		outSocketPath:        eventSocket,
 		getMonitorFn:         pmcPkg.GetPMCMontior,
 		runPMCExpGetParentDS: pmcPkg.RunPMCExpGetParentDS,
 	}
@@ -50,6 +51,7 @@ type PMCProcess struct {
 	parentDSCh        chan protocol.ParentDataSet
 	exitCh            chan struct{}
 	clockType         string
+	outSocketPath     string
 	c                 net.Conn // guarded by lock
 	messageTag        string
 	eventHandler      *event.EventHandler
@@ -146,8 +148,17 @@ func (pmc *PMCProcess) EmitClockClassLogs() {
 	go pmc.eventHandler.EmitClockClass(pmc.configFileName)
 }
 
+func (pmc *PMCProcess) dialSocket() (net.Conn, error) {
+	c, err := net.DialTimeout("unix", pmc.outSocketPath, socketDialTimeout)
+	if err != nil {
+		glog.Errorf("error trying to connect to event socket")
+		time.Sleep(connectionRetryInterval)
+	}
+	return c, err
+}
+
 // CmdRun starts the PMC monitoring process.
-func (pmc *PMCProcess) CmdRun(stdToSocket bool) {
+func (pmc *PMCProcess) CmdRun() {
 	isStopped := pmc.getAndSetStopped(false)
 	if isStopped {
 		return
@@ -160,13 +171,12 @@ func (pmc *PMCProcess) CmdRun(stdToSocket bool) {
 				return
 			}
 
-			var c net.Conn
-			if stdToSocket {
-				cAttempt, dialErr := dialSocket()
-				for dialErr != nil {
-					cAttempt, dialErr = dialSocket()
+			c, dialErr := pmc.dialSocket()
+			for dialErr != nil {
+				if pmc.Stopped() {
+					return
 				}
-				c = cAttempt
+				c, dialErr = pmc.dialSocket()
 			}
 			monitorErr := pmc.Monitor(c)
 			if monitorErr == nil && pmc.Stopped() {

--- a/pkg/daemon/pmc_internal_test.go
+++ b/pkg/daemon/pmc_internal_test.go
@@ -1,22 +1,62 @@
 package daemon
 
 import (
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+
 	expect "github.com/google/goexpect"
 	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/protocol"
 )
 
+// startTestSocket creates a Unix socket listener at a temp path and accepts
+// connections in the background. Returns the socket path and a cleanup function.
+func startTestSocket(t *testing.T) (string, func()) {
+	t.Helper()
+	sockPath := filepath.Join(t.TempDir(), "test.sock")
+	ln, err := net.Listen("unix", sockPath)
+	if err != nil {
+		t.Fatalf("failed to create test socket: %v", err)
+	}
+	go func() {
+		for {
+			conn, acceptErr := ln.Accept()
+			if acceptErr != nil {
+				return
+			}
+			go func(c net.Conn) {
+				buf := make([]byte, 1024)
+				for {
+					if _, readErr := c.Read(buf); readErr != nil {
+						return
+					}
+				}
+			}(conn)
+		}
+	}()
+	return sockPath, func() {
+		ln.Close()
+		os.Remove(sockPath)
+	}
+}
+
 // NewTestPMCProcess creates a PMCProcess with injectable dependencies for testing.
 func NewTestPMCProcess(
+	t *testing.T,
 	configFileName, clockType string,
 	getMonitorFn func(string) (*expect.GExpect, <-chan error, error),
 	pollFn func(string, bool) (protocol.ParentDataSet, error),
 ) *PMCProcess {
+	sockPath, cleanup := startTestSocket(t)
+	t.Cleanup(cleanup)
 	return &PMCProcess{
 		configFileName:       configFileName,
 		messageTag:           "[" + configFileName + ":{level}]",
 		monitorParentData:    true,
 		parentDSCh:           make(chan protocol.ParentDataSet, 10),
 		clockType:            clockType,
+		outSocketPath:        sockPath,
 		exitCh:               make(chan struct{}, 1),
 		getMonitorFn:         getMonitorFn,
 		runPMCExpGetParentDS: pollFn,

--- a/pkg/daemon/pmc_test.go
+++ b/pkg/daemon/pmc_test.go
@@ -104,10 +104,10 @@ func waitFor(t *testing.T, timeout time.Duration, desc string, cond func() bool)
 
 func TestMonitorExitsViaCmdStop(t *testing.T) {
 	mock := newTestPMCMonitor(t, 50)
-	pmc := daemon.NewTestPMCProcess("test.config", "T-BC", mock.getMonitor, mock.poll)
+	pmc := daemon.NewTestPMCProcess(t, "test.config", "T-BC", mock.getMonitor, mock.poll)
 	mock.pmc = pmc
 
-	pmc.CmdRun(false)
+	pmc.CmdRun()
 
 	waitFor(t, 5*time.Second, "poll called at least once", func() bool {
 		return mock.pollCount.Load() > 0
@@ -122,10 +122,10 @@ func TestMonitorExitsViaCmdStop(t *testing.T) {
 
 func TestMonitorNoOrphanAfterProcessDeath(t *testing.T) {
 	mock := newTestPMCMonitor(t, 50)
-	pmc := daemon.NewTestPMCProcess("test.config", "T-BC", mock.getMonitor, mock.poll)
+	pmc := daemon.NewTestPMCProcess(t, "test.config", "T-BC", mock.getMonitor, mock.poll)
 	mock.pmc = pmc
 
-	pmc.CmdRun(false)
+	pmc.CmdRun()
 
 	waitFor(t, 5*time.Second, "poll called at least once", func() bool {
 		return mock.pollCount.Load() > 0
@@ -158,10 +158,10 @@ func TestMonitorNoOrphanAfterProcessDeath(t *testing.T) {
 
 func TestCmdStopIdempotent(t *testing.T) {
 	mock := newTestPMCMonitor(t, 50)
-	pmc := daemon.NewTestPMCProcess("test.config", "T-BC", mock.getMonitor, mock.poll)
+	pmc := daemon.NewTestPMCProcess(t, "test.config", "T-BC", mock.getMonitor, mock.poll)
 	mock.pmc = pmc
 
-	pmc.CmdRun(false)
+	pmc.CmdRun()
 
 	waitFor(t, 5*time.Second, "poll called at least once", func() bool {
 		return mock.pollCount.Load() > 0
@@ -178,7 +178,7 @@ func TestCmdStopIdempotent(t *testing.T) {
 
 func TestCmdStopBeforeCmdRun(t *testing.T) {
 	mock := newTestPMCMonitor(t, 50)
-	pmc := daemon.NewTestPMCProcess("test.config", "T-BC", mock.getMonitor, mock.poll)
+	pmc := daemon.NewTestPMCProcess(t, "test.config", "T-BC", mock.getMonitor, mock.poll)
 	mock.pmc = pmc
 
 	pmc.CmdStop()
@@ -188,7 +188,7 @@ func TestCmdStopBeforeCmdRun(t *testing.T) {
 	}
 
 	// CmdRun after CmdStop should return early without starting monitoring
-	pmc.CmdRun(false)
+	pmc.CmdRun()
 
 	time.Sleep(500 * time.Millisecond)
 

--- a/pkg/daemon/process.go
+++ b/pkg/daemon/process.go
@@ -12,7 +12,7 @@ type process interface {
 	CmdStop()
 	CmdInit()
 	ProcessStatus(c net.Conn, status int64)
-	CmdRun(stdToSocket bool)
+	CmdRun()
 	MonitorProcess(p config.ProcessConfig)
 	ExitCh() chan struct{}
 }

--- a/pkg/daemon/ready.go
+++ b/pkg/daemon/ready.go
@@ -111,14 +111,12 @@ func (h portAliasesHandler) ServeHTTP(w http.ResponseWriter, _ *http.Request) {
 }
 
 // StartReadyServer ...
-func StartReadyServer(bindAddress string, tracker *ReadyTracker, serveInitMetrics bool) {
+func StartReadyServer(bindAddress string, tracker *ReadyTracker) {
 	glog.Info("Starting Ready Server")
 	mux := http.NewServeMux()
 	mux.Handle("/ready", readyHandler{tracker: tracker})
 	mux.Handle("/port-aliases", portAliasesHandler{})
-	if serveInitMetrics {
-		mux.Handle("/emit-logs", metricHandler{tracker: tracker})
-	}
+	mux.Handle("/emit-logs", metricHandler{tracker: tracker})
 	go utilwait.Until(func() {
 		err := http.ListenAndServe(bindAddress, mux)
 		if err != nil {

--- a/pkg/dpll/dpll.go
+++ b/pkg/dpll/dpll.go
@@ -360,7 +360,7 @@ func (d *DpllConfig) ProcessStatus(_ net.Conn, _ int64) {
 }
 
 // CmdRun ... run command
-func (d *DpllConfig) CmdRun(stdToSocket bool) {
+func (d *DpllConfig) CmdRun() {
 	// noting to run, monitor() function takes care of dpll run
 }
 

--- a/pkg/dpll/dpll_test.go
+++ b/pkg/dpll/dpll_test.go
@@ -183,7 +183,7 @@ func TestDpllConfig_MonitorProcessGNSS(t *testing.T) {
 	eChannel := make(chan event.EventChannel, 10)
 	closeChn := make(chan bool)
 	// event has to be running before dpll is started
-	eventProcessor := event.Init("node", false, "/tmp/go.sock", eChannel, closeChn, nil, nil, nil)
+	eventProcessor := event.Init("node", "/tmp/go.sock", eChannel, closeChn, nil, nil, nil)
 	d := dpll.NewDpll(clockid, 10, 2, 5, "ens01",
 		[]event.EventSource{event.GNSS}, dpll.MOCK, map[string]map[string]string{}, 0, 0, 0)
 	d.CmdInit()
@@ -226,7 +226,7 @@ func TestDpllConfig_MonitorProcessPPS(t *testing.T) {
 	eChannel := make(chan event.EventChannel, 10)
 	closeChn := make(chan bool)
 	// event has to be running before dpll is started
-	eventProcessor := event.Init("node", false, "/tmp/go.sock", eChannel, closeChn, nil, nil, nil)
+	eventProcessor := event.Init("node", "/tmp/go.sock", eChannel, closeChn, nil, nil, nil)
 	d := dpll.NewDpll(clockid, 10, 2, 5, "ens01",
 		[]event.EventSource{event.GNSS}, dpll.MOCK, map[string]map[string]string{}, 0, 0, 0)
 	d.CmdInit()
@@ -267,7 +267,7 @@ func TestDpllConfig_MonitorProcessPartial(t *testing.T) {
 	eChannel := make(chan event.EventChannel, 10)
 	closeChn := make(chan bool)
 	// event has to be running before dpll is started
-	eventProcessor := event.Init("node", false, "/tmp/go.sock", eChannel, closeChn, nil, nil, nil)
+	eventProcessor := event.Init("node", "/tmp/go.sock", eChannel, closeChn, nil, nil, nil)
 	d := dpll.NewDpll(clockid, 10, 2, 5, "ens01",
 		[]event.EventSource{event.GNSS}, dpll.MOCK, map[string]map[string]string{}, 0, 0, dpll.FlagOnlyPhaseStatus)
 	d.CmdInit()

--- a/pkg/event/event.go
+++ b/pkg/event/event.go
@@ -173,7 +173,6 @@ type EventHandler struct {
 	sync.Mutex
 	nodeName           string
 	stdoutSocket       string
-	stdoutToSocket     bool
 	processChannel     <-chan EventChannel
 	closeCh            chan bool
 	conn               net.Conn   // event socket connection, guarded by connMu
@@ -241,12 +240,11 @@ func (e *EventHandler) MockEnable() {
 }
 
 // Init ... initialize event manager
-func Init(nodeName string, stdOutToSocket bool, socketName string, processChannel chan EventChannel, closeCh chan bool,
+func Init(nodeName string, socketName string, processChannel chan EventChannel, closeCh chan bool,
 	offsetMetric *prometheus.GaugeVec, clockMetric *prometheus.GaugeVec, clockClassMetric *prometheus.GaugeVec) *EventHandler {
 	ptpEvent := &EventHandler{
 		nodeName:           nodeName,
 		stdoutSocket:       socketName,
-		stdoutToSocket:     stdOutToSocket,
 		closeCh:            closeCh,
 		processChannel:     processChannel,
 		data:               map[string][]*Data{},
@@ -650,17 +648,11 @@ func (e *EventHandler) storeClockClassLocked(cfgName string, clockClass fbprotoc
 	e.clkSyncState[cfgName].clockAccuracy = clockAcc
 }
 
-// emitClockClass writes the clock class to the socket and updates the metric.
+// emitClockClass writes the clock class to the socket.
 // Must NOT be called while holding e.Lock().
 func (e *EventHandler) emitClockClass(clockClass fbprotocol.ClockClass, cfgName string) {
-	if e.stdoutToSocket {
-		logMsg := utils.GetClockClassLogMessage(PTP4lProcessName, cfgName, clockClass)
-		e.writeLogToSocket(logMsg)
-	}
-	if !e.stdoutToSocket && e.clockClassMetric != nil {
-		e.clockClassMetric.With(prometheus.Labels{
-			"process": PTP4lProcessName, "config": cfgName, "node": e.nodeName}).Set(float64(clockClass))
-	}
+	logMsg := utils.GetClockClassLogMessage(PTP4lProcessName, cfgName, clockClass)
+	e.writeLogToSocket(logMsg)
 }
 
 // reconnectEventSocket closes the current connection and dials a new one using
@@ -759,25 +751,19 @@ func (e *EventHandler) ProcessEvents() {
 	redialClockClass := true
 
 	defer func() {
-		if e.stdoutToSocket {
-			e.setConn(nil) // closes the connection if present
-		}
+		e.setConn(nil) // closes the connection if present
 	}()
 	var lastClockState PTPState
 
 	// Establish initial connection to the event socket using exponential backoff.
 	// Retries indefinitely until connected or the handler is shutting down.
-	if e.stdoutToSocket {
-		for !e.reconnectEventSocket() {
-			// reconnectEventSocket returns false on shutdown or exhausted retries;
-			// check for shutdown before retrying
-			select {
-			case <-e.closeCh:
-				return
-			default:
-				glog.Warning("Initial connection to event socket failed, retrying in 1 second...")
-				time.Sleep(1 * time.Second)
-			}
+	for !e.reconnectEventSocket() {
+		select {
+		case <-e.closeCh:
+			return
+		default:
+			glog.Warning("Initial connection to event socket failed, retrying in 1 second...")
+			time.Sleep(1 * time.Second)
 		}
 	}
 
@@ -897,13 +883,9 @@ func (e *EventHandler) ProcessEvents() {
 			var logOut []string
 			logDataValues := ""
 			if event.ProcessName == SYNCE {
-				// Update the metrics
 				logDataValues = event.GetLogData()
 				if event.WriteToLog && logDataValues != "" {
 					logOut = append(logOut, logDataValues)
-				}
-				if !e.stdoutToSocket {
-					e.UpdateClockStateMetrics(event.State, string(event.ProcessName), event.IFace)
 				}
 			} else {
 
@@ -961,17 +943,6 @@ func (e *EventHandler) ProcessEvents() {
 					logOut = append(logOut, clockState.clkLog)
 				}
 
-				// Update the metrics
-				if !e.stdoutToSocket { // if events not enabled
-					e.UpdateClockStateMetrics(event.State, string(event.ProcessName), alias.GetAlias(event.IFace))
-					//  update all metric that was sent to events
-					e.updateMetrics(event.CfgName, event.ProcessName, event.Values, dataDetails)
-
-					e.updateMetrics(event.CfgName, event.ProcessName, event.Values, dataDetails)
-					if clockState.leadingIFace != LEADING_INTERFACE_UNKNOWN { // race condition ;
-						e.UpdateClockStateMetrics(clockState.state, string(event.ClockType), alias.GetAlias(clockState.leadingIFace))
-					}
-				}
 				if event.ClockType == GM {
 					// Default Assignment: The clockAccuracy of clockState is initially set to the clockAccuracy of the event
 					//This serves as a default value.
@@ -1024,21 +995,18 @@ func (e *EventHandler) ProcessEvents() {
 			} // Not SYNC-E
 
 			if len(logOut) > 0 {
-				// Always print all logs to stdout regardless of socket state
 				for _, l := range logOut {
 					fmt.Printf("%s", l)
 				}
-				if e.stdoutToSocket {
-					if e.getConn() == nil {
-						glog.Error("No connection available, attempting reconnect")
-						if !e.reconnectEventSocket() {
-							glog.Warning("Reconnect failed, skipping socket writes; will retry on next event")
-						}
+				if e.getConn() == nil {
+					glog.Error("No connection available, attempting reconnect")
+					if !e.reconnectEventSocket() {
+						glog.Warning("Reconnect failed, skipping socket writes; will retry on next event")
 					}
-					for _, l := range logOut {
-						if !e.writeLogToSocket(l) {
-							break
-						}
+				}
+				for _, l := range logOut {
+					if !e.writeLogToSocket(l) {
+						break
 					}
 				}
 			}
@@ -1126,10 +1094,10 @@ func (e *EventHandler) GetPTPState(source EventSource, cfgName string) PTPState 
 
 // UpdateClockStateMetrics ...
 func (e *EventHandler) UpdateClockStateMetrics(state PTPState, process, iFace string) {
-	if !utils.CheckMetricSanity("ClockState", process, iFace) {
+	if e.clockMetric == nil {
 		return
 	}
-	if e.stdoutToSocket {
+	if !utils.CheckMetricSanity("ClockState", process, iFace) {
 		return
 	}
 	labels := prometheus.Labels{
@@ -1146,6 +1114,9 @@ func (e *EventHandler) UpdateClockStateMetrics(state PTPState, process, iFace st
 }
 
 func (e *EventHandler) updateMetrics(cfgName string, process EventSource, processData map[ValueType]interface{}, d *DataDetails) {
+	if e.offsetMetric == nil {
+		return
+	}
 	iface := alias.GetAlias(d.IFace)
 
 	for dataType, value := range processData { // update process with metrics
@@ -1226,9 +1197,6 @@ func registerMetrics(m *prometheus.GaugeVec) {
 }
 
 func (e *EventHandler) unregisterMetrics(configName string, processName string) {
-	if e.stdoutToSocket {
-		return // no need to unregister metrics if events are going to socket
-	}
 	if data, ok := e.data[configName]; ok {
 		for _, v := range data {
 			if string(v.ProcessName) == processName || processName == "" {
@@ -1290,12 +1258,7 @@ func (e *EventHandler) UpdateClockClass(clk ClockClassRequest) {
 		e.storeClockClassLocked(clk.cfgName, clockClass, clockAccuracy)
 		e.Unlock()
 		clockClassOut := utils.GetClockClassLogMessage(PTP4lProcessName, clk.cfgName, clockClass)
-		if e.stdoutToSocket {
-			e.writeLogToSocket(clockClassOut)
-		} else if e.clockClassMetric != nil {
-			e.clockClassMetric.With(prometheus.Labels{
-				"process": PTP4lProcessName, "config": clk.cfgName, "node": e.nodeName}).Set(float64(clockClass))
-		}
+		e.writeLogToSocket(clockClassOut)
 		fmt.Printf("%s", clockClassOut)
 	}
 }

--- a/pkg/event/event_socket_test.go
+++ b/pkg/event/event_socket_test.go
@@ -19,10 +19,9 @@ import (
 // newTestEventHandler creates a minimal EventHandler for testing socket logic.
 func newTestEventHandler(socketPath string) *EventHandler {
 	return &EventHandler{
-		stdoutSocket:   socketPath,
-		stdoutToSocket: true,
-		closeCh:        make(chan bool, 1),
-		clkSyncState:   map[string]*clockSyncState{},
+		stdoutSocket: socketPath,
+		closeCh:      make(chan bool, 1),
+		clkSyncState: map[string]*clockSyncState{},
 	}
 }
 

--- a/pkg/event/event_test.go
+++ b/pkg/event/event_test.go
@@ -306,7 +306,7 @@ func TestEventHandler_ProcessEvents(t *testing.T) {
 	eChannel := make(chan event.EventChannel, 100)
 	closeChn := make(chan bool)
 	go listenToEvents(closeChn, logOut)
-	eventManager := event.Init("node", true, "/tmp/go.sock", eChannel, closeChn, nil, nil, nil)
+	eventManager := event.Init("node", "/tmp/go.sock", eChannel, closeChn, nil, nil, nil)
 	eventManager.MockEnable()
 	go eventManager.ProcessEvents()
 	assert.NoError(t, leap.MockLeapFile())


### PR DESCRIPTION
The daemon previously supported two modes: with or without the cloud-event-proxy sidecar, controlled by the LOGS_TO_SOCKET env var and stdoutToSocket flag. In practice, cloud-event-proxy is always deployed, resulting in the maintenance of two major deployment methods for little gain. By removing the flag, the code execution flow is cleaned up, and the code as a whole becomes easier to parse.