### PR TITLE
CNF-20903: First check the SOURCE_GIT_COMMIT before using the embedded git hash

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -86,8 +86,11 @@ func (cp *cliParams) debugPrint() {
 }
 
 func main() {
-
-	fmt.Printf("Git commit: %s\n", GitCommit)
+	commit := os.Getenv("SOURCE_GIT_COMMIT")
+	if commit == "" {
+		commit = GitCommit
+	}
+	fmt.Printf("Git commit: %s\n", commit)
 	cp := &cliParams{}
 	cp.flagInit()
 


### PR DESCRIPTION
This allows for better traceablilty when the build system copies the source code into a local git store before building.