### PR TITLE
Abstract PMC I/O behind a package-level mockable client

### DIFF
--- a/pkg/daemon/pmc.go
+++ b/pkg/daemon/pmc.go
@@ -26,14 +26,13 @@ const (
 // NewPMCProcess creates a new PMC process instance for monitoring PTP events.
 func NewPMCProcess(runID int, eventHandler *event.EventHandler, clockType string) *PMCProcess {
 	return &PMCProcess{
-		configFileName:       fmt.Sprintf("ptp4l.%d.config", runID),
-		messageTag:           fmt.Sprintf("[ptp4l.%d.config:{level}]", runID),
-		monitorParentData:    true,
-		parentDSCh:           make(chan protocol.ParentDataSet, 10),
-		eventHandler:         eventHandler,
-		clockType:            clockType,
-		getMonitorFn:         pmcPkg.GetPMCMontior,
-		runPMCExpGetParentDS: pmcPkg.RunPMCExpGetParentDS,
+		configFileName:    fmt.Sprintf("ptp4l.%d.config", runID),
+		messageTag:        fmt.Sprintf("[ptp4l.%d.config:{level}]", runID),
+		monitorParentData: true,
+		parentDSCh:        make(chan protocol.ParentDataSet, 10),
+		eventHandler:      eventHandler,
+		clockType:         clockType,
+		getMonitorFn:      pmcPkg.GetPMCMontior,
 	}
 }
 
@@ -54,8 +53,7 @@ type PMCProcess struct {
 	messageTag        string
 	eventHandler      *event.EventHandler
 
-	getMonitorFn         func(string) (*expect.GExpect, <-chan error, error)
-	runPMCExpGetParentDS func(string, bool) (protocol.ParentDataSet, error)
+	getMonitorFn func(string) (*expect.GExpect, <-chan error, error)
 }
 
 // getConn returns the current socket connection under lock.
@@ -190,7 +188,7 @@ func (pmc *PMCProcess) Poll() {
 	default:
 	}
 
-	parentDS, err := pmc.runPMCExpGetParentDS(pmc.configFileName, false)
+	parentDS, err := pmcPkg.GetParentDS(pmc.configFileName)
 	if err != nil {
 		glog.Error("pmc poll failure ", err)
 		return

--- a/pkg/daemon/pmc_internal_test.go
+++ b/pkg/daemon/pmc_internal_test.go
@@ -9,16 +9,14 @@ import (
 func NewTestPMCProcess(
 	configFileName, clockType string,
 	getMonitorFn func(string) (*expect.GExpect, <-chan error, error),
-	pollFn func(string, bool) (protocol.ParentDataSet, error),
 ) *PMCProcess {
 	return &PMCProcess{
-		configFileName:       configFileName,
-		messageTag:           "[" + configFileName + ":{level}]",
-		monitorParentData:    true,
-		parentDSCh:           make(chan protocol.ParentDataSet, 10),
-		clockType:            clockType,
-		exitCh:               make(chan struct{}, 1),
-		getMonitorFn:         getMonitorFn,
-		runPMCExpGetParentDS: pollFn,
+		configFileName:    configFileName,
+		messageTag:        "[" + configFileName + ":{level}]",
+		monitorParentData: true,
+		parentDSCh:        make(chan protocol.ParentDataSet, 10),
+		clockType:         clockType,
+		exitCh:            make(chan struct{}, 1),
+		getMonitorFn:      getMonitorFn,
 	}
 }

--- a/pkg/daemon/pmc_test.go
+++ b/pkg/daemon/pmc_test.go
@@ -9,6 +9,7 @@ import (
 
 	expect "github.com/google/goexpect"
 	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/daemon"
+	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/pmc"
 	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/protocol"
 )
 
@@ -18,7 +19,7 @@ type discardWriteCloser struct{}
 func (discardWriteCloser) Write(p []byte) (int, error) { return len(p), nil }
 func (discardWriteCloser) Close() error                { return nil }
 
-// testPMCMonitor provides mock getMonitor and poll functions for PMCProcess tests.
+// testPMCMonitor provides mock getMonitor and a MockClient for PMCProcess tests.
 type testPMCMonitor struct {
 	t         *testing.T
 	killCh    chan struct{}
@@ -26,15 +27,24 @@ type testPMCMonitor struct {
 	calls     atomic.Int32
 	pmc       *daemon.PMCProcess
 	maxPolls  int32
+	mock      *pmc.MockClient
 }
 
 //nolint:unparam
 func newTestPMCMonitor(t *testing.T, maxPolls int32) *testPMCMonitor {
-	return &testPMCMonitor{
+	m := &testPMCMonitor{
 		t:        t,
 		killCh:   make(chan struct{}),
 		maxPolls: maxPolls,
 	}
+	m.mock = &pmc.MockClient{
+		ParentDSErr: fmt.Errorf("test: poll disabled"),
+	}
+	return m
+}
+
+func (m *testPMCMonitor) client() pmc.Client {
+	return &countingPMCClient{MockClient: m.mock, monitor: m}
 }
 
 func (m *testPMCMonitor) getMonitor(_ string) (*expect.GExpect, <-chan error, error) {
@@ -79,13 +89,19 @@ func (m *testPMCMonitor) getMonitor(_ string) (*expect.GExpect, <-chan error, er
 	return exp, errCh, nil
 }
 
-func (m *testPMCMonitor) poll(_ string, _ bool) (protocol.ParentDataSet, error) {
-	count := m.pollCount.Add(1)
-	if count > m.maxPolls {
-		m.t.Errorf("runaway detected: poll called %d times, orphaned expectWorker spinning", count)
-		m.pmc.CmdStop()
+// countingPMCClient wraps a MockClient and counts GetParentDS calls to detect runaway polling.
+type countingPMCClient struct {
+	*pmc.MockClient
+	monitor *testPMCMonitor
+}
+
+func (c *countingPMCClient) GetParentDS(cfgName string) (protocol.ParentDataSet, error) {
+	count := c.monitor.pollCount.Add(1)
+	if count > c.monitor.maxPolls {
+		c.monitor.t.Errorf("runaway detected: poll called %d times, orphaned expectWorker spinning", count)
+		c.monitor.pmc.CmdStop()
 	}
-	return protocol.ParentDataSet{}, fmt.Errorf("test: poll disabled")
+	return c.MockClient.GetParentDS(cfgName)
 }
 
 //nolint:unparam
@@ -104,28 +120,32 @@ func waitFor(t *testing.T, timeout time.Duration, desc string, cond func() bool)
 
 func TestMonitorExitsViaCmdStop(t *testing.T) {
 	mock := newTestPMCMonitor(t, 50)
-	pmc := daemon.NewTestPMCProcess("test.config", "T-BC", mock.getMonitor, mock.poll)
-	mock.pmc = pmc
+	pmc.SetMock(mock.client())
+	defer pmc.ResetMock()
+	proc := daemon.NewTestPMCProcess("test.config", "T-BC", mock.getMonitor)
+	mock.pmc = proc
 
-	pmc.CmdRun(false)
+	proc.CmdRun(false)
 
 	waitFor(t, 5*time.Second, "poll called at least once", func() bool {
 		return mock.pollCount.Load() > 0
 	})
 
-	pmc.CmdStop()
+	proc.CmdStop()
 
 	waitFor(t, 5*time.Second, "process stopped", func() bool {
-		return pmc.Stopped()
+		return proc.Stopped()
 	})
 }
 
 func TestMonitorNoOrphanAfterProcessDeath(t *testing.T) {
 	mock := newTestPMCMonitor(t, 50)
-	pmc := daemon.NewTestPMCProcess("test.config", "T-BC", mock.getMonitor, mock.poll)
-	mock.pmc = pmc
+	pmc.SetMock(mock.client())
+	defer pmc.ResetMock()
+	proc := daemon.NewTestPMCProcess("test.config", "T-BC", mock.getMonitor)
+	mock.pmc = proc
 
-	pmc.CmdRun(false)
+	proc.CmdRun(false)
 
 	waitFor(t, 5*time.Second, "poll called at least once", func() bool {
 		return mock.pollCount.Load() > 0
@@ -150,45 +170,48 @@ func TestMonitorNoOrphanAfterProcessDeath(t *testing.T) {
 			delta, countAfterKill, countFinal)
 	}
 
-	pmc.CmdStop()
+	proc.CmdStop()
 	waitFor(t, 5*time.Second, "process stopped", func() bool {
-		return pmc.Stopped()
+		return proc.Stopped()
 	})
 }
 
 func TestCmdStopIdempotent(t *testing.T) {
 	mock := newTestPMCMonitor(t, 50)
-	pmc := daemon.NewTestPMCProcess("test.config", "T-BC", mock.getMonitor, mock.poll)
-	mock.pmc = pmc
+	pmc.SetMock(mock.client())
+	defer pmc.ResetMock()
+	proc := daemon.NewTestPMCProcess("test.config", "T-BC", mock.getMonitor)
+	mock.pmc = proc
 
-	pmc.CmdRun(false)
+	proc.CmdRun(false)
 
 	waitFor(t, 5*time.Second, "poll called at least once", func() bool {
 		return mock.pollCount.Load() > 0
 	})
 
-	pmc.CmdStop()
-	pmc.CmdStop()
-	pmc.CmdStop()
+	proc.CmdStop()
+	proc.CmdStop()
+	proc.CmdStop()
 
 	waitFor(t, 5*time.Second, "process stopped", func() bool {
-		return pmc.Stopped()
+		return proc.Stopped()
 	})
 }
 
 func TestCmdStopBeforeCmdRun(t *testing.T) {
 	mock := newTestPMCMonitor(t, 50)
-	pmc := daemon.NewTestPMCProcess("test.config", "T-BC", mock.getMonitor, mock.poll)
-	mock.pmc = pmc
+	pmc.SetMock(mock.client())
+	defer pmc.ResetMock()
+	proc := daemon.NewTestPMCProcess("test.config", "T-BC", mock.getMonitor)
+	mock.pmc = proc
 
-	pmc.CmdStop()
+	proc.CmdStop()
 
-	if !pmc.Stopped() {
+	if !proc.Stopped() {
 		t.Error("expected process to be stopped after CmdStop")
 	}
 
-	// CmdRun after CmdStop should return early without starting monitoring
-	pmc.CmdRun(false)
+	proc.CmdRun(false)
 
 	time.Sleep(500 * time.Millisecond)
 

--- a/pkg/event/event.go
+++ b/pkg/event/event.go
@@ -79,19 +79,6 @@ var (
 	//  make sure only one clock class update is tried if it fails next  try will pass
 	// this will also stop flooding
 	clockClassRequestCh = make(chan ClockClassRequest, 1)
-
-	PMCGMGetter = func(cfgName string) (protocol.GrandmasterSettings, error) {
-		cfgName = strings.Replace(cfgName, TS2PHCProcessName, PTP4lProcessName, 1)
-		return pmc.RunPMCExpGetGMSettings(cfgName)
-	}
-	PMCGMSetter = func(cfgName string, g protocol.GrandmasterSettings) error {
-		cfgName = strings.Replace(cfgName, TS2PHCProcessName, PTP4lProcessName, 1)
-		err := pmc.RunPMCExpSetGMSettings(cfgName, g)
-		if err != nil {
-			return fmt.Errorf("failed to update GRANDMASTER_SETTINGS_NP: %s", err)
-		}
-		return nil
-	}
 )
 
 const (
@@ -1277,8 +1264,19 @@ func (e *EventHandler) addEvent(event EventChannel) *DataDetails {
 
 // UpdateClockClass ... update clock class
 func (e *EventHandler) UpdateClockClass(clk ClockClassRequest) {
+	getter := func(cfgName string) (protocol.GrandmasterSettings, error) {
+		cfgName = strings.Replace(cfgName, TS2PHCProcessName, PTP4lProcessName, 1)
+		return pmc.GetGMSettings(cfgName)
+	}
+	setter := func(cfgName string, g protocol.GrandmasterSettings) error {
+		cfgName = strings.Replace(cfgName, TS2PHCProcessName, PTP4lProcessName, 1)
+		if err := pmc.SetGMSettings(cfgName, g); err != nil {
+			return fmt.Errorf("failed to update GRANDMASTER_SETTINGS_NP: %s", err)
+		}
+		return nil
+	}
 	classErr, clockClass, clockAccuracy := e.updateClockClass(clk.cfgName, clk.clockClass, clk.clockType, clk.clockAccuracy,
-		PMCGMGetter, PMCGMSetter)
+		getter, setter)
 	glog.Infof("received %s,%v,%s,%v", clk.cfgName, clk.clockClass, clk.clockType, clk.clockAccuracy)
 	if classErr != nil {
 		glog.Errorf("error updating clock class %s", classErr)

--- a/pkg/event/event_tbc.go
+++ b/pkg/event/event_tbc.go
@@ -327,7 +327,7 @@ func (e *EventHandler) announceLocalData(cfgName string) {
 	}
 	glog.Infof("EGP %++v", egp)
 	go func() {
-		if err := pmc.RunPMCExpSetExternalGMPropertiesNP(controlledPortsConfig, egp); err != nil {
+		if err := pmc.SetExternalGMPropertiesNP(controlledPortsConfig, egp); err != nil {
 			glog.Errorf("Failed to set external GM properties: %v", err)
 		}
 	}()
@@ -373,12 +373,12 @@ func (e *EventHandler) announceLocalData(cfgName string) {
 	default:
 	}
 	go func() {
-		if err := pmc.RunPMCExpSetGMSettings(controlledPortsConfig, gs); err != nil {
+		if err := pmc.SetGMSettings(controlledPortsConfig, gs); err != nil {
 			glog.Errorf("Failed to set GM settings: %v", err)
 		}
 	}()
 	go func() {
-		if err := pmc.RunPMCExpSetGMSettings(cfgName, gs); err != nil {
+		if err := pmc.SetGMSettings(cfgName, gs); err != nil {
 			glog.Errorf("Failed to set GM settings: %v", err)
 		}
 	}()
@@ -413,7 +413,7 @@ func (e *EventHandler) downstreamAnnounceIWF(ctx context.Context, cfgName string
 	controlledPortsConfig := e.LeadingClockData.controlledPortsConfig
 	e.Unlock()
 
-	upsteamData, fetchErr := pmc.RunPMCExpGetParentTimeAndCurrentDataSets(cfgName)
+	upsteamData, fetchErr := pmc.GetParentTimeAndCurrentDS(cfgName)
 	if fetchErr != nil {
 		glog.Error("Failed to fetch upstream data, downstream data can not be updated.")
 		return
@@ -452,10 +452,10 @@ func (e *EventHandler) downstreamAnnounceIWF(ctx context.Context, cfgName string
 	}
 	glog.Infof("%++v", es)
 	e.announceClockClass(gs.ClockQuality.ClockClass, gs.ClockQuality.ClockAccuracy, cfgName)
-	if err := pmc.RunPMCExpSetExternalGMPropertiesNP(controlledPortsConfig, es); err != nil {
+	if err := pmc.SetExternalGMPropertiesNP(controlledPortsConfig, es); err != nil {
 		glog.Error(err)
 	}
-	if err := pmc.RunPMCExpSetGMSettings(controlledPortsConfig, gs); err != nil {
+	if err := pmc.SetGMSettings(controlledPortsConfig, gs); err != nil {
 		glog.Error(err)
 	}
 	glog.Infof("%++v", es)

--- a/pkg/event/event_tbc_pmc_test.go
+++ b/pkg/event/event_tbc_pmc_test.go
@@ -1,0 +1,467 @@
+package event
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	fbprotocol "github.com/facebook/time/ptp/protocol"
+	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/leap"
+	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/pmc"
+	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/protocol"
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	testControlledCfg = "ptp4l.1.config"
+	testCfgName       = "ts2phc.0.config"
+)
+
+var leapOnce sync.Once
+
+func ensureLeapMocked(t *testing.T) {
+	t.Helper()
+	leapOnce.Do(func() {
+		if err := leap.MockLeapFile(); err != nil {
+			t.Fatalf("failed to mock leap file: %v", err)
+		}
+	})
+}
+
+func newPMCTestEventHandler() *EventHandler {
+	if StateRegisterer == nil {
+		StateRegisterer = NewStateNotifier()
+	}
+	return &EventHandler{
+		data:             map[string][]*Data{},
+		clkSyncState:     map[string]*clockSyncState{},
+		downstreamCancel: map[string]context.CancelFunc{},
+		LeadingClockData: newLeadingClockParams(),
+	}
+}
+
+func filterSetCalls(calls []pmc.SetCall, method string) []pmc.SetCall {
+	var out []pmc.SetCall
+	for _, c := range calls {
+		if c.Method == method {
+			out = append(out, c)
+		}
+	}
+	return out
+}
+
+// --- applyIfLockedBC ---
+
+func TestApplyIfLockedBC_LockedRunsFn(t *testing.T) {
+	e := newPMCTestEventHandler()
+	cfgName := testCfgName
+	e.clkSyncState[cfgName] = &clockSyncState{state: PTP_LOCKED}
+
+	called := false
+	ok := e.applyIfLockedBC(cfgName, "test", func() { called = true })
+
+	assert.True(t, ok)
+	assert.True(t, called)
+}
+
+func TestApplyIfLockedBC_NotLockedSkipsFn(t *testing.T) {
+	e := newPMCTestEventHandler()
+	cfgName := testCfgName
+	e.clkSyncState[cfgName] = &clockSyncState{state: PTP_FREERUN}
+
+	called := false
+	ok := e.applyIfLockedBC(cfgName, "test", func() { called = true })
+
+	assert.False(t, ok)
+	assert.False(t, called)
+}
+
+func TestApplyIfLockedBC_MissingConfigSkipsFn(t *testing.T) {
+	e := newPMCTestEventHandler()
+
+	called := false
+	ok := e.applyIfLockedBC("nonexistent", "test", func() { called = true })
+
+	assert.False(t, ok)
+	assert.False(t, called)
+}
+
+// --- announceLocalData ---
+
+func TestAnnounceLocalData_Freerun_SetsGMSettingsAndEGP(t *testing.T) {
+	ensureLeapMocked(t)
+	mock := &pmc.MockClient{}
+	pmc.SetMock(mock)
+	defer pmc.ResetMock()
+	e := newPMCTestEventHandler()
+	cfgName := testCfgName
+	e.LeadingClockData.clockID = "001122.fffe.334455"
+	e.LeadingClockData.controlledPortsConfig = testControlledCfg
+	e.clkSyncState[cfgName] = &clockSyncState{
+		state:      PTP_FREERUN,
+		clockClass: protocol.ClockClassFreerun,
+	}
+
+	e.announceLocalData(cfgName)
+
+	// 3 async goroutines: 1 EGP + 2 GM settings
+	if !assert.Eventually(t, func() bool {
+		return len(mock.SnapshotSetCalls()) >= 3
+	}, 1*time.Second, 10*time.Millisecond) {
+		return
+	}
+
+	egpCalls := filterSetCalls(mock.SnapshotSetCalls(), "SetExternalGMPropertiesNP")
+	if !assert.Len(t, egpCalls, 1) {
+		return
+	}
+	assert.Equal(t, testControlledCfg, egpCalls[0].CfgName)
+	assert.Equal(t, "001122.fffe.334455", egpCalls[0].ExternalGMPropertiesNP.GrandmasterIdentity)
+	assert.Equal(t, uint16(0), egpCalls[0].ExternalGMPropertiesNP.StepsRemoved)
+
+	gmCalls := filterSetCalls(mock.SnapshotSetCalls(), "SetGMSettings")
+	if !assert.Len(t, gmCalls, 2) {
+		return
+	}
+
+	configs := []string{gmCalls[0].CfgName, gmCalls[1].CfgName}
+	assert.Contains(t, configs, testControlledCfg)
+	assert.Contains(t, configs, cfgName)
+
+	for _, call := range gmCalls {
+		gs := call.GMSettings
+		if !assert.NotNil(t, gs) {
+			continue
+		}
+		assert.Equal(t, protocol.ClockClassFreerun, gs.ClockQuality.ClockClass)
+		assert.Equal(t, fbprotocol.ClockAccuracyUnknown, gs.ClockQuality.ClockAccuracy)
+		assert.True(t, gs.TimePropertiesDS.PtpTimescale)
+		assert.False(t, gs.TimePropertiesDS.TimeTraceable)
+		assert.False(t, gs.TimePropertiesDS.FrequencyTraceable)
+	}
+}
+
+func TestAnnounceLocalData_Holdover135_SetsTimeProperties(t *testing.T) {
+	mock := &pmc.MockClient{}
+	pmc.SetMock(mock)
+	defer pmc.ResetMock()
+	e := newPMCTestEventHandler()
+	cfgName := testCfgName
+	e.LeadingClockData.clockID = "aabbcc.fffe.ddeeff"
+	e.LeadingClockData.controlledPortsConfig = testControlledCfg
+	e.LeadingClockData.downstreamTimeProperties = &protocol.TimePropertiesDS{
+		CurrentUtcOffset:      37,
+		CurrentUtcOffsetValid: true,
+		Leap61:                true,
+	}
+	e.clkSyncState[cfgName] = &clockSyncState{
+		state:      PTP_HOLDOVER,
+		clockClass: fbprotocol.ClockClass(135),
+	}
+
+	e.announceLocalData(cfgName)
+
+	if !assert.Eventually(t, func() bool {
+		return len(filterSetCalls(mock.SnapshotSetCalls(), "SetGMSettings")) >= 2
+	}, 1*time.Second, 10*time.Millisecond) {
+		return
+	}
+
+	gmCalls := filterSetCalls(mock.SnapshotSetCalls(), "SetGMSettings")
+	if !assert.Len(t, gmCalls, 2) {
+		return
+	}
+
+	for _, call := range gmCalls {
+		gs := call.GMSettings
+		if !assert.NotNil(t, gs) {
+			continue
+		}
+		assert.Equal(t, fbprotocol.ClockClass(135), gs.ClockQuality.ClockClass)
+		assert.True(t, gs.TimePropertiesDS.PtpTimescale)
+		assert.True(t, gs.TimePropertiesDS.TimeTraceable, "class 135 should be time traceable")
+		assert.True(t, gs.TimePropertiesDS.CurrentUtcOffsetValid)
+		assert.Equal(t, int32(37), gs.TimePropertiesDS.CurrentUtcOffset)
+		assert.True(t, gs.TimePropertiesDS.Leap61)
+	}
+}
+
+func TestAnnounceLocalData_Holdover165_NotTimeTraceable(t *testing.T) {
+	mock := &pmc.MockClient{}
+	pmc.SetMock(mock)
+	defer pmc.ResetMock()
+	e := newPMCTestEventHandler()
+	cfgName := testCfgName
+	e.LeadingClockData.clockID = "aabbcc.fffe.ddeeff"
+	e.LeadingClockData.controlledPortsConfig = testControlledCfg
+	e.LeadingClockData.downstreamTimeProperties = &protocol.TimePropertiesDS{
+		CurrentUtcOffset: 37,
+	}
+	e.clkSyncState[cfgName] = &clockSyncState{
+		state:      PTP_HOLDOVER,
+		clockClass: fbprotocol.ClockClass(165),
+	}
+
+	e.announceLocalData(cfgName)
+
+	if !assert.Eventually(t, func() bool {
+		return len(filterSetCalls(mock.SnapshotSetCalls(), "SetGMSettings")) >= 2
+	}, 1*time.Second, 10*time.Millisecond) {
+		return
+	}
+
+	gmCalls := filterSetCalls(mock.SnapshotSetCalls(), "SetGMSettings")
+	if !assert.Len(t, gmCalls, 2) {
+		return
+	}
+
+	for _, call := range gmCalls {
+		gs := call.GMSettings
+		if !assert.NotNil(t, gs) {
+			continue
+		}
+		assert.Equal(t, fbprotocol.ClockClass(165), gs.ClockQuality.ClockClass)
+		assert.False(t, gs.TimePropertiesDS.TimeTraceable, "class 165 should NOT be time traceable")
+	}
+}
+
+func TestAnnounceLocalData_NilDownstreamTimeProperties_SkipsGMSettings(t *testing.T) {
+	mock := &pmc.MockClient{}
+	pmc.SetMock(mock)
+	defer pmc.ResetMock()
+	e := newPMCTestEventHandler()
+	cfgName := testCfgName
+
+	e.LeadingClockData.clockID = "aabbcc.fffe.ddeeff"
+	e.LeadingClockData.controlledPortsConfig = testControlledCfg
+	e.LeadingClockData.downstreamTimeProperties = nil
+	e.clkSyncState[cfgName] = &clockSyncState{
+		state:      PTP_HOLDOVER,
+		clockClass: fbprotocol.ClockClass(135),
+	}
+
+	e.announceLocalData(cfgName)
+
+	// EGP runs in a goroutine; GM settings should be skipped
+	if !assert.Eventually(t, func() bool {
+		return len(filterSetCalls(mock.SnapshotSetCalls(), "SetExternalGMPropertiesNP")) >= 1
+	}, 1*time.Second, 10*time.Millisecond) {
+		return
+	}
+
+	egpCalls := filterSetCalls(mock.SnapshotSetCalls(), "SetExternalGMPropertiesNP")
+	assert.Len(t, egpCalls, 1)
+
+	gmCalls := filterSetCalls(mock.SnapshotSetCalls(), "SetGMSettings")
+	assert.Empty(t, gmCalls)
+}
+
+func TestAnnounceLocalData_MissingClkSyncState_Returns(t *testing.T) {
+	mock := &pmc.MockClient{}
+	pmc.SetMock(mock)
+	defer pmc.ResetMock()
+	e := newPMCTestEventHandler()
+
+	e.announceLocalData("nonexistent")
+
+	// Returns synchronously before launching any goroutines
+	assert.Empty(t, mock.SnapshotSetCalls())
+	assert.Empty(t, mock.SnapshotGetCalls())
+}
+
+// --- downstreamAnnounceIWF ---
+
+func TestDownstreamAnnounceIWF_Locked_FetchesAndSetsDownstream(t *testing.T) {
+	cfgName := testCfgName
+	mock := &pmc.MockClient{
+		ParentTimeCurrentDSResult: pmc.ParentTimeCurrentDS{
+			ParentDataSet: protocol.ParentDataSet{
+				GrandmasterClockClass:              6,
+				GrandmasterClockAccuracy:           0x21,
+				GrandmasterOffsetScaledLogVariance: 0x4e5d,
+				GrandmasterIdentity:                "aabb.ccdd.eeff",
+			},
+			TimePropertiesDS: protocol.TimePropertiesDS{
+				CurrentUtcOffset:      37,
+				CurrentUtcOffsetValid: true,
+				PtpTimescale:          true,
+				TimeTraceable:         true,
+			},
+			CurrentDS: protocol.CurrentDS{
+				StepsRemoved: 1,
+			},
+		},
+	}
+	pmc.SetMock(mock)
+	defer pmc.ResetMock()
+
+	e := newPMCTestEventHandler()
+	e.LeadingClockData.controlledPortsConfig = testControlledCfg
+	e.clkSyncState[cfgName] = &clockSyncState{state: PTP_LOCKED}
+
+	ctx := context.Background()
+	e.downstreamAnnounceIWF(ctx, cfgName)
+
+	getCalls := mock.SnapshotGetCalls()
+	if !assert.Len(t, getCalls, 1) {
+		return
+	}
+	assert.Equal(t, "GetParentTimeAndCurrentDS", getCalls[0].Method)
+	assert.Equal(t, cfgName, getCalls[0].CfgName)
+
+	egpCalls := filterSetCalls(mock.SnapshotSetCalls(), "SetExternalGMPropertiesNP")
+	if !assert.Len(t, egpCalls, 1) {
+		return
+	}
+	assert.Equal(t, testControlledCfg, egpCalls[0].CfgName)
+	assert.Equal(t, "aabb.ccdd.eeff", egpCalls[0].ExternalGMPropertiesNP.GrandmasterIdentity)
+	assert.Equal(t, uint16(1), egpCalls[0].ExternalGMPropertiesNP.StepsRemoved)
+
+	gmCalls := filterSetCalls(mock.SnapshotSetCalls(), "SetGMSettings")
+	if !assert.Len(t, gmCalls, 1) {
+		return
+	}
+	assert.Equal(t, testControlledCfg, gmCalls[0].CfgName)
+	gs := gmCalls[0].GMSettings
+	if !assert.NotNil(t, gs) {
+		return
+	}
+	assert.Equal(t, fbprotocol.ClockClass6, gs.ClockQuality.ClockClass)
+	assert.Equal(t, fbprotocol.ClockAccuracy(0x21), gs.ClockQuality.ClockAccuracy)
+	assert.Equal(t, uint16(0x4e5d), gs.ClockQuality.OffsetScaledLogVariance)
+	assert.True(t, gs.TimePropertiesDS.PtpTimescale)
+	assert.True(t, gs.TimePropertiesDS.TimeTraceable)
+
+	assert.Equal(t, uint8(6), e.LeadingClockData.upstreamParentDataSet.GrandmasterClockClass)
+	assert.Equal(t, uint8(6), e.LeadingClockData.downstreamParentDataSet.GrandmasterClockClass)
+	assert.Equal(t, uint16(1), e.LeadingClockData.upstreamCurrentDSStepsRemoved)
+}
+
+func TestDownstreamAnnounceIWF_FetchError_ReturnsEarly(t *testing.T) {
+	mock := &pmc.MockClient{
+		ParentTimeCurrentDSErr: assert.AnError,
+	}
+	pmc.SetMock(mock)
+	defer pmc.ResetMock()
+	e := newPMCTestEventHandler()
+	cfgName := testCfgName
+	e.clkSyncState[cfgName] = &clockSyncState{state: PTP_LOCKED}
+
+	ctx := context.Background()
+	e.downstreamAnnounceIWF(ctx, cfgName)
+
+	getCalls := mock.SnapshotGetCalls()
+	if !assert.Len(t, getCalls, 1) {
+		return
+	}
+	assert.Empty(t, mock.SnapshotSetCalls())
+}
+
+func TestDownstreamAnnounceIWF_NotLocked_AbortsAfterFetch(t *testing.T) {
+	mock := &pmc.MockClient{
+		ParentTimeCurrentDSResult: pmc.ParentTimeCurrentDS{
+			ParentDataSet: protocol.ParentDataSet{GrandmasterClockClass: 6},
+		},
+	}
+	pmc.SetMock(mock)
+	defer pmc.ResetMock()
+	e := newPMCTestEventHandler()
+	cfgName := testCfgName
+	e.clkSyncState[cfgName] = &clockSyncState{state: PTP_FREERUN}
+
+	ctx := context.Background()
+	e.downstreamAnnounceIWF(ctx, cfgName)
+
+	getCalls := mock.SnapshotGetCalls()
+	if !assert.Len(t, getCalls, 1) {
+		return
+	}
+	assert.Empty(t, mock.SnapshotSetCalls())
+}
+
+func TestDownstreamAnnounceIWF_CancelledBeforeAnnounce(t *testing.T) {
+	mock := &pmc.MockClient{
+		ParentTimeCurrentDSResult: pmc.ParentTimeCurrentDS{
+			ParentDataSet: protocol.ParentDataSet{GrandmasterClockClass: 6},
+		},
+	}
+	pmc.SetMock(mock)
+	defer pmc.ResetMock()
+	e := newPMCTestEventHandler()
+	cfgName := testCfgName
+	e.clkSyncState[cfgName] = &clockSyncState{state: PTP_LOCKED}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	e.downstreamAnnounceIWF(ctx, cfgName)
+
+	getCalls := mock.SnapshotGetCalls()
+	if !assert.Len(t, getCalls, 1) {
+		return
+	}
+	assert.Empty(t, mock.SnapshotSetCalls())
+}
+
+// --- updateDownstreamData ---
+
+func TestUpdateDownstreamData_Locked_CallsDownstreamAnnounceIWF(t *testing.T) {
+	mock := &pmc.MockClient{
+		ParentTimeCurrentDSResult: pmc.ParentTimeCurrentDS{
+			ParentDataSet: protocol.ParentDataSet{GrandmasterClockClass: 6},
+			CurrentDS:     protocol.CurrentDS{StepsRemoved: 1},
+		},
+	}
+	pmc.SetMock(mock)
+	defer pmc.ResetMock()
+	e := newPMCTestEventHandler()
+	cfgName := testCfgName
+	e.LeadingClockData.controlledPortsConfig = testControlledCfg
+	e.clkSyncState[cfgName] = &clockSyncState{state: PTP_LOCKED}
+
+	e.updateDownstreamData(cfgName)
+
+	if !assert.Eventually(t, func() bool {
+		return len(mock.SnapshotGetCalls()) >= 1
+	}, 1*time.Second, 10*time.Millisecond) {
+		return
+	}
+
+	getCalls := mock.SnapshotGetCalls()
+	assert.Equal(t, "GetParentTimeAndCurrentDS", getCalls[0].Method)
+}
+
+func TestUpdateDownstreamData_Freerun_CallsAnnounceLocalData(t *testing.T) {
+	ensureLeapMocked(t)
+	mock := &pmc.MockClient{}
+	pmc.SetMock(mock)
+	defer pmc.ResetMock()
+	e := newPMCTestEventHandler()
+	cfgName := testCfgName
+	e.LeadingClockData.clockID = "001122.fffe.334455"
+	e.LeadingClockData.controlledPortsConfig = testControlledCfg
+	e.clkSyncState[cfgName] = &clockSyncState{
+		state:      PTP_FREERUN,
+		clockClass: protocol.ClockClassFreerun,
+	}
+
+	e.updateDownstreamData(cfgName)
+
+	assert.Eventually(t, func() bool {
+		return len(filterSetCalls(mock.SnapshotSetCalls(), "SetExternalGMPropertiesNP")) >= 1
+	}, 1*time.Second, 10*time.Millisecond)
+}
+
+func TestUpdateDownstreamData_MissingConfig_Returns(t *testing.T) {
+	mock := &pmc.MockClient{}
+	pmc.SetMock(mock)
+	defer pmc.ResetMock()
+	e := newPMCTestEventHandler()
+
+	e.updateDownstreamData("nonexistent")
+
+	// Returns synchronously before launching any goroutines
+	assert.Empty(t, mock.SnapshotSetCalls())
+	assert.Empty(t, mock.SnapshotGetCalls())
+}

--- a/pkg/event/event_test.go
+++ b/pkg/event/event_test.go
@@ -9,13 +9,15 @@ import (
 	"testing"
 	"time"
 
-	fbprotocol "github.com/facebook/time/ptp/protocol"
 	"github.com/golang/glog"
 	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/event"
 	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/leap"
+	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/pmc"
 	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/protocol"
 	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/testhelpers"
 	"github.com/stretchr/testify/assert"
+
+	fbprotocol "github.com/facebook/time/ptp/protocol"
 )
 
 func TestMain(m *testing.M) {
@@ -28,11 +30,9 @@ var (
 	staleSocketTimeout = 100 * time.Millisecond
 )
 
-func monkeyPatch() {
-
-	event.PMCGMGetter = func(cfgName string) (protocol.GrandmasterSettings, error) {
-		cfgName = strings.Replace(cfgName, event.TS2PHCProcessName, event.PTP4lProcessName, 1)
-		return protocol.GrandmasterSettings{
+func newTestPMCMock() *pmc.MockClient {
+	return &pmc.MockClient{
+		GMSettingsResult: protocol.GrandmasterSettings{
 			ClockQuality: fbprotocol.ClockQuality{
 				ClockClass:              0,
 				ClockAccuracy:           0,
@@ -48,11 +48,7 @@ func monkeyPatch() {
 				PtpTimescale:          false,
 				TimeSource:            0,
 			},
-		}, nil
-	}
-	event.PMCGMSetter = func(cfgName string, g protocol.GrandmasterSettings) error {
-		cfgName = strings.Replace(cfgName, event.TS2PHCProcessName, event.PTP4lProcessName, 1)
-		return nil
+		},
 	}
 }
 
@@ -71,7 +67,9 @@ type PTPEvents struct {
 }
 
 func TestEventHandler_ProcessEvents(t *testing.T) {
-	monkeyPatch()
+	pmcMock := newTestPMCMock()
+	pmc.SetMock(pmcMock)
+	defer pmc.ResetMock()
 	tests := []PTPEvents{
 		{
 			processName:      event.DPLL,

--- a/pkg/pmc/client.go
+++ b/pkg/pmc/client.go
@@ -1,0 +1,71 @@
+package pmc
+
+import "github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/protocol"
+
+// Client abstracts the PMC I/O layer so that callers in the event and daemon
+// packages can be tested without spawning real pmc processes.
+type Client interface {
+	GetGMSettings(cfgName string) (protocol.GrandmasterSettings, error)
+	SetGMSettings(cfgName string, g protocol.GrandmasterSettings) error
+	GetParentDS(cfgName string) (protocol.ParentDataSet, error)
+	GetParentTimeAndCurrentDS(cfgName string) (ParentTimeCurrentDS, error)
+	SetExternalGMPropertiesNP(cfgName string, egp protocol.ExternalGrandmasterProperties) error
+}
+
+// defaultClient delegates every call to the real RunPMCExp* functions.
+type defaultClient struct{}
+
+func (defaultClient) GetGMSettings(cfgName string) (protocol.GrandmasterSettings, error) {
+	return RunPMCExpGetGMSettings(cfgName)
+}
+
+func (defaultClient) GetParentDS(cfgName string) (protocol.ParentDataSet, error) {
+	return RunPMCExpGetParentDS(cfgName, false)
+}
+
+func (defaultClient) SetGMSettings(cfgName string, g protocol.GrandmasterSettings) error {
+	return RunPMCExpSetGMSettings(cfgName, g)
+}
+
+func (defaultClient) GetParentTimeAndCurrentDS(cfgName string) (ParentTimeCurrentDS, error) {
+	return RunPMCExpGetParentTimeAndCurrentDataSets(cfgName)
+}
+
+func (defaultClient) SetExternalGMPropertiesNP(cfgName string, egp protocol.ExternalGrandmasterProperties) error {
+	return RunPMCExpSetExternalGMPropertiesNP(cfgName, egp)
+}
+
+var activeClient Client = defaultClient{}
+
+// SetMock replaces the package-level client with a test double.
+// Call ResetMock (or defer it) when done.
+func SetMock(c Client) { activeClient = c }
+
+// ResetMock restores the real defaultClient.
+func ResetMock() { activeClient = defaultClient{} }
+
+// GetGMSettings retrieves the current GRANDMASTER_SETTINGS_NP from ptp4l.
+func GetGMSettings(cfgName string) (protocol.GrandmasterSettings, error) {
+	return activeClient.GetGMSettings(cfgName)
+}
+
+// SetGMSettings applies GRANDMASTER_SETTINGS_NP to ptp4l.
+func SetGMSettings(cfgName string, g protocol.GrandmasterSettings) error {
+	return activeClient.SetGMSettings(cfgName, g)
+}
+
+// GetParentDS retrieves the PARENT_DATA_SET from ptp4l.
+func GetParentDS(cfgName string) (protocol.ParentDataSet, error) {
+	return activeClient.GetParentDS(cfgName)
+}
+
+// GetParentTimeAndCurrentDS retrieves PARENT_DATA_SET, TIME_PROPERTIES_DS,
+// and CURRENT_DATA_SET in a single PMC session.
+func GetParentTimeAndCurrentDS(cfgName string) (ParentTimeCurrentDS, error) {
+	return activeClient.GetParentTimeAndCurrentDS(cfgName)
+}
+
+// SetExternalGMPropertiesNP applies EXTERNAL_GRANDMASTER_PROPERTIES_NP to ptp4l.
+func SetExternalGMPropertiesNP(cfgName string, egp protocol.ExternalGrandmasterProperties) error {
+	return activeClient.SetExternalGMPropertiesNP(cfgName, egp)
+}

--- a/pkg/pmc/mock.go
+++ b/pkg/pmc/mock.go
@@ -1,0 +1,112 @@
+package pmc
+
+import (
+	"sync"
+
+	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/protocol"
+)
+
+// GetCall records a single getter invocation on the MockClient.
+type GetCall struct {
+	Method  string
+	CfgName string
+}
+
+// SetCall records a single setter invocation on the MockClient, including
+// the full payload that would have been applied to ptp4l.
+type SetCall struct {
+	Method                 string
+	CfgName                string
+	GMSettings             *protocol.GrandmasterSettings
+	ExternalGMPropertiesNP *protocol.ExternalGrandmasterProperties
+}
+
+// MockClient is a spy that records every PMC call along with its full
+// payload. All methods are safe for concurrent use. Tests should read
+// recorded calls via SnapshotGetCalls / SnapshotSetCalls.
+type MockClient struct {
+	mu       sync.Mutex
+	getCalls []GetCall
+	setCalls []SetCall
+
+	// Canned return values for getters. Tests set these before exercising
+	// the code under test.
+	GMSettingsResult          protocol.GrandmasterSettings
+	GMSettingsErr             error
+	ParentDSResult            protocol.ParentDataSet
+	ParentDSErr               error
+	ParentTimeCurrentDSResult ParentTimeCurrentDS
+	ParentTimeCurrentDSErr    error
+
+	// Canned errors for setters (nil = success).
+	SetGMSettingsErr             error
+	SetExternalGMPropertiesNPErr error
+}
+
+var _ Client = (*MockClient)(nil)
+
+// SnapshotGetCalls returns a copy of the recorded getter calls.
+func (m *MockClient) SnapshotGetCalls() []GetCall {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make([]GetCall, len(m.getCalls))
+	copy(out, m.getCalls)
+	return out
+}
+
+// SnapshotSetCalls returns a copy of the recorded setter calls.
+func (m *MockClient) SnapshotSetCalls() []SetCall {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make([]SetCall, len(m.setCalls))
+	copy(out, m.setCalls)
+	return out
+}
+
+// GetGMSettings implements Client.
+func (m *MockClient) GetGMSettings(cfgName string) (protocol.GrandmasterSettings, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.getCalls = append(m.getCalls, GetCall{Method: "GetGMSettings", CfgName: cfgName})
+	return m.GMSettingsResult, m.GMSettingsErr
+}
+
+// SetGMSettings implements Client.
+func (m *MockClient) SetGMSettings(cfgName string, g protocol.GrandmasterSettings) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.setCalls = append(m.setCalls, SetCall{
+		Method:     "SetGMSettings",
+		CfgName:    cfgName,
+		GMSettings: &g,
+	})
+	return m.SetGMSettingsErr
+}
+
+// GetParentDS implements Client.
+func (m *MockClient) GetParentDS(cfgName string) (protocol.ParentDataSet, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.getCalls = append(m.getCalls, GetCall{Method: "GetParentDS", CfgName: cfgName})
+	return m.ParentDSResult, m.ParentDSErr
+}
+
+// GetParentTimeAndCurrentDS implements Client.
+func (m *MockClient) GetParentTimeAndCurrentDS(cfgName string) (ParentTimeCurrentDS, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.getCalls = append(m.getCalls, GetCall{Method: "GetParentTimeAndCurrentDS", CfgName: cfgName})
+	return m.ParentTimeCurrentDSResult, m.ParentTimeCurrentDSErr
+}
+
+// SetExternalGMPropertiesNP implements Client.
+func (m *MockClient) SetExternalGMPropertiesNP(cfgName string, egp protocol.ExternalGrandmasterProperties) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.setCalls = append(m.setCalls, SetCall{
+		Method:                 "SetExternalGMPropertiesNP",
+		CfgName:                cfgName,
+		ExternalGMPropertiesNP: &egp,
+	})
+	return m.SetExternalGMPropertiesNPErr
+}


### PR DESCRIPTION
Introduce pmc.Client interface + DefaultClient so that event and daemon code calls pmc.GetGMSettings / pmc.SetGMSettings / etc. as plain package functions.  Tests swap the implementation via pmc.SetMock() and restore it with pmc.ResetMock(), keeping the change invisible to production callers.

- Remove global PMCGMGetter/PMCGMSetter vars from event package
- Remove runPMCExpGetParentDS func field from daemon PMCProcess
- Replace direct pmc.RunPMCExp* calls in event_tbc.go with client wrapper functions
- Add MockClient with full payload recording (SetCalls/GetCalls)
- Add 15 unit tests for T-BC PMC interactions (event_tbc_pmc_test.go)
- Update existing daemon and event tests to use pmc.SetMock()

Generated-by: Cursor