### PR TITLE
Always update Prometheus clock_class metric regardless of socket mode

### DIFF
--- a/pkg/event/event.go
+++ b/pkg/event/event.go
@@ -657,7 +657,7 @@ func (e *EventHandler) emitClockClass(clockClass fbprotocol.ClockClass, cfgName 
 		logMsg := utils.GetClockClassLogMessage(PTP4lProcessName, cfgName, clockClass)
 		e.writeLogToSocket(logMsg)
 	}
-	if !e.stdoutToSocket && e.clockClassMetric != nil {
+	if e.clockClassMetric != nil {
 		e.clockClassMetric.With(prometheus.Labels{
 			"process": PTP4lProcessName, "config": cfgName, "node": e.nodeName}).Set(float64(clockClass))
 	}
@@ -1292,7 +1292,8 @@ func (e *EventHandler) UpdateClockClass(clk ClockClassRequest) {
 		clockClassOut := utils.GetClockClassLogMessage(PTP4lProcessName, clk.cfgName, clockClass)
 		if e.stdoutToSocket {
 			e.writeLogToSocket(clockClassOut)
-		} else if e.clockClassMetric != nil {
+		}
+		if e.clockClassMetric != nil {
 			e.clockClassMetric.With(prometheus.Labels{
 				"process": PTP4lProcessName, "config": clk.cfgName, "node": e.nodeName}).Set(float64(clockClass))
 		}

--- a/pkg/event/event_socket_test.go
+++ b/pkg/event/event_socket_test.go
@@ -13,6 +13,8 @@ import (
 
 	fbprotocol "github.com/facebook/time/ptp/protocol"
 	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/parser"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -615,6 +617,43 @@ func TestEmitClockClass_NilConnectionNoWrite(_ *testing.T) {
 	e.closeCh <- true
 	// should not panic
 	e.emitClockClass(fbprotocol.ClockClass(6), "ptp4l.0.config")
+}
+
+func TestEmitClockClass_UpdatesPrometheusMetricWithSocket(t *testing.T) {
+	socketPath := shortSocketPath(t)
+	listener, err := net.Listen("unix", socketPath)
+	assert.NoError(t, err)
+	defer listener.Close()
+
+	received := make(chan string, 10)
+	go acceptAndRead(listener, received)
+
+	e := newTestEventHandler(socketPath)
+	assert.True(t, e.stdoutToSocket, "stdoutToSocket must be true for this test")
+	assert.True(t, e.reconnectEventSocket())
+
+	metric := prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: "openshift",
+		Subsystem: "ptp",
+		Name:      "clock_class_test",
+		Help:      "test metric",
+	}, []string{"process", "config", "node"})
+	e.clockClassMetric = metric
+
+	e.emitClockClass(fbprotocol.ClockClass(248), "ptp4l.0.config")
+
+	select {
+	case got := <-received:
+		assert.Contains(t, got, "CLOCK_CLASS_CHANGE 248", "socket should receive the clock class event")
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for socket message")
+	}
+
+	g := metric.With(prometheus.Labels{"process": PTP4lProcessName, "config": "ptp4l.0.config", "node": e.nodeName})
+	assert.Equal(t, float64(248), testutil.ToFloat64(g),
+		"Prometheus metric must be updated even when stdoutToSocket is true")
+
+	e.setConn(nil)
 }
 
 func TestEmitClockClass_ReconnectsOnBrokenPipe(t *testing.T) {


### PR DESCRIPTION
## Summary

When cloud-event-proxy is deployed (stdoutToSocket=true), the openshift_ptp_clock_class Prometheus metric is never updated. Both emitClockClass() and UpdateClockClass() guard the metric update behind !stdoutToSocket, so the metric remains stale while the actual clock class changes.

This breaks any monitoring or conformance tests that rely on the Prometheus endpoint to observe clock class transitions (e.g. LOCKED to FREERUN after port down).

**Root cause:** The else-if / if !stdoutToSocket condition treats socket writes and Prometheus metric updates as mutually exclusive, but they serve different consumers and should both be active.

**Fix:** Decouple the Prometheus metric update from the socket write condition. The metric is now always set when clockClassMetric is non-nil, regardless of whether events are also forwarded to cloud-event-proxy.

## Changes

- emitClockClass(): Changed if !e.stdoutToSocket && e.clockClassMetric != nil to if e.clockClassMetric != nil
- UpdateClockClass(): Changed else if e.clockClassMetric != nil to separate if e.clockClassMetric != nil block
- Added TestEmitClockClass_UpdatesPrometheusMetricWithSocket test verifying that the Prometheus metric is updated even when stdoutToSocket is true

## Test plan

- [ ] New unit test TestEmitClockClass_UpdatesPrometheusMetricWithSocket passes
- [ ] Existing TestEmitClockClass_* tests still pass
- [ ] E2E: Verify clockClass when locking PTP source on single NIC boundary clock test passes with cloud-event-proxy deployed