### PR TITLE
OCPBUGS-85377: Sanitize GNSS UART before starting gpsd

### DIFF
--- a/pkg/daemon/gpsd.go
+++ b/pkg/daemon/gpsd.go
@@ -221,7 +221,7 @@ func (g *GPSD) CmdRun(stdoutToSocket bool) {
 		// Don't restart after termination
 		if !g.Stopped() {
 			time.Sleep(1 * time.Second)
-			if resetErr := g.resetSerialPort(context.Background()); resetErr != nil {
+			if resetErr := g.resetSerialPort(g.monitorCtx); resetErr != nil {
 				glog.Warningf("gpsd: proceeding with start despite serial port reset failure: %v", resetErr)
 			}
 			err = g.cmd.Start() // this is asynchronous call,

--- a/pkg/daemon/gpsd.go
+++ b/pkg/daemon/gpsd.go
@@ -58,6 +58,9 @@ type GPSD struct {
 	monitorCtx           context.Context
 	monitorCancel        context.CancelFunc
 	c                    net.Conn
+	// cmdRunner executes an external command; defaults to exec.CommandContext and
+	// can be overridden in tests to inject a fake command.
+	cmdRunner func(ctx context.Context, name string, args ...string) *exec.Cmd
 }
 
 // GPSDSubscriber ... event subscriber
@@ -160,6 +163,30 @@ func (g *GPSD) CmdInit() {
 	}
 	g.monitorCtx, g.monitorCancel = context.WithCancel(context.Background())
 	g.cmdLine = fmt.Sprintf("/usr/local/sbin/%s -p -n -S 2947 -G -N %s", g.Name(), g.SerialPort())
+	if g.cmdRunner == nil {
+		g.cmdRunner = exec.CommandContext
+	}
+}
+
+// resetSerialPort resets the serial device to a sane state before starting gpsd.
+// On platforms where GNSS is connected via UART (e.g. HPE), an abrupt gpsd
+// termination can leave the UART in a dirty state that prevents a new gpsd
+// instance from communicating with the GNSS module. Running "stty sane" clears
+// that state. The reset is unconditional — it is also harmless on platforms
+// with USB-connected GNSS devices.
+// If serialPort is empty the reset is skipped with a warning.
+// A reset failure is logged as a warning but never blocks gpsd startup.
+func (g *GPSD) resetSerialPort(ctx context.Context) error {
+	if g.serialPort == "" {
+		glog.Warningf("gpsd: no serial port configured, skipping device reset before gpsd start")
+		return nil
+	}
+	out, err := g.cmdRunner(ctx, "stty", "-F", g.serialPort, "sane").CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("stty -F %s sane: %w (output: %s)", g.serialPort, err, strings.TrimSpace(string(out)))
+	}
+	glog.Infof("gpsd: serial port %s reset to sane state", g.serialPort)
+	return nil
 }
 
 // ProcessStatus ...
@@ -194,6 +221,9 @@ func (g *GPSD) CmdRun(stdoutToSocket bool) {
 		// Don't restart after termination
 		if !g.Stopped() {
 			time.Sleep(1 * time.Second)
+			if resetErr := g.resetSerialPort(context.Background()); resetErr != nil {
+				glog.Warningf("gpsd: proceeding with start despite serial port reset failure: %v", resetErr)
+			}
 			err = g.cmd.Start() // this is asynchronous call,
 			if err != nil {
 				glog.Errorf("CmdRun() error starting %s: %v", g.Name(), err)

--- a/pkg/daemon/gpsd_test.go
+++ b/pkg/daemon/gpsd_test.go
@@ -1,0 +1,84 @@
+package daemon
+
+import (
+	"context"
+	"os/exec"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestResetSerialPort(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		serialPort string
+		runner     func(ctx context.Context, name string, args ...string) *exec.Cmd
+		wantErr    bool
+	}{
+		{
+			name:       "happy path: stty succeeds",
+			serialPort: "/dev/ttyUSB0",
+			runner: func(ctx context.Context, _ string, _ ...string) *exec.Cmd {
+				return exec.CommandContext(ctx, "true")
+			},
+			wantErr: false,
+		},
+		{
+			name:       "stty command fails",
+			serialPort: "/dev/ttyUSB0",
+			runner: func(ctx context.Context, _ string, _ ...string) *exec.Cmd {
+				return exec.CommandContext(ctx, "false")
+			},
+			wantErr: true,
+		},
+		{
+			name:       "empty serialPort skips reset without error",
+			serialPort: "",
+			runner: func(_ context.Context, _ string, _ ...string) *exec.Cmd {
+				t.Error("cmdRunner must not be called when serialPort is empty")
+				return nil
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			g := &GPSD{
+				serialPort: tt.serialPort,
+				cmdRunner:  tt.runner,
+			}
+			err := g.resetSerialPort(context.Background())
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestResetSerialPortPassesCorrectArgs(t *testing.T) {
+	t.Parallel()
+
+	const device = "/dev/ttyS0"
+	var capturedName string
+	var capturedArgs []string
+
+	g := &GPSD{
+		serialPort: device,
+		cmdRunner: func(ctx context.Context, name string, args ...string) *exec.Cmd {
+			capturedName = name
+			capturedArgs = args
+			return exec.CommandContext(ctx, "true")
+		},
+	}
+
+	err := g.resetSerialPort(context.Background())
+	assert.NoError(t, err)
+	assert.Equal(t, "stty", capturedName)
+	assert.Equal(t, []string{"-F", device, "sane"}, capturedArgs)
+}


### PR DESCRIPTION
On platforms where the GNSS module is connected via UART, killing gpsd during configuration transitions can leave the interface in an inconsistent state. This prevents gpsd from reconnecting properly on the next start.

This commit adds an stty sane invocation prior to starting gpsd. This ensures the UART is in a clean operational state. No regressions were observed on USB-connected GNSS modules.

Assisted by Cursor