### PR TITLE
docs: add dual TR ports PoC plan and config manifests for E810 and GNR-D

### DIFF
--- a/addons/intel/clock-chain.go
+++ b/addons/intel/clock-chain.go
@@ -3,10 +3,10 @@ package intel
 import (
 	"errors"
 	"fmt"
-	"time"
 
 	"github.com/golang/glog"
 	dpll "github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/dpll-netlink"
+	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/hardwareconfig"
 
 	ptpv1 "github.com/k8snetworkplumbingwg/ptp-operator/api/v1"
 )
@@ -600,38 +600,8 @@ func (c *ClockChain) SetPinDefaults() error {
 	return errors.Join(err, fetchErr)
 }
 
-// BatchPinSet function pointer allows mocking of BatchPinSet
-var BatchPinSet = batchPinSet
-
-func batchPinSet(commands []dpll.PinParentDeviceCtl) error {
-	conn, err := dpll.Dial(nil)
-	if err != nil {
-		return fmt.Errorf("failed to dial DPLL: %v", err)
-	}
-	//nolint:errcheck
-	defer conn.Close()
-	for _, command := range commands {
-		glog.Infof("DPLL pin command %s", command.String())
-		b, err := dpll.EncodePinControl(command)
-		if err != nil {
-			return err
-		}
-		err = conn.SendCommand(dpll.DpllCmdPinSet, b)
-		if err != nil {
-			glog.Error("failed to send pin command: ", err)
-			return err
-		}
-		info, err := conn.DoPinGet(dpll.DoPinGetRequest{ID: command.ID})
-		if err != nil {
-			glog.Error("failed to get pin: ", err)
-			return err
-		}
-		reply, err := dpll.GetPinInfoHR(info, time.Now())
-		if err != nil {
-			glog.Error("failed to convert pin reply to human readable: ", err)
-			return err
-		}
-		glog.Info("pin reply: ", string(reply))
-	}
-	return nil
-}
+// BatchPinSet function pointer allows mocking of BatchPinSet. Delegates to
+// hardwareconfig.BatchPinSet so both packages share one implementation
+// (dial, send, read-back-and-log-as-table, RHEL-137801 workaround) instead
+// of maintaining two near-identical copies.
+var BatchPinSet = hardwareconfig.BatchPinSet

--- a/docs/features/dual-tr-ports/gnrd-configs/HwConfigBcGnrd.yaml
+++ b/docs/features/dual-tr-ports/gnrd-configs/HwConfigBcGnrd.yaml
@@ -1,0 +1,18 @@
+apiVersion: ptp.openshift.io/v2alpha1
+kind: HardwareConfig
+metadata:
+  name: t-bc
+spec:
+  profile:
+    name: GNR-D-T-BC
+    clockType: T-BC
+    clockChain:
+      structure:
+      - name: leader
+        hardwareSpecificDefinitions: dell/XR8720t
+        dpll:
+          holdoverParameters:
+            maxInSpecOffset: 100
+            localMaxHoldoverOffset: 1500
+            localHoldoverTimeout: 14400
+  relatedPtpProfileName: 01-bc-tr

--- a/docs/features/dual-tr-ports/gnrd-configs/PtpConfigBcGnrdThreeCardsCustomTrHwConf.yaml
+++ b/docs/features/dual-tr-ports/gnrd-configs/PtpConfigBcGnrdThreeCardsCustomTrHwConf.yaml
@@ -1,0 +1,169 @@
+apiVersion: ptp.openshift.io/v1
+kind: PtpConfig
+metadata:
+  name: gnrd-bc-tr
+  namespace: openshift-ptp
+spec:
+  profile:
+    - name: 01-bc-tr
+      phc2sysOpts: -r -n 24 -N 8 -R 16 -u 0 -m -s eno8403
+      ptp4lConf: |
+        # The interface name is hardware-specific
+        [eno8403]
+        masterOnly 0
+        [eno8503]
+        masterOnly 0
+        [global]
+        #
+        # Default Data Set
+        #
+        twoStepFlag 1
+        slaveOnly 0
+        priority1 128
+        priority2 128
+        domainNumber 24
+        #utc_offset 37
+        clockClass 248
+        clockAccuracy 0xFE
+        offsetScaledLogVariance 0xFFFF
+        free_running 0
+        freq_est_interval 1
+        dscp_event 0
+        dscp_general 0
+        dataset_comparison G.8275.x
+        G.8275.defaultDS.localPriority 128
+        #
+        # Port Data Set
+        #
+        logAnnounceInterval -3
+        logSyncInterval -4
+        logMinDelayReqInterval -4
+        logMinPdelayReqInterval -4
+        announceReceiptTimeout 3
+        syncReceiptTimeout 0
+        delayAsymmetry 0
+        fault_reset_interval -4
+        neighborPropDelayThresh 20000000
+        masterOnly 0
+        G.8275.portDS.localPriority 128
+        #
+        # Run time options
+        #
+        assume_two_step 0
+        logging_level 6
+        path_trace_enabled 0
+        follow_up_info 0
+        hybrid_e2e 0
+        inhibit_multicast_service 0
+        net_sync_monitor 0
+        tc_spanning_tree 0
+        tx_timestamp_timeout 50
+        unicast_listen 0
+        unicast_master_table 0
+        unicast_req_duration 3600
+        use_syslog 1
+        verbose 0
+        summary_interval 0
+        kernel_leap 1
+        check_fup_sync 0
+        clock_class_threshold 135
+        #
+        # Servo Options
+        #
+
+        # NGEN TEST MODIFIED
+        # New:
+        # pi_proportional_const 0.60
+        # pi_integral_const 0.0003
+        # Old:
+        # pi_proportional_const 0.0
+        # pi_integral_const 0.0
+        # END TEST MOD
+
+        pi_proportional_const 0.60
+        pi_integral_const 0.001
+        pi_proportional_scale 0.0
+        pi_proportional_exponent -0.3
+        pi_proportional_norm_max 0.7
+        pi_integral_scale 0.0
+        pi_integral_exponent 0.4
+        pi_integral_norm_max 0.3
+        step_threshold 2.0
+        # end T-BC experiment
+        first_step_threshold 0.00002
+        max_frequency 900000000
+        clock_servo pi
+        sanity_freq_limit 200000000
+        ntpshm_segment 0
+        #
+        # Transport options
+        #
+        transportSpecific 0x0
+        ptp_dst_mac 01:1B:19:00:00:00
+        p2p_dst_mac 01:80:C2:00:00:0E
+        udp_ttl 1
+        udp6_scope 0x0E
+        uds_address /var/run/ptp4l
+        #
+        # Default interface options
+        #
+        clock_type OC
+        network_transport L2
+        delay_mechanism E2E
+        time_stamping hardware
+        tsproc_mode filter
+        delay_filter moving_median
+        delay_filter_length 10
+        egressLatency 0
+        ingressLatency 0
+        boundary_clock_jbod 0
+        #
+        # Clock description
+        #
+        productDescription ;;
+        revisionData ;;
+        manufacturerIdentity 00:00:00
+        userDescription ;
+        timeSource 0xA0
+      ptp4lOpts: -2 --summary_interval -4
+      ptpSchedulingPolicy: SCHED_FIFO
+      ptpSchedulingPriority: 10
+      ptpSettings:
+        clockType: T-BC
+        inSyncConditionThreshold: "100"
+        inSyncConditionTimes: "12"
+        logReduce: "false"
+        leadingInterface: eno8703
+        upstreamPort: eno8403,eno8503
+      ts2phcConf: |
+        [global]
+        use_syslog  0
+        verbose 1
+        logging_level 7
+        ts2phc.pulsewidth 500000000
+        leapfile  /usr/share/zoneinfo/leap-seconds.list
+        domainNumber 24
+        uds_address /var/run/ptp4l.1.socket
+        [eno8703]
+        ts2phc.extts_correction 0
+        ts2phc.master 0
+        ts2phc.channel 0
+        ts2phc.pin_index 1
+        [enp108s0f0]
+        ts2phc.extts_polarity rising
+        ts2phc.extts_correction 0
+        ts2phc.master 0
+        ts2phc.channel 0
+        ts2phc.pin_index 1
+        [enp110s0f0]
+        ts2phc.extts_polarity rising
+        ts2phc.extts_correction 0
+        ts2phc.master 0
+        ts2phc.channel 0
+        ts2phc.pin_index 1
+      ts2phcOpts: -s generic -a --ts2phc.rh_external_pps 1
+  recommend:
+    - match:
+        - nodeLabel: node-role.kubernetes.io/master
+      priority: 4
+      profile: 01-bc-tr

--- a/docs/features/dual-tr-ports/gnrd-configs/PtpConfigBcGnrdThreeCardsCustomTt.yaml
+++ b/docs/features/dual-tr-ports/gnrd-configs/PtpConfigBcGnrdThreeCardsCustomTt.yaml
@@ -1,0 +1,191 @@
+apiVersion: ptp.openshift.io/v1
+kind: PtpConfig
+metadata:
+  name: gnrd-bc-tt
+  namespace: openshift-ptp
+spec:
+  profile:
+    - name: 00-bc-tt
+      ptp4lConf: |
+        # ** E825 NAC: [eno8303]-[eno9003]
+        # Connected to switch (ethernet1/1/7:4)
+        # [eno8303]
+        # masterOnly 1
+        # Configured as TR slave
+        # [eno8403]
+        # masterOnly 1
+        # Loopback to enp108s0f1 (Onboard ↔ Add-in card 1)
+        # [eno8503]
+        # masterOnly 1
+        # Primary interface (br-ex uplink)
+        # [eno8603]
+        # masterOnly 1
+        [eno8703]
+        masterOnly 1
+        [eno8803]
+        masterOnly 1
+        [eno8903]
+        masterOnly 1
+        [eno9003]
+        masterOnly 1
+        # ** E830 Carter Flat 1: [enp110s0f0]-[enp110s0f7]
+        # Connected to switch (ethernet1/1/8:1)
+        # [enp110s0f0]
+        # masterOnly 1
+        # Loopback to enp108s0f0 (Add-in card 1 ↔ Add-in card 2)
+        [enp110s0f1]
+        masterOnly 1
+        [enp110s0f2]
+        masterOnly 1
+        [enp110s0f3]
+        masterOnly 1
+        [enp110s0f4]
+        masterOnly 1
+        [enp110s0f5]
+        masterOnly 1
+        [enp110s0f6]
+        masterOnly 1
+        [enp110s0f7]
+        masterOnly 1
+        # ** E830 Carter Flat 2: [enp108s0f0]-[enp108s0f7]
+        # Loopback to enp110s0f1 (Add-in card 1 ↔ Add-in card 2)
+        [enp108s0f0]
+        masterOnly 1
+        # Loopback to eno8503 (Onboard ↔ Add-in card 1)
+        [enp108s0f1]
+        masterOnly 1
+        [enp108s0f2]
+        masterOnly 1
+        [enp108s0f3]
+        masterOnly 1
+        [enp108s0f4]
+        masterOnly 1
+        [enp108s0f5]
+        masterOnly 1
+        [enp108s0f6]
+        masterOnly 1
+        [enp108s0f7]
+        masterOnly 1
+        [global]
+        #
+        # Default Data Set
+        #
+        twoStepFlag 1
+        slaveOnly 0
+        priority1 128
+        priority2 128
+        domainNumber 24
+        #utc_offset 37
+        clockClass 248
+        clockAccuracy 0xFE
+        offsetScaledLogVariance 0xFFFF
+        free_running 0
+        freq_est_interval 1
+        dscp_event 0
+        dscp_general 0
+        dataset_comparison G.8275.x
+        G.8275.defaultDS.localPriority 128
+        #
+        # Port Data Set
+        #
+        logAnnounceInterval -3
+        logSyncInterval -4
+        logMinDelayReqInterval -4
+        logMinPdelayReqInterval -4
+        announceReceiptTimeout 3
+        syncReceiptTimeout 0
+        delayAsymmetry 0
+        fault_reset_interval -4
+        neighborPropDelayThresh 20000000
+        masterOnly 0
+        G.8275.portDS.localPriority 128
+        #
+        # Run time options
+        #
+        assume_two_step 0
+        logging_level 6
+        path_trace_enabled 0
+        follow_up_info 0
+        hybrid_e2e 0
+        inhibit_multicast_service 0
+        net_sync_monitor 0
+        tc_spanning_tree 0
+        tx_timestamp_timeout 50
+        unicast_listen 0
+        unicast_master_table 0
+        unicast_req_duration 3600
+        use_syslog 1
+        verbose 0
+        summary_interval 0
+        kernel_leap 1
+        check_fup_sync 0
+        clock_class_threshold 135
+        #
+        # Servo Options
+        #
+
+        # NGEN TEST MODIFIED
+        # New:
+        # pi_proportional_const 0.60
+        # pi_integral_const 0.0003
+        # Old:
+        # pi_proportional_const 0.0
+        # pi_integral_const 0.0
+        # END TEST MOD
+
+        pi_proportional_const 0.60
+        pi_integral_const 0.001
+        pi_proportional_scale 0.0
+        pi_proportional_exponent -0.3
+        pi_proportional_norm_max 0.7
+        pi_integral_scale 0.0
+        pi_integral_exponent 0.4
+        pi_integral_norm_max 0.3
+        step_threshold 2.0
+        # end T-BC experiment
+        first_step_threshold 0.00002
+        max_frequency 900000000
+        clock_servo pi
+        sanity_freq_limit 200000000
+        ntpshm_segment 0
+        #
+        # Transport options
+        #
+        transportSpecific 0x0
+        ptp_dst_mac 01:1B:19:00:00:00
+        p2p_dst_mac 01:80:C2:00:00:0E
+        udp_ttl 1
+        udp6_scope 0x0E
+        uds_address /var/run/ptp4l
+        #
+        # Default interface options
+        #
+        clock_type BC
+        network_transport L2
+        delay_mechanism E2E
+        time_stamping hardware
+        tsproc_mode filter
+        delay_filter moving_median
+        delay_filter_length 10
+        egressLatency 0
+        ingressLatency 0
+        boundary_clock_jbod 1
+        #
+        # Clock description
+        #
+        productDescription ;;
+        revisionData ;;
+        manufacturerIdentity 00:00:00
+        userDescription ;
+        timeSource 0xA0
+      ptp4lOpts: -2 --summary_interval -4
+      ptpSchedulingPolicy: SCHED_FIFO
+      ptpSchedulingPriority: 10
+      ptpSettings:
+        controllingProfile: 01-bc-tr
+        logReduce: "false"
+  recommend:
+    - match:
+        - nodeLabel: node-role.kubernetes.io/master
+      priority: 4
+      profile: 00-bc-tt

--- a/docs/features/dual-tr-ports/lab-topology.md
+++ b/docs/features/dual-tr-ports/lab-topology.md
@@ -1,0 +1,73 @@
+# Lab Topology — cnfdg42 (Single-Node OpenShift)
+
+All three NICs are on the same SNO node (`cnfdg42.ptp.eng.rdu2.dc.redhat.com`). Connections are loopback cables between ports on the same host.
+
+## Topology Diagram
+
+```mermaid
+graph LR
+    subgraph GM["GM NIC 0000:11 — Intel E810-XXVDA4T"]
+        GM_lead["ens1f0 (leading)"]
+        GM_p1["ens1f1 (masterOnly)"]
+        GM_p2["ens1f2 (masterOnly)"]
+        GM_p3["ens1f3"]
+    end
+
+    subgraph DUT["DUT T-BC NIC 0000:3f — Intel E810-XXVDA4T"]
+        DUT_lead["ens2f0 (leading / DPLL)"]
+        DUT_tr1["ens2f1 (TR, localPriority 100)"]
+        DUT_tt["ens2f2 (TT, masterOnly)"]
+        DUT_tr2["ens2f3 (TR, localPriority 200)"]
+    end
+
+    subgraph DOWNSTREAM["Downstream NIC 0000:9b"]
+        DS_p0["ens3f0"]
+    end
+
+    GM_p1 -- "L2/PTP domain 24" --- DUT_tr1
+    GM_p2 -- "L2/PTP domain 24" --- DUT_tr2
+    DUT_tt -- "L2/PTP domain 25" --- DS_p0
+```
+
+## NICs
+
+| NIC | PCI Address | Model | Role | Interfaces |
+|-----|-------------|-------|------|------------|
+| GM | 0000:11 | Intel E810-XXVDA4T | Grandmaster (GNSS-locked) | ens1f0 (leading), ens1f1, ens1f2, ens1f3 |
+| DUT | 0000:3f | Intel E810-XXVDA4T | T-BC (Device Under Test) | ens2f0 (leading/DPLL), ens2f1, ens2f2, ens2f3 |
+| Downstream | 0000:9b | Intel E810 | Downstream client | ens3f0 |
+
+## Connections (loopback cables)
+
+| DUT Port | Role | Connected To | GM Port Role |
+|----------|------|-------------|--------------|
+| ens2f1 | TR (upstream, localPriority 100) | ens1f1 | GM-A (masterOnly, domain 24) |
+| ens2f3 | TR (upstream, localPriority 200) | ens1f2 | GM-B (masterOnly, domain 24) |
+| ens2f2 | TT (downstream, masterOnly) | ens3f0 | Downstream client (domain 25) |
+
+## PTP Data Flow
+
+```
+GNSS → GM NIC DPLL (ens1f0) → PHC → ptp4l GM-A (ens1f1) ──loopback──→ DUT ens2f1 (TR primary)
+                                    → ptp4l GM-B (ens1f2) ──loopback──→ DUT ens2f3 (TR backup)
+
+DUT ptp4l (ens2f1/ens2f3) → PHC → DPLL (ens2f0, SDP22) → ptp4l TT (ens2f2) ──loopback──→ ens3f0
+                                                         → phc2sys (-s ens2f1) → CLOCK_REALTIME
+```
+
+## DPLL Clock IDs
+
+| Clock ID | NIC | EEC | PPS |
+|----------|-----|-----|-----|
+| 5799633565436844368 | GM (0000:11) | locked-ho-acq (GNSS) | locked-ho-acq (GNSS) |
+| 5799633565440502668 | DUT (0000:3f) | holdover | locked-ho-acq (SDP22/PTP) |
+| 5799633565440502432 | Downstream (0000:9b) | unlocked | unlocked |
+
+## PtpConfig Profiles
+
+| Profile | Config | NIC | Description |
+|---------|--------|-----|-------------|
+| gm-a | gm-ens2f1 | 0000:11 | ptp4l master on ens1f1, clockClass 6, free_running 1, e810 plugin with gnssInput: true |
+| gm-b | gm-ens2f1 | 0000:11 | ptp4l master on ens1f2, clockClass 6, free_running 1 |
+| tbc-tr | t-bc | 0000:3f | ptp4l slave on ens2f1 (pri 100) + ens2f3 (pri 200), ts2phc, e810 plugin, phc2sys -s ens2f1 |
+| tbc-tt | t-bc | 0000:3f | ptp4l master on ens2f2, domain 25, controlled by tbc-tr |

--- a/docs/features/dual-tr-ports/poc-plan.md
+++ b/docs/features/dual-tr-ports/poc-plan.md
@@ -1,0 +1,518 @@
+# Dual Time Receiver Ports — Proof of Concept Plan
+
+**Date:** 2026-05-17
+**Status:** Draft
+**Epic:** Enable dual time receiver ports (same NIC) for boundary clocks (BC / T-BC)
+
+---
+
+## 1. Objective
+
+Validate that dual time receiver (TR) ports on a boundary clock correctly fail over
+between two upstream PTP paths using ptp4l A-BMCA, with:
+
+- **Per-port state tracking** in the linuxptp-daemon (aggregate holdover only when ALL
+  upstream ports are lost — no false holdover on single-port failure)
+- **phc2sys stability** through switchover and holdover
+- **DPLL control and monitoring orchestration** via HardwareConfig
+
+**Stretch goal — A-BMCA internal vs external clock comparison:** Validate that ptp4l
+compares external source quality against the internal clock (holdover class 135), not
+just against other external sources. This behavior is not specific to dual-TR — it
+applies to single-TR as well — but the dual-TR PoC provides a good opportunity to
+verify it. Covered by exploratory scenarios S2b and S4b.
+
+## 2. Scope
+
+### Two Phases — WPC First
+
+| Phase | GM Node | DUT Node | Configs Tested |
+|-------|---------|----------|----------------|
+| **Phase 1: WPC E810** | WPC E810-XXVDA4T (2 ptp4l instances) | WPC E810-XXVDA4T | T-BC + HwConfig |
+| **Phase 2: GNR-D** | WPC E810-XXVDA4T (2 ptp4l instances) | GNR-D (Dell XR8720t) | T-BC + HwConfig (GNR-D E825 DPLL) |
+
+### Out of Scope
+
+- TR ports on different NICs (all TR ports must share the same PHC)
+- Non-Intel platform HardwareConfig/DPLL support
+- phc2sys automatic mode (`-a`) for dual-TR — use `-s <main-TR-port>` instead
+
+---
+
+## 3. Lab Topology
+
+### 3.1 GM Node Setup
+
+A single WPC E810-XXVDA4T node runs **two independent ptp4l instances**, one per
+downstream port. Both instances are disciplined by the same PHC (same NIC) via
+ts2phc/GNSS, so they provide identical baseline time quality. Each instance can be
+independently controlled via `pmc` to simulate path-specific quality degradation or
+clock class changes.
+
+### 3.2 Diagram — Phase 1: WPC E810 → WPC E810
+
+```
+  ┌──────────────────────────────────────────────┐
+  │         GM Node — Intel WPC E810-XXVDA4T     │
+  │                                              │
+  │  ┌────────────────┐   ┌────────────────┐     │
+  │  │ ptp4l inst-A   │   │ ptp4l inst-B   │     │
+  │  │ clockClass 6   │   │ clockClass 6   │     │
+  │  │ domain 24      │   │ domain 24      │     │
+  │  │ G.8275.x BMCA  │   │ G.8275.x BMCA  │     │
+  │  │                │   │                │     │
+  │  │ Port: ens4f0   │   │ Port: ens4f1   │     │
+  │  │ masterOnly 1   │   │ masterOnly 1   │     │
+  │  └───────┬────────┘   └───────┬────────┘     │
+  │          │     same PHC       │              │
+  │          │                    │              │
+  │          │  ┌──────────────┐  │              │
+  │          └──┤ ts2phc/GNSS  ├──┘              │
+  │             └──────────────┘                 │
+  └──────────────┼────────────────┼──────────────┘
+                 │  P2P L2/PTP   │  P2P L2/PTP
+                 ▼               ▼
+  ┌──────────────────────────────────────────────┐
+  │       DUT Node — Intel WPC E810-XXVDA4T      │
+  │                                              │
+  │  ┌────────────────────────────────────┐      │
+  │  │         ptp4l (single instance)    │      │
+  │  │                                    │      │
+  │  │  ens4f0 ── TR  (localPriority 100) │      │
+  │  │  ens4f1 ── TR  (localPriority 200) │      │
+  │  │  ens4f2 ── TT  (masterOnly 1)      │      │
+  │  │  ens4f3 ── TT  (masterOnly 1)      │      │
+  │  │                                    │      │
+  │  │  A-BMCA: G.8275.x                  │      │
+  │  │  clock_class_threshold: 135        │      │
+  │  └───────────────┬────────────────────┘      │
+  │                  │                           │
+  │         ┌────────┴────────┐                  │
+  │         │    phc2sys      │                  │
+  │         │  -s ens4f0      │                  │
+  │         │  -r -n 24       │                  │
+  │         └─────────────────┘                  │
+  └──────────────────────────────────────────────┘
+```
+
+### 3.3 Diagram — Phase 2: WPC E810 → GNR-D
+
+```
+  ┌──────────────────────────────────────────────┐
+  │         GM Node — Intel WPC E810-XXVDA4T     │
+  │                                              │
+  │  ┌────────────────┐   ┌────────────────┐     │
+  │  │ ptp4l inst-A   │   │ ptp4l inst-B   │     │
+  │  │ clockClass 6   │   │ clockClass 6   │     │
+  │  │ domain 24      │   │ domain 24      │     │
+  │  │ G.8275.x BMCA  │   │ G.8275.x BMCA  │     │
+  │  │                │   │                │     │
+  │  │ Port: ens4f0   │   │ Port: ens4f1   │     │
+  │  │ masterOnly 1   │   │ masterOnly 1   │     │
+  │  └───────┬────────┘   └───────┬────────┘     │
+  │          │     same PHC       │              │
+  │          │                    │              │
+  │          │  ┌──────────────┐  │              │
+  │          └──┤ ts2phc/GNSS  ├──┘              │
+  │             └──────────────┘                 │
+  └──────────────┼────────────────┼──────────────┘
+                 │  P2P L2/PTP   │  P2P L2/PTP
+                 ▼               ▼
+  ┌──────────────────────────────────────────────┐
+  │      DUT Node — GNR-D (Dell XR8720t)         │
+  │      Intel E825 subsystem                    │
+  │                                              │
+  │  ┌────────────────────────────────────┐      │
+  │  │         ptp4l (single instance)    │      │
+  │  │                                    │      │
+  │  │  eno2  ── TR  (localPriority 100)  │      │
+  │  │  eno3  ── TR  (localPriority 200)  │      │
+  │  │  eno4  ── TT  (masterOnly 1)       │      │
+  │  │                                    │      │
+  │  │  A-BMCA: G.8275.x                  │      │
+  │  │  clock_class_threshold: 135        │      │
+  │  └───────────────┬────────────────────┘      │
+  │                  │                           │
+  │  ┌───────────────┴────────────────────┐      │
+  │  │   DPLL via eno5 (E825 leader)      │      │
+  │  │   (HardwareConfig)                 │      │
+  │  └───────────────┬────────────────────┘      │
+  │                  │                           │
+  │         ┌────────┴────────┐                  │
+  │         │    phc2sys      │                  │
+  │         │  -s eno2        │                  │
+  │         │  -r -n 24       │                  │
+  │         └─────────────────┘                  │
+  └──────────────────────────────────────────────┘
+```
+
+### 3.4 GM Clock Class Control via pmc
+
+Each GM ptp4l instance runs on a separate port with its own UDS socket. To control
+which upstream path the DUT selects as active, set different `priority2` values on
+each GM instance (lower = preferred by A-BMCA). To simulate quality degradation,
+manipulate the `clockClass` via `pmc`:
+
+```bash
+# Degrade GM-A (inst-A) to clockClass 165:
+pmc -u -b 0 -f /var/run/ptp4l.0.socket \
+  'SET GRANDMASTER_SETTINGS_NP clockClass 165 clockAccuracy 0x21 \
+   offsetScaledLogVariance 0x4e5d currentUtcOffset 37 leap61 0 \
+   leap59 0 currentUtcOffsetValid 1 ptpTimescale 1 \
+   timeTraceable 1 frequencyTraceable 1 timeSource 0x20'
+
+# Restore GM-A to clockClass 6:
+pmc -u -b 0 -f /var/run/ptp4l.0.socket \
+  'SET GRANDMASTER_SETTINGS_NP clockClass 6 clockAccuracy 0x21 \
+   offsetScaledLogVariance 0x4e5d currentUtcOffset 37 leap61 0 \
+   leap59 0 currentUtcOffsetValid 1 ptpTimescale 1 \
+   timeTraceable 1 frequencyTraceable 1 timeSource 0x20'
+```
+
+---
+
+## 4. Phase 1 Test Matrix — WPC E810 DUT
+
+| Test ID | DUT PtpConfig | HardwareConfig | What It Validates |
+|---------|---------------|----------------|-------------------|
+| **P1-A** | `poc-e810-tbc-dual-tr.yaml` | `poc-e810-hwconfig-dual-tr.yaml` | T-BC with full HwConfig orchestration: DPLL + per-port state + offset filtering |
+
+---
+
+## 5. Test Scenarios
+
+### Pre-conditions (all scenarios)
+
+Before starting each scenario, verify:
+
+1. DUT PtpConfig is applied and ptp4l is running
+2. One TR port is in SLAVE state (the preferred port — localPriority 100 for T-BC)
+3. The other TR port is in PASSIVE
+4. phc2sys is running with `-s <main-TR-port>` (e.g., `-s ens4f0`) — verify no `-a` flag
+5. Downstream TT ports are in MASTER state
+6. Both GM ptp4l instances are running, announcing clockClass 6
+
+```bash
+# Verify DUT port states:
+oc logs -n openshift-ptp <daemon-pod> -c linuxptp-daemon-container | \
+  grep -E "(to SLAVE|to PASSIVE|to MASTER|to LISTENING)" | tail -10
+
+# Verify phc2sys is running with interface name (not -a):
+oc logs -n openshift-ptp <daemon-pod> -c linuxptp-daemon-container | \
+  grep "phc2sys" | grep "\-s" | tail -5
+
+# Verify GM instances are announcing clockClass 6:
+# On GM node:
+pmc -u -b 0 -f /var/run/ptp4l.0.socket 'GET GRANDMASTER_SETTINGS_NP'
+pmc -u -b 0 -f /var/run/ptp4l.1.socket 'GET GRANDMASTER_SETTINGS_NP'
+```
+
+---
+
+### Scenario 1 — Active upstream port disconnection
+
+**Purpose:** Validate that when the active upstream path is lost due to physical
+disconnection, the DUT re-selects the backup upstream path — provided the backup
+source quality is better than the internal clock.
+
+#### Steps
+
+| Step | Action | Expected Result |
+|------|--------|-----------------|
+| 1.1 | Identify the active TR port | Grep logs for `"to SLAVE on MASTER_CLOCK_SELECTED"`. The active path can be controlled by setting different `priority2` values on each GM ptp4l instance (lower value = preferred by A-BMCA). |
+| 1.2 | **Disconnect the active upstream path** | Physical cable pull, or `sudo ip link set <GM-port> down` on the GM node (e.g., `ip link set ens2f0 down` if ens2f0 is the GM peer of the DUT's active TR port) |
+| 1.3 | ptp4l detects loss | Active port: `"SLAVE to FAULTY"` within ~50ms (`tx_timestamp_timeout 50`) |
+| 1.4 | A-BMCA evaluates backup vs internal | Backup port's GM is clockClass 6 (better than internal holdover class 135). A-BMCA selects backup. |
+| 1.5 | BMCA promotes backup port | Backup port: `"PASSIVE to UNCALIBRATED on RS_SLAVE"` then `"UNCALIBRATED to SLAVE on MASTER_CLOCK_SELECTED"` |
+| 1.6 | Daemon per-port state | Log: `"BC port ens4f0 lost SLAVE"` then `"BC port ens4f1 LOCKED"` |
+| 1.7 | Brief holdover during BMCA gap | Log may show `"all upstream ports lost"` briefly while BMCA promotes backup port. Must be followed by `"BC port <backup> LOCKED"` and holdover exit once backup reaches SLAVE. |
+| 1.8 | DPLL behavior | Brief holdover during BMCA gap (~5-7s: UNCALIBRATED→SLAVE ~1-3 sync intervals + offset filter fill ~4s). Then DPLL re-locks. Log: `"T-BC MOVE TO NORMAL STATE"` |
+| 1.9 | phc2sys continuity | phc2sys continues on main TR port — no restart, no error, system clock updated throughout |
+| 1.10 | Downstream TT ports | Remain in MASTER state throughout the switchover |
+
+#### Pass Criteria
+
+- Backup port becomes SLAVE within 30s of active port failure
+- phc2sys is NOT restarted
+- Brief holdover during the BMCA gap is expected (DPLL not disciplined by PTP until backup port locks). DUT must exit holdover once backup reaches SLAVE.
+- Downstream TT ports remain stable in MASTER
+
+---
+
+### Scenario 2 — Active upstream quality degradation with A-BMCA internal clock comparison
+
+**Purpose:** Validate two sub-cases of quality degradation:
+- **S2a:** Active path degrades but backup path has better quality than internal clock
+  → DUT switches to backup
+- **S2b:** Active path degrades AND backup path also has worse quality than the internal
+  clock in holdover → DUT remains in holdover (does NOT lock to degraded external source)
+
+This validates that A-BMCA compares external sources against the internal clock
+(holdover class 135, controlled by `clock_class_threshold`), not just against each other.
+
+#### S2a — Backup path has better quality than internal clock
+
+| Step | Action | Expected Result |
+|------|--------|-----------------|
+| 2a.1 | Verify DUT steady state | ens4f0 is SLAVE (localPriority 100), ens4f1 is PASSIVE |
+| 2a.2 | **Degrade GM-A to clockClass 165** | `pmc -u -b 0 -f /var/run/ptp4l.0.socket 'SET GRANDMASTER_SETTINGS_NP clockClass 165 ...'` |
+| 2a.3 | A-BMCA re-evaluates | DUT detects degraded announce from GM-A (clockClass 165). GM-B is still clockClass 6. |
+| 2a.4 | A-BMCA comparison | GM-B (class 6) is better than GM-A (class 165) AND better than internal clock (class 135 threshold). A-BMCA selects GM-B. |
+| 2a.5 | Port switchover | ens4f1: `"PASSIVE → UNCALIBRATED → SLAVE"`. ens4f0: `"SLAVE → PASSIVE"` or `"SLAVE → LISTENING"` |
+| 2a.6 | Daemon per-port tracking | Per-port state updates. Brief holdover possible during BMCA gap until backup port reaches SLAVE. |
+| 2a.7 | phc2sys | Unaffected — still syncing from main TR port |
+| 2a.8 | Restore GM-A to clockClass 6 | `pmc` restore. A-BMCA may switch back to ens4f0 (lower localPriority). |
+
+**Pass criteria:** DUT switches to backup port. No holdover. phc2sys stable.
+
+#### S2b — Both external sources worse than internal clock (EXPLORATORY)
+
+> **Note:** This scenario is **exploratory**. The design spec (Section 8 — Out of
+> Scope) defers the A-BMCA internal-vs-external clock class awareness to a separate
+> epic. The behavior tested here relies on ptp4l's `clock_class_threshold` parameter,
+> not on A-BMCA logic itself. The purpose of this scenario is to **determine whether
+> `clock_class_threshold 135` achieves the desired rejection** of degraded sources.
+> If ptp4l does NOT reject the external sources, document the actual behavior — this
+> informs whether additional logic is needed in the daemon or ptp4l configuration.
+
+| Step | Action | Expected Result |
+|------|--------|-----------------|
+| 2b.1 | Verify DUT steady state | ens4f0 is SLAVE, ens4f1 is PASSIVE |
+| 2b.2 | **Degrade GM-A to clockClass 165** | `pmc` on inst-A socket |
+| 2b.3 | **Degrade GM-B to clockClass 165** | `pmc -u -b 0 -f /var/run/ptp4l.1.socket 'SET GRANDMASTER_SETTINGS_NP clockClass 165 ...'` |
+| 2b.4 | A-BMCA re-evaluates | Both external sources are clockClass 165. Internal clock threshold is 135. |
+| 2b.5 | **Observe: does ptp4l reject both external sources?** | **Expected (if clock_class_threshold works):** clockClass 165 > threshold 135, ptp4l rejects both. Both TR ports leave SLAVE. **Alternative (if threshold does not apply here):** ptp4l may keep one port in SLAVE because 165 < 248 (default clockClass). Document actual behavior. |
+| 2b.6 | If both rejected → DUT enters holdover | Log: `"all upstream ports lost - MOVE TO HOLDOVER"` |
+| 2b.7 | DPLL holdover | DPLL enters hardware holdover. Plugin hook `tbc-ho-entry` fired. |
+| 2b.8 | phc2sys | Continues on main TR port. PHC hardware-disciplined in holdover. |
+| 2b.9 | **Restore GM-A to clockClass 6** | `pmc` on inst-A socket |
+| 2b.10 | A-BMCA re-evaluates | GM-A (class 6) is now better than internal clock (class 135). A-BMCA selects GM-A. |
+| 2b.11 | Recovery | ens4f0 transitions to SLAVE. Daemon exits holdover. |
+
+**Expected outcome:** DUT does NOT lock to clockClass 165 sources when internal
+holdover clock (class 135) is better. DUT enters holdover instead. DUT recovers when
+a source with quality better than internal clock becomes available.
+
+**If ptp4l does NOT reject the degraded sources:** Document the actual behavior and
+the conclusion that additional logic (either in ptp4l configuration or in the daemon)
+is needed to handle this case. This finding feeds into the deferred epic.
+
+---
+
+### Scenario 3 — Both upstream paths lost (holdover entry)
+
+**Purpose:** Validate that the DUT enters holdover when both upstream paths are
+physically lost, and that holdover is correctly detected only after ALL ports lose
+SLAVE state.
+
+#### Steps
+
+| Step | Action | Expected Result |
+|------|--------|-----------------|
+| 3.1 | Verify DUT steady state | One TR port is SLAVE |
+| 3.2 | **Disconnect both upstream paths simultaneously** | Physical cable pull on both ports, or `sudo ip link set <GM-port-A> down && sudo ip link set <GM-port-B> down` on the GM node. If simultaneous disconnect is not feasible, bring down the backup GM port first (DUT backup port is PASSIVE, no state change), then the active GM port. |
+| 3.3 | Both ports lose upstream connectivity | Active port loses SLAVE. Backup port never receives announces to trigger BMCA promotion. |
+| 3.4 | Both ports lost | Both TR ports: `"to FAULTY"` (with `ip link set down`) or `"to MASTER on ANNOUNCE_RECEIPT_TIMEOUT_EXPIRES"` / `"to LISTENING"` (with cable pull) |
+| 3.5 | Aggregate holdover detection | Log: `"BC all upstream ports lost - MOVE TO HOLDOVER"` |
+| 3.6 | DPLL holdover | DPLL enters hardware holdover. Log: `"tbc-ho-entry"` plugin hook fired. |
+| 3.7 | phc2sys behavior | Continues running on main TR port. PHC hardware-disciplined in holdover, system clock gets holdover-quality time. |
+| 3.8 | Downstream TT ports | Remain in MASTER state — still serving time (holdover quality). DUT clockClass changes to 135 (holdover). |
+
+#### Pass Criteria
+
+- Holdover detected ONLY after BOTH ports lost — not on single-port failure
+- DPLL enters hardware holdover, plugin hook `tbc-ho-entry` fired
+- phc2sys continues running
+- DUT clockClass advertised to downstream changes to holdover class (135)
+
+---
+
+### Scenario 4 — Recovery from holdover with A-BMCA internal clock comparison
+
+**Purpose:** Validate that the DUT recovers from holdover and synchronizes to the
+upstream clock ONLY IF the upstream clock quality is better than the local clock's
+holdover quality. If the recovering source has worse quality than the internal
+holdover clock, the DUT must remain in holdover.
+
+#### S4a — Upstream source quality is better than internal holdover clock
+
+| Step | Action | Expected Result |
+|------|--------|-----------------|
+| 4a.1 | Start from holdover state (Scenario 3) | Both ports disconnected, DUT in holdover, clockClass 135 |
+| 4a.2 | **Reconnect one upstream path** (e.g., to GM-B, clockClass 6) | Reconnect cable or `sudo ip link set <GM-port-B> up`. GM-B is announcing clockClass 6, which is better than internal holdover class 135. |
+| 4a.3 | ptp4l detects announces | Port transitions: `"LISTENING → UNCALIBRATED on RS_SLAVE"` → `"UNCALIBRATED → SLAVE on MASTER_CLOCK_SELECTED"` |
+| 4a.4 | A-BMCA comparison | GM-B clockClass 6 < clock_class_threshold 135. A-BMCA accepts external source. |
+| 4a.5 | Daemon recovery | Log: `"BC port ens4f1 LOCKED"`. `allPortsLost()` returns false. |
+| 4a.6 | DPLL recovery | DPLL exits holdover after offset filter stabilizes (~4s). Log: `"T-BC MOVE TO NORMAL STATE"`. Plugin hook `tbc-ho-exit` fired. |
+| 4a.7 | phc2sys | Continues uninterrupted. System clock now receiving accurate time again. |
+| 4a.8 | Reconnect second upstream path | Reconnect cable or `ip link set up`. Second port becomes PASSIVE — no dual-SLAVE condition. |
+| 4a.9 | DUT clockClass | Changes back from 135 (holdover) to 6 (locked to external source) |
+
+**Pass criteria:** Clean exit from holdover. No dual-SLAVE. phc2sys unaffected. DUT
+clockClass restored.
+
+#### S4b — Upstream source quality is worse than internal holdover clock (EXPLORATORY)
+
+> **Note:** Same caveat as S2b — this is an **exploratory scenario** testing whether
+> `clock_class_threshold` prevents ptp4l from locking to a degraded source during
+> holdover. The design spec defers this as an open question. Document actual behavior.
+
+| Step | Action | Expected Result |
+|------|--------|-----------------|
+| 4b.1 | Start from holdover state (Scenario 3) | Both ports disconnected, DUT in holdover, clockClass 135 |
+| 4b.2 | **On GM-B, set clockClass to 165** | `pmc -u -b 0 -f /var/run/ptp4l.1.socket 'SET GRANDMASTER_SETTINGS_NP clockClass 165 ...'` |
+| 4b.3 | **Reconnect upstream path to GM-B** | Reconnect cable or `sudo ip link set <GM-port-B> up`. GM-B is announcing clockClass 165. |
+| 4b.4 | **Observe: does ptp4l reject the degraded source?** | **Expected (if clock_class_threshold works):** clockClass 165 > threshold 135. ptp4l rejects. Port does NOT transition to SLAVE. DUT remains in holdover. **Alternative:** ptp4l may accept the source (165 < 248). Document actual behavior. |
+| 4b.5 | If rejected → DUT remains in holdover | Log: no `"to SLAVE"` for the reconnected port |
+| 4b.6 | phc2sys | Continues on main TR port in holdover mode |
+| 4b.7 | **Restore GM-B to clockClass 6** | `pmc` on inst-B socket |
+| 4b.8 | A-BMCA re-evaluates | GM-B clockClass 6 < threshold 135. A-BMCA accepts. |
+| 4b.9 | DUT recovers | Port transitions to SLAVE. Daemon exits holdover. |
+
+**Expected outcome:** DUT does NOT lock to clockClass 165 source while in holdover
+(internal clock at class 135 is better). DUT recovers only when source quality
+improves above the threshold.
+
+**If ptp4l accepts the degraded source:** Document this as a finding. It means
+`clock_class_threshold` does not prevent locking to a source with clockClass between
+the threshold and the default (248), and additional logic is needed.
+
+---
+
+## 6. Phase 2 Test Matrix — GNR-D DUT
+
+| Test ID | DUT PtpConfig | HardwareConfig | What It Validates |
+|---------|---------------|----------------|-------------------|
+| **P2-A** | `poc-gnrd-tbc-dual-tr.yaml` | `poc-gnrd-hwconfig-dual-tr.yaml` | T-BC with GNR-D E825 DPLL + HardwareConfig |
+
+Same scenarios (S1, S2a, S2b, S3, S4a, S4b) executed on GNR-D DUT.
+
+Key differences to observe vs Phase 1:
+- GNR-D uses E825 DPLL (different pin labels: `GNR-D_SDP0`, `GNSS_1PPS_IN`)
+- DPLL leader interface is `eno5` (not one of the TR ports)
+- TR ports are `eno2` and `eno3` (interface names vary by firmware/BIOS — verify
+  with `ip link` and `ethtool -T` on target hardware)
+- Different holdover oscillator characteristics (E825 vs E810 TCXO)
+
+---
+
+## 7. Measurements and Observability
+
+### 7.1 Switchover Time
+
+Measure the time between the active port losing SLAVE and the backup port entering
+SLAVE. Extract from ptp4l log timestamps:
+
+```bash
+# Timestamp of active port losing SLAVE:
+oc logs -n openshift-ptp <daemon-pod> -c linuxptp-daemon-container | \
+  grep "ens4f0.*SLAVE to" | tail -1
+
+# Timestamp of backup port entering SLAVE:
+oc logs -n openshift-ptp <daemon-pod> -c linuxptp-daemon-container | \
+  grep "ens4f1.*to SLAVE on MASTER_CLOCK_SELECTED" | tail -1
+
+# Delta = switchover time. Target: < 10 seconds.
+```
+
+### 7.2 Holdover Duration
+
+For scenarios where DPLL enters holdover (P1-A, P2-A), measure the holdover window:
+
+```bash
+# Holdover entry:
+oc logs ... | grep "MOVE TO HOLDOVER" | tail -1
+
+# Holdover exit:
+oc logs ... | grep "MOVE TO NORMAL STATE" | tail -1
+
+# Delta = holdover duration during switchover.
+# Expected: ~6-8s (BMCA timeout + offset filter fill).
+# For E810 TCXO (~1.5ppm): worst-case drift ~12ns during this window.
+```
+
+### 7.3 phc2sys Continuity
+
+Verify phc2sys was not restarted during any scenario:
+
+```bash
+# Check phc2sys process start count (should be 1 throughout all scenarios):
+oc logs -n openshift-ptp <daemon-pod> -c linuxptp-daemon-container | \
+  grep -c "phc2sys.*started"
+
+# Verify phc2sys offset is being reported throughout:
+oc logs -n openshift-ptp <daemon-pod> -c linuxptp-daemon-container | \
+  grep "phc2sys.*offset" | tail -20
+```
+
+### 7.4 DUT ClockClass Advertised Downstream
+
+Verify the DUT's clockClass changes correctly during holdover:
+
+```bash
+# On a downstream device or via pmc on DUT:
+pmc -u -b 0 'GET GRANDMASTER_SETTINGS_NP'
+# During normal operation: clockClass 6
+# During holdover: clockClass 135
+# After recovery: clockClass 6
+```
+
+---
+
+## 8. DUT Configuration Files
+
+### Phase 1 — WPC E810
+
+| Config | File | Notes |
+|--------|------|-------|
+| P1-A PtpConfig | `poc-e810-tbc-dual-tr.yaml` | T-BC with upstreamPort: ens4f0,ens4f1 |
+| P1-A HardwareConfig | `poc-e810-hwconfig-dual-tr.yaml` | DPLL conditions: init, locked, lost |
+
+**Note on phc2sysOpts:** All PoC config YAMLs use `-s <main-TR-port>` (the primary
+upstream interface name, e.g., `-s ens4f0`).
+
+### Phase 2 — GNR-D
+
+| Config | File | Notes |
+|--------|------|-------|
+| P2-A PtpConfig | `poc-gnrd-tbc-dual-tr.yaml` | T-BC with upstreamPort: eno2,eno3 |
+| P2-A HardwareConfig | `poc-gnrd-hwconfig-dual-tr.yaml` | GNR-D DPLL conditions via eno5 leader |
+
+---
+
+## 9. Expected PoC Results Summary
+
+| Result | How We Validate | Applies To |
+|--------|-----------------|------------|
+| A-BMCA correctly selects best upstream port | Port state transitions in ptp4l logs | P1-A, P2-A |
+| A-BMCA compares external vs internal clock | DUT stays in holdover when external source is worse than holdover class (S2b, S4b) | P1-A, P2-A |
+| A-BMCA recovers only when external > internal | DUT locks to external source only when clockClass < threshold 135 (S4a) | P1-A, P2-A |
+| phc2sys on main TR port stable through all transitions | phc2sys not restarted, no errors, system clock updated | P1-A, P2-A |
+| Aggregate holdover detection | Brief holdover during BMCA gap on single-port failure (S1, S2a), full holdover only when all ports lost (S3) | P1-A, P2-A |
+| DPLL holdover/recovery | DPLL pin conditions change on entry/exit, holdover offset within spec | P1-A, P2-A |
+| Plugin hooks | `tbc-ho-entry`/`tbc-ho-exit` called on holdover entry/exit | P1-A, P2-A |
+| Switchover time | < 10s from active port loss to backup port SLAVE | P1-A, P2-A |
+| DUT clockClass reflects state | Class 6 when locked, class 135 in holdover | P1-A, P2-A |
+| Clean recovery, no dual-SLAVE | Only one port in SLAVE after recovery | P1-A, P2-A |
+
+---
+
+## 10. Known Limitations and Caveats
+
+1. **clock_class_threshold behavior:** The `clock_class_threshold 135` setting in ptp4l
+   controls whether ptp4l accepts an external source. When the DUT is in holdover and
+   its own clockClass is 135, ptp4l should reject sources with clockClass > 135.
+   This is the mechanism that prevents locking to degraded sources. The PoC must verify
+   this works correctly in practice.
+
+2. **DPLL brief holdover during switchover:** Even in the single-port-failure case (S1),
+   the DPLL will briefly enter holdover during the BMCA gap. This is by design — the
+   DPLL is not being disciplined by PTP during that ~6-8s window. The holdover drift
+   during this gap is negligible for E810 TCXO (~12ns worst case).
+
+3. **phc2sys must use `-s <main-TR-port>` (interface name):**
+
+4. **GM node PtpConfig:** The GM node configuration (two independent ptp4l instances
+   on separate ports) is not provided in this document. The tester configures the GM
+   node with two profiles, each mastering on a separate E810 port, sharing the same
+   PHC via ts2phc/GNSS.

--- a/docs/features/dual-tr-ports/wpc-configs/wpc-gm.yaml
+++ b/docs/features/dual-tr-ports/wpc-configs/wpc-gm.yaml
@@ -1,0 +1,207 @@
+# Grandmaster (GM) config for dual TR port PoC — NIC 0000:11 (Intel E810-XXVDA4T)
+#
+# Runs two independent free-running ptp4l master instances on separate ports,
+# each feeding one upstream TR port on the DUT T-BC via loopback cable:
+#
+#   gm-a: ens1f1 (masterOnly) → DUT ens2f1 (TR, localPriority 100)
+#   gm-b: ens1f2 (masterOnly) → DUT ens2f3 (TR, localPriority 200)
+#
+# Both instances share the same PHC on NIC 0000:11. The DPLL on this NIC is
+# locked to GNSS via the e810 plugin (gnssInput: true on gm-a), so the PHC
+# is hardware-disciplined to GPS time.
+
+# NIC: Intel E810-XXVDA4T (PCI 0000:11), GNSS receiver on gnss0
+# DPLL: locked-ho-acq on GNSS, Clock ID: 0x507c6ffffe4b9950
+# Domain 24, ITU-T G.8275.x telecom profile, L2 transport
+apiVersion: ptp.openshift.io/v1
+kind: PtpConfig
+metadata:
+  name: gm
+  namespace: openshift-ptp
+spec:
+  profile:
+  - name: gm-a
+    ptp4lConf: |
+      [ens1f1]
+      masterOnly 1
+      [global]
+      twoStepFlag 1
+      slaveOnly 0
+      priority1 128
+      priority2 128
+      domainNumber 24
+      clockClass 6
+      clockAccuracy 0x21
+      offsetScaledLogVariance 0x4E5D
+      free_running 1
+      freq_est_interval 1
+      dscp_event 0
+      dscp_general 0
+      dataset_comparison G.8275.x
+      G.8275.defaultDS.localPriority 128
+      logAnnounceInterval -3
+      logSyncInterval -4
+      logMinDelayReqInterval -4
+      logMinPdelayReqInterval -4
+      announceReceiptTimeout 3
+      syncReceiptTimeout 0
+      delayAsymmetry 0
+      fault_reset_interval -4
+      neighborPropDelayThresh 20000000
+      masterOnly 0
+      G.8275.portDS.localPriority 128
+      assume_two_step 0
+      logging_level 6
+      path_trace_enabled 0
+      follow_up_info 0
+      hybrid_e2e 0
+      inhibit_multicast_service 0
+      net_sync_monitor 0
+      tc_spanning_tree 0
+      tx_timestamp_timeout 50
+      unicast_listen 0
+      unicast_master_table 0
+      unicast_req_duration 3600
+      use_syslog 1
+      verbose 0
+      summary_interval 0
+      kernel_leap 1
+      check_fup_sync 0
+      clock_class_threshold 248
+      pi_proportional_const 0.0
+      pi_integral_const 0.0
+      pi_proportional_scale 0.0
+      pi_proportional_exponent -0.3
+      pi_proportional_norm_max 0.7
+      pi_integral_scale 0.0
+      pi_integral_exponent 0.4
+      pi_integral_norm_max 0.3
+      step_threshold 2.0
+      first_step_threshold 0.00002
+      max_frequency 900000000
+      clock_servo pi
+      sanity_freq_limit 200000000
+      ntpshm_segment 0
+      transportSpecific 0x0
+      ptp_dst_mac 01:1B:19:00:00:00
+      p2p_dst_mac 01:80:C2:00:00:0E
+      udp_ttl 1
+      udp6_scope 0x0E
+      uds_address /var/run/ptp4l
+      clock_type OC
+      network_transport L2
+      delay_mechanism E2E
+      time_stamping hardware
+      tsproc_mode filter
+      delay_filter moving_median
+      delay_filter_length 10
+      egressLatency 0
+      ingressLatency 0
+      boundary_clock_jbod 0
+      productDescription ;;
+      revisionData ;;
+      manufacturerIdentity 00:00:00
+      userDescription ;
+      timeSource 0x20
+    ptp4lOpts: "-2 --summary_interval -4"
+    ptpSchedulingPolicy: SCHED_FIFO
+    ptpSchedulingPriority: 10
+    ptpSettings:
+      logReduce: "false"
+  - name: gm-b
+    ptp4lConf: |
+      [ens1f2]
+      masterOnly 1
+      [global]
+      twoStepFlag 1
+      slaveOnly 0
+      priority1 128
+      priority2 128
+      domainNumber 24
+      clockClass 6
+      clockAccuracy 0x21
+      offsetScaledLogVariance 0x4E5D
+      free_running 1
+      freq_est_interval 1
+      dscp_event 0
+      dscp_general 0
+      dataset_comparison G.8275.x
+      G.8275.defaultDS.localPriority 128
+      logAnnounceInterval -3
+      logSyncInterval -4
+      logMinDelayReqInterval -4
+      logMinPdelayReqInterval -4
+      announceReceiptTimeout 3
+      syncReceiptTimeout 0
+      delayAsymmetry 0
+      fault_reset_interval -4
+      neighborPropDelayThresh 20000000
+      masterOnly 0
+      G.8275.portDS.localPriority 128
+      assume_two_step 0
+      logging_level 6
+      path_trace_enabled 0
+      follow_up_info 0
+      hybrid_e2e 0
+      inhibit_multicast_service 0
+      net_sync_monitor 0
+      tc_spanning_tree 0
+      tx_timestamp_timeout 50
+      unicast_listen 0
+      unicast_master_table 0
+      unicast_req_duration 3600
+      use_syslog 1
+      verbose 0
+      summary_interval 0
+      kernel_leap 1
+      check_fup_sync 0
+      clock_class_threshold 248
+      pi_proportional_const 0.0
+      pi_integral_const 0.0
+      pi_proportional_scale 0.0
+      pi_proportional_exponent -0.3
+      pi_proportional_norm_max 0.7
+      pi_integral_scale 0.0
+      pi_integral_exponent 0.4
+      pi_integral_norm_max 0.3
+      step_threshold 2.0
+      first_step_threshold 0.00002
+      max_frequency 900000000
+      clock_servo pi
+      sanity_freq_limit 200000000
+      ntpshm_segment 0
+      transportSpecific 0x0
+      ptp_dst_mac 01:1B:19:00:00:00
+      p2p_dst_mac 01:80:C2:00:00:0E
+      udp_ttl 1
+      udp6_scope 0x0E
+      uds_address /var/run/ptp4l
+      clock_type OC
+      network_transport L2
+      delay_mechanism E2E
+      time_stamping hardware
+      tsproc_mode filter
+      delay_filter moving_median
+      delay_filter_length 10
+      egressLatency 0
+      ingressLatency 0
+      boundary_clock_jbod 0
+      productDescription ;;
+      revisionData ;;
+      manufacturerIdentity 00:00:00
+      userDescription ;
+      timeSource 0x20
+    ptp4lOpts: "-2 --summary_interval -4"
+    ptpSchedulingPolicy: SCHED_FIFO
+    ptpSchedulingPriority: 10
+    ptpSettings:
+      logReduce: "false"
+  recommend:
+  - match:
+    - nodeLabel: node-role.kubernetes.io/master
+    priority: 4
+    profile: gm-a
+  - match:
+    - nodeLabel: node-role.kubernetes.io/master
+    priority: 4
+    profile: gm-b

--- a/docs/features/dual-tr-ports/wpc-configs/wpc-hwconfig.yaml
+++ b/docs/features/dual-tr-ports/wpc-configs/wpc-hwconfig.yaml
@@ -1,0 +1,118 @@
+apiVersion: ptp.openshift.io/v2alpha1
+kind: HardwareConfig
+metadata:
+  name: wpc-hwconfig
+  namespace: openshift-ptp
+spec:
+  profile:
+    clockChain:
+      behavior:
+        conditions:
+        - desiredStates:
+          - ptpPin:
+              name: SMA1
+              func: Disabled
+              chan: 0
+              sourceName: PTP
+          - ptpPin:
+              name: SMA2
+              func: TX
+              chan: 2
+              sourceName: PTP
+          - ptpPeriod:
+              index: 2
+              period:
+                sec: 1
+                nsec: 0
+              sourceName: PTP
+          - dpll:
+              subsystem: leader
+              boardLabel: GNSS-1PPS
+              eec:
+                priority: 255
+              pps:
+                priority: 255
+          - dpll:
+              boardLabel: CVL-SDP20
+              eec:
+                priority: 255
+              pps:
+                priority: 255
+              subsystem: leader
+          - dpll:
+              boardLabel: CVL-SDP21
+              eec:
+                state: disconnected
+              pps:
+                state: disconnected
+              subsystem: leader
+          name: Initialize T-BC
+          triggers:
+          - conditionType: init
+            sourceName: PTP
+        - desiredStates:
+          - dpll:
+              subsystem: leader
+              boardLabel: CVL-SDP22
+              eec:
+                priority: 255
+              pps:
+                priority: 0
+          - dpll:
+              subsystem: leader
+              boardLabel: CVL-SDP23
+              eec:
+                state: disconnected
+              pps:
+                state: disconnected
+          name: PTP Source Active
+          triggers:
+          - conditionType: locked
+            sourceName: PTP
+        - desiredStates:
+          - dpll:
+              subsystem: leader
+              boardLabel: CVL-SDP22
+              eec:
+                priority: 255
+              pps:
+                priority: 255
+          - dpll:
+              subsystem: leader
+              boardLabel: CVL-SDP23
+              eec:
+                state: disconnected
+              pps:
+                state: connected
+          name: PTP Source Lost - Leader Holdover
+          triggers:
+          - conditionType: lost
+            sourceName: PTP
+        sources:
+        - boardLabel: CVL-SDP22
+          name: PTP
+          ptpTimeReceivers:
+          - ens2f1
+          - ens2f3
+          sourceType: ptpTimeReceiver
+          subsystem: leader
+      structure:
+      - dpll:
+          holdoverParameters:
+            maxInSpecOffset: 100
+            localMaxHoldoverOffset: 1500
+            localHoldoverTimeout: 14400
+          networkInterface: ens2f0
+          phaseInputs:
+            CVL-SDP22:
+              description: PTP TR input
+              frequency: 1
+        ethernet:
+        - ports:
+          - ens2f0
+          - ens2f1
+          - ens2f3
+        hardwareSpecificDefinitions: intel/e810
+        name: leader
+    name: wpc-hwconfig
+  relatedPtpProfileName: tbc-tr

--- a/docs/features/dual-tr-ports/wpc-configs/wpc-tbc.yaml
+++ b/docs/features/dual-tr-ports/wpc-configs/wpc-tbc.yaml
@@ -1,0 +1,296 @@
+# T-BC (Telecom Boundary Clock) with WPC (Westport Channel) configuration
+# This profile receives PTP time from an upstream source and redistributes it
+# Interface variables:
+#   - $iface_timeRx: Receives (Rx) PTP time from upstream source
+#   - $iface_FirstPort: First port on the card (used for WPC timing)
+#   - $iface_timeTx_N: Transmits (Tx) PTP time to downstream devices (N = 0-2)
+apiVersion: ptp.openshift.io/v1
+kind: PtpConfig
+metadata:
+  name: t-bc
+  namespace: openshift-ptp
+  annotations:
+    ran.openshift.io/ztp-deploy-wave: "10"
+spec:
+  profile:
+  - name: tbc-tr
+    phc2sysOpts: -r -n 24 -N 8 -R 16 -u 0 -m -s ens2f1
+    plugins:
+      e810:
+        enableDefaultConfig: false
+        interconnections:
+          - gnssInput: false
+            id: ens2f0
+            part: E810-XXVDA4T
+            phaseOutputConnectors:
+            - SMA1
+            upstreamPort: ens2f1,ens2f3
+        settings:
+          LocalHoldoverTimeout: 14400
+          LocalMaxHoldoverOffSet: 1500
+          MaxInSpecOffset: 100
+        pins:
+          # Syntax guide:
+          # - The 1st number in each pair must be one of:
+          #    0 - Disabled
+          #    1 - RX
+          #    2 - TX
+          # - The 2nd number in each pair must match the channel number
+          ens2f0:
+            SMA1: 2 1
+            SMA2: 2 2
+            U.FL1: 0 1
+            U.FL2: 0 2
+    ptp4lConf: |
+      # The interface name is hardware-specific
+      [ens2f1]
+      masterOnly 0
+      [ens2f3]
+      masterOnly 0
+      [global]
+      #
+      # Default Data Set
+      #
+      twoStepFlag 1
+      slaveOnly 1
+      priority1 128
+      priority2 128
+      domainNumber 24
+      clockClass 248
+      clockAccuracy 0xFE
+      offsetScaledLogVariance 0xFFFF
+      free_running 0
+      freq_est_interval 1
+      dscp_event 0
+      dscp_general 0
+      dataset_comparison G.8275.x
+      G.8275.defaultDS.localPriority 128
+      #
+      # Port Data Set
+      #
+      logAnnounceInterval -3
+      logSyncInterval -4
+      logMinDelayReqInterval -4
+      logMinPdelayReqInterval -4
+      announceReceiptTimeout 3
+      syncReceiptTimeout 0
+      delayAsymmetry 0
+      fault_reset_interval -4
+      neighborPropDelayThresh 20000000
+      masterOnly 0
+      G.8275.portDS.localPriority 128
+      #
+      # Run time options
+      #
+      assume_two_step 0
+      logging_level 6
+      path_trace_enabled 0
+      follow_up_info 0
+      hybrid_e2e 0
+      inhibit_multicast_service 0
+      net_sync_monitor 0
+      tc_spanning_tree 0
+      tx_timestamp_timeout 50
+      unicast_listen 0
+      unicast_master_table 0
+      unicast_req_duration 3600
+      use_syslog 1
+      verbose 0
+      summary_interval 0
+      kernel_leap 1
+      check_fup_sync 0
+      clock_class_threshold 135
+      #
+      # Servo Options
+      #
+      pi_proportional_const 0.60
+      pi_integral_const 0.0003
+      pi_proportional_scale 0.0
+      pi_proportional_exponent -0.3
+      pi_proportional_norm_max 0.7
+      pi_integral_scale 0.0
+      pi_integral_exponent 0.4
+      pi_integral_norm_max 0.3
+      step_threshold 2.0
+      first_step_threshold 0.00002
+      max_frequency 900000000
+      clock_servo pi
+      sanity_freq_limit 200000000
+      ntpshm_segment 0
+      #
+      # Transport options
+      #
+      transportSpecific 0x0
+      ptp_dst_mac 01:1B:19:00:00:00
+      p2p_dst_mac 01:80:C2:00:00:0E
+      udp_ttl 1
+      udp6_scope 0x0E
+      uds_address /var/run/ptp4l
+      #
+      # Default interface options
+      #
+      clock_type OC
+      network_transport L2
+      delay_mechanism E2E
+      time_stamping hardware
+      tsproc_mode filter
+      delay_filter moving_median
+      delay_filter_length 10
+      egressLatency 0
+      ingressLatency 0
+      # ens2f1 and ens2f3 share the same PHC (same NIC, disciplined via ens2f0's
+      # DPLL). boundary_clock_jbod must stay 0 (default): setting it to 1 makes
+      # ptp4l tear down and recreate the clock servo (fresh PI state, count=0)
+      boundary_clock_jbod 0
+      #
+      # Clock description
+      #
+      productDescription ;;
+      revisionData ;;
+      manufacturerIdentity 00:00:00
+      userDescription ;
+      timeSource 0xA0
+    ptp4lOpts: -2 --summary_interval -4
+    ptpSchedulingPolicy: SCHED_FIFO
+    ptpSchedulingPriority: 10
+    ptpSettings:
+      clockType: "T-BC"
+      inSyncConditionThreshold: "10"
+      inSyncConditionTimes: "12"
+      logReduce: "false"
+      leadingInterface: ens2f0
+      upstreamPort: ens2f1,ens2f3
+    ts2phcConf: |
+      [global]
+      use_syslog  0
+      verbose 1
+      logging_level 7
+      ts2phc.pulsewidth 100000000
+      leapfile  /usr/share/zoneinfo/leap-seconds.list
+      domainNumber 24
+      uds_address /var/run/ptp4l.0.socket
+      [ens2f0]
+      ts2phc.extts_polarity rising
+      ts2phc.pin_index 1
+      ts2phc.extts_correction -10
+      ts2phc.master 0
+    ts2phcOpts: -s generic -a --ts2phc.rh_external_pps 1
+  - name: tbc-tt
+    ptp4lConf: |
+      [ens2f2]
+      masterOnly 1
+      [global]
+      #
+      # Default Data Set
+      #
+      twoStepFlag 1
+      slaveOnly 0
+      priority1 128
+      priority2 128
+      domainNumber 25
+      clockClass 248
+      clockAccuracy 0xFE
+      offsetScaledLogVariance 0xFFFF
+      free_running 0
+      freq_est_interval 1
+      dscp_event 0
+      dscp_general 0
+      dataset_comparison G.8275.x
+      G.8275.defaultDS.localPriority 128
+      #
+      # Port Data Set
+      #
+      logAnnounceInterval -3
+      logSyncInterval -4
+      logMinDelayReqInterval -4
+      logMinPdelayReqInterval -4
+      announceReceiptTimeout 3
+      syncReceiptTimeout 0
+      delayAsymmetry 0
+      fault_reset_interval -4
+      neighborPropDelayThresh 20000000
+      masterOnly 0
+      G.8275.portDS.localPriority 128
+      #
+      # Run time options
+      #
+      assume_two_step 0
+      logging_level 6
+      path_trace_enabled 0
+      follow_up_info 0
+      hybrid_e2e 0
+      inhibit_multicast_service 0
+      net_sync_monitor 0
+      tc_spanning_tree 0
+      tx_timestamp_timeout 50
+      unicast_listen 0
+      unicast_master_table 0
+      unicast_req_duration 3600
+      use_syslog 1
+      verbose 0
+      summary_interval 0
+      kernel_leap 1
+      check_fup_sync 0
+      clock_class_threshold 135
+      #
+      # Servo Options
+      #
+      pi_proportional_const 0.60
+      pi_integral_const 0.0003
+      pi_proportional_scale 0.0
+      pi_proportional_exponent -0.3
+      pi_proportional_norm_max 0.7
+      pi_integral_scale 0.0
+      pi_integral_exponent 0.4
+      pi_integral_norm_max 0.3
+      step_threshold 2.0
+      first_step_threshold 0.00002
+      max_frequency 900000000
+      clock_servo pi
+      sanity_freq_limit 200000000
+      ntpshm_segment 0
+      #
+      # Transport options
+      #
+      transportSpecific 0x0
+      ptp_dst_mac 01:1B:19:00:00:00
+      p2p_dst_mac 01:80:C2:00:00:0E
+      udp_ttl 1
+      udp6_scope 0x0E
+      uds_address /var/run/ptp4l
+      #
+      # Default interface options
+      #
+      clock_type OC
+      network_transport L2
+      delay_mechanism E2E
+      time_stamping hardware
+      tsproc_mode filter
+      delay_filter moving_median
+      delay_filter_length 10
+      egressLatency 0
+      ingressLatency 0
+      boundary_clock_jbod 0
+      #
+      # Clock description
+      #
+      productDescription ;;
+      revisionData ;;
+      manufacturerIdentity 00:00:00
+      userDescription ;
+      timeSource 0xA0
+    ptp4lOpts: -2 --summary_interval -4
+    ptpSchedulingPolicy: SCHED_FIFO
+    ptpSchedulingPriority: 10
+    ptpSettings:
+      controllingProfile: tbc-tr
+      logReduce: "false"
+  recommend:
+  - match:
+    - nodeLabel: node-role.kubernetes.io/master
+    priority: 4
+    profile: tbc-tr
+  - match:
+    - nodeLabel: node-role.kubernetes.io/master
+    priority: 4
+    profile: tbc-tt

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/mdlayher/netlink v1.8.0
 	github.com/prometheus/client_golang v1.23.2
 	github.com/redhat-cne/sdk-go v1.23.6
+	github.com/rodaine/table v1.3.1
 	github.com/sirupsen/logrus v1.9.3
 	github.com/stratoberry/go-gpsd v1.1.0
 	github.com/stretchr/testify v1.11.1

--- a/go.sum
+++ b/go.sum
@@ -12,6 +12,8 @@ github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
+github.com/clipperhouse/uax29/v2 v2.2.0 h1:ChwIKnQN3kcZteTXMgb1wztSgaU+ZemkgWdohwgs8tY=
+github.com/clipperhouse/uax29/v2 v2.2.0/go.mod h1:EFJ2TJMRUaplDxHKj1qAEhCtQPW2tJSwu5BF98AuoVM=
 github.com/cloudevents/sdk-go/v2 v2.15.2 h1:54+I5xQEnI73RBhWHxbI1XJcqOFOVJN85vb41+8mHUc=
 github.com/cloudevents/sdk-go/v2 v2.15.2/go.mod h1:lL7kSWAE/V8VI4Wh0jbL2v/jvqsm6tjmaQBSvxcv4uE=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
@@ -106,6 +108,8 @@ github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0=
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
+github.com/mattn/go-runewidth v0.0.21 h1:jJKAZiQH+2mIinzCJIaIG9Be1+0NR+5sz/lYEEjdM8w=
+github.com/mattn/go-runewidth v0.0.21/go.mod h1:XBkDxAl56ILZc9knddidhrOlY5R/pDhgLpndooCuJAs=
 github.com/mdlayher/genetlink v1.3.2 h1:KdrNKe+CTu+IbZnm/GVUMXSqBBLqcGpRDa0xkQy56gw=
 github.com/mdlayher/genetlink v1.3.2/go.mod h1:tcC3pkCrPUGIKKsCsp0B3AdaaKuHtaxoJRz3cc+528o=
 github.com/mdlayher/netlink v1.8.0 h1:e7XNIYJKD7hUct3Px04RuIGJbBxy1/c4nX7D5YyvvlM=
@@ -142,6 +146,8 @@ github.com/prometheus/procfs v0.16.1 h1:hZ15bTNuirocR6u0JZ6BAHHmwS1p8B4P6MRqxtzM
 github.com/prometheus/procfs v0.16.1/go.mod h1:teAbpZRB1iIAJYREa1LsoWUXykVXA1KlTmWl8x/U+Is=
 github.com/redhat-cne/sdk-go v1.23.6 h1:L+Rs12UihwDBJc/tj1eEMc4Otf7Lxf0bkFjdsg7FPGA=
 github.com/redhat-cne/sdk-go v1.23.6/go.mod h1:5hK1sILdB33pdMsNYTyBKV/v5GjjibmQZcyRtVrVfvs=
+github.com/rodaine/table v1.3.1 h1:jBVgg1bEu5EzEdYSrwUUlQpayDtkvtTmgFS0FPAxOq8=
+github.com/rodaine/table v1.3.1/go.mod h1:VYCJRCHa2DpD25uFALcB6hi5ECF3eEJQVhCXRjHgXc4=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=

--- a/pkg/dpll-netlink/pin_table.go
+++ b/pkg/dpll-netlink/pin_table.go
@@ -1,0 +1,301 @@
+package dpll_netlink
+
+import (
+	"bytes"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/golang/glog"
+	"github.com/rodaine/table"
+)
+
+// pinTableNetlinkTimeout bounds how long a single pin-table dial/dump is
+// allowed to take. Pin dumps are diagnostic-only, so it's better to skip a
+// table when the DPLL driver is slow/unresponsive than to stall on it.
+const pinTableNetlinkTimeout = 2 * time.Second
+
+// pinTableHeaders/pinTableHeadersWithDir are the column sets shared by every
+// pin table rendered from this file. Kept as package vars (rather than
+// inlined at each call site) so the two render paths (filtered/no-dir vs.
+// unfiltered/with-dir) stay visibly in sync.
+var (
+	pinTableHeaders        = []interface{}{"id", "Brd. L", "Pkg. L", "prio", "adm.", "oper."}
+	pinTableHeadersWithDir = []interface{}{"id", "Brd. L", "Pkg. L", "dir", "prio", "adm.", "oper."}
+)
+
+// pinTableConn is a DPLL netlink connection shared across LogPinTable calls,
+// guarded by pinTableConnMu. Reusing one connection instead of dialing fresh
+// on every device notification avoids the socket churn a per-call Dial would
+// cause during lock-state flapping; the mutex also naturally serializes
+// concurrent LogPinTable calls onto a single in-flight dial/dump at a time.
+var (
+	pinTableConnMu sync.Mutex
+	pinTableConn   *Conn
+)
+
+// dialPinTableConn dials a new DPLL connection, bounded by
+// pinTableNetlinkTimeout. The dial package doesn't expose a timeout/context
+// knob, so the wait is bounded from the caller's side via a background
+// goroutine: on timeout we give up and return an error instead of blocking
+// forever, at the cost of abandoning that one dial attempt (harmless; it
+// either fails on its own or yields a connection nobody uses).
+func dialPinTableConn() (*Conn, error) {
+	type result struct {
+		conn *Conn
+		err  error
+	}
+	ch := make(chan result, 1)
+	go func() {
+		conn, err := Dial(nil)
+		ch <- result{conn, err}
+	}()
+	select {
+	case r := <-ch:
+		return r.conn, r.err
+	case <-time.After(pinTableNetlinkTimeout):
+		return nil, fmt.Errorf("timed out dialing DPLL netlink after %s", pinTableNetlinkTimeout)
+	}
+}
+
+// getPinTableConn returns the shared connection, dialing one lazily if there
+// isn't a healthy one cached yet.
+func getPinTableConn() (*Conn, error) {
+	if pinTableConn != nil {
+		return pinTableConn, nil
+	}
+	conn, err := dialPinTableConn()
+	if err != nil {
+		return nil, err
+	}
+	pinTableConn = conn
+	return conn, nil
+}
+
+// invalidatePinTableConn discards the shared connection so the next call
+// dials a fresh one. Called whenever an operation on it fails or times out,
+// since the connection may be left in a broken/indeterminate state.
+func invalidatePinTableConn() {
+	if pinTableConn != nil {
+		_ = pinTableConn.Close() //nolint:errcheck
+		pinTableConn = nil
+	}
+}
+
+// isLockedState returns true if the lock status means the DPLL has selected
+// a single active reference (locked or locked-ho-acq), as opposed to
+// unlocked/holdover where there is no single winning input yet.
+func isLockedState(lockStatus uint32) bool {
+	return lockStatus == DpllLockStatusLocked || lockStatus == DpllLockStatusLockedHoldoverAcquired
+}
+
+// isEnabledParent returns true if the parent device admin state indicates the
+// pin is a candidate input for the DPLL (selectable or connected).
+func isEnabledParent(pd *PinParentDevice) bool {
+	return pd.State == PinStateSelectable || pd.State == PinStateConnected
+}
+
+// isActiveParent returns true if the parent device is the one currently
+// selected/used by the DPLL as its synchronization source. Mirrors
+// DpllConfig.ActivePhaseOffsetPin in pkg/dpll: legacy stacks report this via
+// admin state "connected", while newer stacks report it via operstate
+// "active" instead (in which case the admin state never exceeds
+// "selectable"). Both signals are checked since not every driver populates
+// both consistently.
+func isActiveParent(pd *PinParentDevice) bool {
+	return pd.State == PinStateConnected || pd.Operstate == PinOperstateActive
+}
+
+// pinRow holds the single relevant parent-device entry for one pin, ready to
+// be rendered as one table row (no "dir" column: buildPinRows only ever
+// keeps input pins, so it would be constant and redundant).
+type pinRow struct {
+	id           uint32
+	boardLabel   string
+	packageLabel string
+	prio         string
+	admin        string
+	oper         string
+}
+
+// columns renders a pinRow as a table row.
+func (r pinRow) columns() []string {
+	return []string{fmt.Sprintf("%d", r.id), r.boardLabel, r.packageLabel, r.prio, r.admin, r.oper}
+}
+
+// pinRowsToColumns converts rows to the [][]string shape renderTable expects.
+func pinRowsToColumns(rows []pinRow) [][]string {
+	cols := make([][]string, len(rows))
+	for i, r := range rows {
+		cols[i] = r.columns()
+	}
+	return cols
+}
+
+// renderTable renders headers/rows into a table string using the shared
+// rodaine/table formatting for this package. Pure function: no I/O, no
+// logging, so it's trivial to unit test and safe to reuse from any call site
+// that already has data shaped as rows of strings.
+func renderTable(headers []interface{}, rows [][]string) string {
+	var buf bytes.Buffer
+	tbl := table.New(headers...)
+	tbl.WithWriter(&buf)
+	tbl.SetRows(rows)
+	tbl.Print()
+	return buf.String()
+}
+
+// LogPins logs the given pins as a compact table, one row per parent device
+// of each pin. Unlike LogPinTable, this applies no filtering by direction,
+// clock ID, device, or lock state — every parent device of every pin passed
+// in is shown, including output pins.
+//
+// This is the shared rendering primitive behind LogPinTable and
+// LogPinConfirmation, exported so other packages that already hold a
+// []*PinInfo (their own DumpPinGet result, a single pin from DoPinGet, or a
+// test fixture) can log a consistent table without duplicating table-building
+// code or going through LogPinTable's dial/dump/notification-filtering path.
+func LogPins(title string, pins []*PinInfo) {
+	var rows [][]string
+	for _, pin := range pins {
+		for _, pd := range pin.ParentDevice {
+			prioStr := "n/a"
+			if pd.Prio != nil {
+				prioStr = fmt.Sprintf("%d", *pd.Prio)
+			}
+			rows = append(rows, []string{
+				fmt.Sprintf("%d", pin.ID),
+				pin.BoardLabel,
+				pin.PackageLabel,
+				GetPinDirection(pd.Direction),
+				prioStr,
+				GetPinState(pd.State),
+				GetPinOperstate(pd.Operstate),
+			})
+		}
+	}
+	if len(rows) == 0 {
+		glog.Infof("=== DPLL pin table (%s): no relevant pins ===", title)
+		return
+	}
+	glog.Infof("=== DPLL pin table (%s) ===\n%s", title, renderTable(pinTableHeadersWithDir, rows))
+}
+
+// LogPinConfirmation logs the current configuration of a single pin via
+// LogPins. Unlike LogPinTable, this applies no filtering by direction, clock
+// ID, device, or lock state — it's meant to show the full post-write state of
+// exactly the pin that was just set (including output pins, which
+// LogPinTable always skips), immediately after a pin-set command, for
+// confirmation purposes.
+func LogPinConfirmation(pin *PinInfo) {
+	LogPins(fmt.Sprintf("confirm pin=%d %#x", pin.ID, pin.ClockID), []*PinInfo{pin})
+}
+
+// buildPinRows selects, among the pins belonging to clockID, the input pins
+// whose parent-device entry matches deviceID (the DPLL device that triggered
+// the notification), and returns one row per matching pin.
+//
+// Output pins are always skipped: they aren't related to a device lock-state
+// change and are logged separately whenever they are set.
+//
+// Row selection also depends on lockStatus:
+//   - locked / locked-ho-acq: only the active input pin (there's only one
+//     reference that matters once a DPLL has locked onto it). See
+//     isActiveParent for why both admin state and operstate are checked.
+//   - unlocked / holdover: all enabled (selectable or connected) input pins,
+//     to show every candidate the DPLL could pick next.
+func buildPinRows(pins []*PinInfo, clockID uint64, deviceID uint32, lockStatus uint32) []pinRow {
+	locked := isLockedState(lockStatus)
+	var rows []pinRow
+
+	for _, pin := range pins {
+		if pin.ClockID != clockID {
+			continue
+		}
+		for _, pd := range pin.ParentDevice {
+			if pd.ParentID != deviceID || pd.Direction != PinDirectionInput {
+				continue
+			}
+			include := false
+			if locked {
+				include = isActiveParent(&pd)
+			} else {
+				include = isEnabledParent(&pd)
+			}
+			if !include {
+				continue
+			}
+			prioStr := "n/a"
+			if pd.Prio != nil {
+				prioStr = fmt.Sprintf("%d", *pd.Prio)
+			}
+			rows = append(rows, pinRow{
+				id:           pin.ID,
+				boardLabel:   pin.BoardLabel,
+				packageLabel: pin.PackageLabel,
+				prio:         prioStr,
+				admin:        GetPinState(pd.State),
+				oper:         GetPinOperstate(pd.Operstate),
+			})
+			break
+		}
+	}
+	return rows
+}
+
+// LogPinTable logs a compact table of the input pins relevant to the DPLL
+// device (deviceID) on the given clockID that just reported a lock-state
+// change (reason is a free-form description used in the log line, e.g.
+// "eth0 eec->LOCKED").
+//
+// This is a best-effort diagnostic: the actual netlink dial/dump happens in a
+// background goroutine so callers on latency-sensitive paths (e.g.
+// nlUpdateState, processing notifications inline) are never blocked or
+// stalled by it.
+func LogPinTable(reason string, clockID uint64, deviceID uint32, lockStatus uint32) {
+	go fetchAndLogPinTable(reason, clockID, deviceID, lockStatus)
+}
+
+// fetchAndLogPinTable dials (or reuses) a DPLL connection, dumps every pin on
+// the system, filters them down to the ones relevant to clockID/deviceID/
+// lockStatus (see buildPinRows), and logs the result as a table. Only pins
+// belonging to clockID are considered, and only the parent-device entry for
+// deviceID is looked at, so unrelated clock chips and the other DPLL sharing
+// the same chip (e.g. PPS vs EEC) don't pollute the table.
+//
+// It reuses a shared connection (see pinTableConn) rather than dialing fresh
+// every call, and bounds the dump with pinTableNetlinkTimeout so a slow or
+// unresponsive DPLL driver can't stall this indefinitely; either failure
+// mode discards the shared connection so the next call starts clean.
+func fetchAndLogPinTable(reason string, clockID uint64, deviceID uint32, lockStatus uint32) {
+	pinTableConnMu.Lock()
+	defer pinTableConnMu.Unlock()
+
+	conn, err := getPinTableConn()
+	if err != nil {
+		glog.Errorf("pin table: failed to dial DPLL: %v", err)
+		return
+	}
+
+	err = conn.GetGenetlinkConn().SetDeadline(time.Now().Add(pinTableNetlinkTimeout))
+	if err != nil {
+		glog.Errorf("pin table: failed to set netlink deadline: %v", err)
+		invalidatePinTableConn()
+		return
+	}
+
+	pins, err := conn.DumpPinGet()
+	if err != nil {
+		glog.Errorf("pin table: failed to dump pins: %v", err)
+		invalidatePinTableConn()
+		return
+	}
+
+	rows := buildPinRows(pins, clockID, deviceID, lockStatus)
+	if len(rows) == 0 {
+		glog.Infof("=== DPLL pin table (%s) clockID=%#x: no relevant pins ===", reason, clockID)
+		return
+	}
+
+	glog.Infof("=== DPLL pin table (%s) clockID=%#x ===\n%s", reason, clockID, renderTable(pinTableHeaders, pinRowsToColumns(rows)))
+}

--- a/pkg/dpll-netlink/pin_table_test.go
+++ b/pkg/dpll-netlink/pin_table_test.go
@@ -1,0 +1,280 @@
+package dpll_netlink
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	testPinREF0P = "REF0P"
+	testPinREF0N = "REF0N"
+)
+
+func prio(v uint32) *uint32 { return &v }
+
+func TestIsLockedState(t *testing.T) {
+	assert.False(t, isLockedState(DpllLockStatusUnlocked))
+	assert.False(t, isLockedState(DpllLockStatusHoldover))
+	assert.True(t, isLockedState(DpllLockStatusLocked))
+	assert.True(t, isLockedState(DpllLockStatusLockedHoldoverAcquired))
+}
+
+func TestIsEnabledParent(t *testing.T) {
+	assert.True(t, isEnabledParent(&PinParentDevice{State: PinStateSelectable}))
+	assert.True(t, isEnabledParent(&PinParentDevice{State: PinStateConnected}))
+	assert.False(t, isEnabledParent(&PinParentDevice{State: PinStateDisconnected}))
+}
+
+func TestIsActiveParent(t *testing.T) {
+	// Newer stacks: admin state stays "selectable", operstate reports "active".
+	assert.True(t, isActiveParent(&PinParentDevice{State: PinStateSelectable, Operstate: PinOperstateActive}))
+	// Legacy stacks: admin state goes to "connected", operstate may be unreported/unknown.
+	assert.True(t, isActiveParent(&PinParentDevice{State: PinStateConnected, Operstate: 0}))
+	// Neither signal present: not active.
+	assert.False(t, isActiveParent(&PinParentDevice{State: PinStateSelectable, Operstate: PinOperstateStandby}))
+	assert.False(t, isActiveParent(&PinParentDevice{State: PinStateDisconnected, Operstate: 0}))
+}
+
+func TestBuildPinRows_FiltersByClockIDAndDevice(t *testing.T) {
+	pins := []*PinInfo{
+		{
+			ID: 16, ClockID: 0xAA, BoardLabel: testPinREF0P,
+			ParentDevice: []PinParentDevice{
+				{ParentID: 1, Direction: PinDirectionInput, State: PinStateSelectable, Operstate: PinOperstateActive, Prio: prio(6)},
+				{ParentID: 2, Direction: PinDirectionInput, State: PinStateDisconnected, Operstate: PinOperstateStandby, Prio: prio(14)},
+			},
+		},
+		{
+			// Different clock ID entirely: must be excluded.
+			ID: 17, ClockID: 0xBB, BoardLabel: "OTHERCHIP",
+			ParentDevice: []PinParentDevice{
+				{ParentID: 1, Direction: PinDirectionInput, State: PinStateSelectable, Operstate: PinOperstateActive, Prio: prio(1)},
+			},
+		},
+	}
+
+	// Unlocked: pin is enabled for device 1, should be included.
+	rows := buildPinRows(pins, 0xAA, 1, DpllLockStatusUnlocked)
+	assert.Len(t, rows, 1)
+	assert.Equal(t, uint32(16), rows[0].id)
+	assert.Equal(t, testPinREF0P, rows[0].boardLabel)
+	assert.Equal(t, "6", rows[0].prio)
+
+	// Device 2's parent entry for the same pin is disconnected, so nothing shows for it.
+	rows = buildPinRows(pins, 0xAA, 2, DpllLockStatusUnlocked)
+	assert.Empty(t, rows)
+}
+
+func TestBuildPinRows_SkipsOutputPins(t *testing.T) {
+	pins := []*PinInfo{
+		{
+			ID: 25, ClockID: 0xAA, BoardLabel: "OUT3",
+			ParentDevice: []PinParentDevice{
+				{ParentID: 1, Direction: PinDirectionOutput, State: PinStateConnected, Operstate: PinOperstateActive},
+			},
+		},
+	}
+	rows := buildPinRows(pins, 0xAA, 1, DpllLockStatusLocked)
+	assert.Empty(t, rows, "output pins must never be included")
+}
+
+func TestBuildPinRows_LockedShowsOnlyActive(t *testing.T) {
+	pins := []*PinInfo{
+		{
+			ID: 16, ClockID: 0xAA, BoardLabel: testPinREF0P,
+			ParentDevice: []PinParentDevice{
+				{ParentID: 1, Direction: PinDirectionInput, State: PinStateSelectable, Operstate: PinOperstateActive, Prio: prio(6)},
+			},
+		},
+		{
+			ID: 17, ClockID: 0xAA, BoardLabel: testPinREF0N,
+			ParentDevice: []PinParentDevice{
+				{ParentID: 1, Direction: PinDirectionInput, State: PinStateSelectable, Operstate: PinOperstateStandby, Prio: prio(7)},
+			},
+		},
+	}
+
+	rows := buildPinRows(pins, 0xAA, 1, DpllLockStatusLocked)
+	assert.Len(t, rows, 1, "locked state should only show the active input")
+	assert.Equal(t, uint32(16), rows[0].id)
+
+	rows = buildPinRows(pins, 0xAA, 1, DpllLockStatusLockedHoldoverAcquired)
+	assert.Len(t, rows, 1, "locked-ho-acq state should only show the active input")
+	assert.Equal(t, uint32(16), rows[0].id)
+}
+
+// TestBuildPinRows_LockedFallsBackToLegacyConnectedState covers hardware/drivers
+// that never report Operstate as active (it stays "unknown"), but do report the
+// legacy admin state "connected" for the pin actually in use. Without this
+// fallback the table would always print "no relevant pins" once locked.
+func TestBuildPinRows_LockedFallsBackToLegacyConnectedState(t *testing.T) {
+	pins := []*PinInfo{
+		{
+			ID: 16, ClockID: 0xAA, BoardLabel: testPinREF0P,
+			ParentDevice: []PinParentDevice{
+				{ParentID: 1, Direction: PinDirectionInput, State: PinStateConnected, Operstate: 0, Prio: prio(6)},
+			},
+		},
+		{
+			ID: 17, ClockID: 0xAA, BoardLabel: testPinREF0N,
+			ParentDevice: []PinParentDevice{
+				{ParentID: 1, Direction: PinDirectionInput, State: PinStateSelectable, Operstate: 0, Prio: prio(7)},
+			},
+		},
+	}
+
+	rows := buildPinRows(pins, 0xAA, 1, DpllLockStatusLocked)
+	assert.Len(t, rows, 1, "the legacy 'connected' admin state should count as active even with an unreported operstate")
+	assert.Equal(t, uint32(16), rows[0].id)
+}
+
+func TestBuildPinRows_UnlockedShowsAllEnabled(t *testing.T) {
+	pins := []*PinInfo{
+		{
+			ID: 16, ClockID: 0xAA, BoardLabel: testPinREF0P,
+			ParentDevice: []PinParentDevice{
+				{ParentID: 1, Direction: PinDirectionInput, State: PinStateSelectable, Operstate: PinOperstateStandby, Prio: prio(6)},
+			},
+		},
+		{
+			ID: 17, ClockID: 0xAA, BoardLabel: testPinREF0N,
+			ParentDevice: []PinParentDevice{
+				{ParentID: 1, Direction: PinDirectionInput, State: PinStateDisconnected, Operstate: PinOperstateNoSignal, Prio: prio(7)},
+			},
+		},
+	}
+
+	rows := buildPinRows(pins, 0xAA, 1, DpllLockStatusUnlocked)
+	assert.Len(t, rows, 1, "only the enabled (selectable/connected) input should show")
+	assert.Equal(t, uint32(16), rows[0].id)
+
+	rows = buildPinRows(pins, 0xAA, 1, DpllLockStatusHoldover)
+	assert.Len(t, rows, 1, "holdover behaves the same as unlocked")
+	assert.Equal(t, uint32(16), rows[0].id)
+}
+
+func TestBuildPinRows_PrioNil(t *testing.T) {
+	pins := []*PinInfo{
+		{
+			ID: 5, ClockID: 0xBB, BoardLabel: "IN0",
+			ParentDevice: []PinParentDevice{
+				{ParentID: 0, Direction: PinDirectionInput, State: PinStateConnected, Operstate: PinOperstateActive, Prio: nil},
+			},
+		},
+	}
+	rows := buildPinRows(pins, 0xBB, 0, DpllLockStatusLocked)
+	assert.Len(t, rows, 1)
+	assert.Equal(t, "n/a", rows[0].prio)
+}
+
+func TestBuildPinRows_Empty(t *testing.T) {
+	assert.Empty(t, buildPinRows(nil, 0xAA, 0, DpllLockStatusUnlocked))
+}
+
+func TestInvalidatePinTableConn_NilSafe(t *testing.T) {
+	pinTableConnMu.Lock()
+	pinTableConn = nil
+	pinTableConnMu.Unlock()
+
+	assert.NotPanics(t, invalidatePinTableConn)
+}
+
+// TestDialPinTableConn_ReturnsPromptly guards against dialPinTableConn ever
+// silently blocking for the full pinTableNetlinkTimeout. Whether the "dpll"
+// netlink family is available depends on the environment (e.g. it fails
+// immediately on non-Linux OSes, but some Linux CI kernels register the
+// family even without real DPLL hardware behind it), so this only asserts
+// on timing, not on a specific dial outcome.
+func TestDialPinTableConn_ReturnsPromptly(t *testing.T) {
+	start := time.Now()
+	conn, err := dialPinTableConn()
+	if err == nil {
+		defer conn.Close() //nolint:errcheck
+	}
+	assert.Less(t, time.Since(start), pinTableNetlinkTimeout)
+}
+
+func TestRenderTable(t *testing.T) {
+	selectable := GetPinState(PinStateSelectable)
+	out := renderTable(pinTableHeaders, [][]string{
+		{"16", "REF0P", "", "6", selectable, pinOperstateActive},
+		{"17", "REF0N", "", "7", selectable, pinOperstateStandby},
+	})
+	assert.Contains(t, out, "id")
+	assert.Contains(t, out, "REF0P")
+	assert.Contains(t, out, "REF0N")
+	assert.Contains(t, out, pinOperstateActive)
+}
+
+func TestRenderTable_Empty(t *testing.T) {
+	out := renderTable(pinTableHeaders, nil)
+	// Header row should still render even with zero data rows.
+	assert.Contains(t, out, "id")
+}
+
+func TestPinRowColumns(t *testing.T) {
+	selectable := GetPinState(PinStateSelectable)
+	r := pinRow{id: 16, boardLabel: testPinREF0P, packageLabel: "", prio: "6", admin: selectable, oper: pinOperstateActive}
+	assert.Equal(t, []string{"16", testPinREF0P, "", "6", selectable, pinOperstateActive}, r.columns())
+}
+
+func TestPinRowsToColumns(t *testing.T) {
+	selectable := GetPinState(PinStateSelectable)
+	rows := []pinRow{
+		{id: 16, boardLabel: testPinREF0P, prio: "6", admin: selectable, oper: pinOperstateActive},
+		{id: 17, boardLabel: testPinREF0N, prio: "7", admin: selectable, oper: pinOperstateStandby},
+	}
+	cols := pinRowsToColumns(rows)
+	assert.Len(t, cols, 2)
+	assert.Equal(t, "16", cols[0][0])
+	assert.Equal(t, testPinREF0N, cols[1][1])
+}
+
+// TestLogPins_DoesNotPanic exercises LogPins (and, through it,
+// LogPinConfirmation) across a few shapes that could plausibly trip up the
+// row-building loop: no pins, a pin with no parent devices, and a pin with
+// multiple parents including an output direction (which LogPins, unlike
+// LogPinTable/buildPinRows, must still show).
+func TestLogPins_DoesNotPanic(t *testing.T) {
+	assert.NotPanics(t, func() { LogPins("empty", nil) })
+	assert.NotPanics(t, func() { LogPins("no-parents", []*PinInfo{{ID: 1, BoardLabel: "X"}}) })
+	assert.NotPanics(t, func() {
+		LogPins("mixed", []*PinInfo{
+			{
+				ID: 25, ClockID: 0xAA, BoardLabel: "OUT3",
+				ParentDevice: []PinParentDevice{
+					{ParentID: 1, Direction: PinDirectionOutput, State: PinStateConnected, Prio: prio(3)},
+					{ParentID: 2, Direction: PinDirectionInput, State: PinStateSelectable, Prio: nil},
+				},
+			},
+		})
+	})
+}
+
+func TestLogPinConfirmation_DoesNotPanic(t *testing.T) {
+	assert.NotPanics(t, func() {
+		LogPinConfirmation(&PinInfo{
+			ID: 16, ClockID: 0xAA, BoardLabel: testPinREF0P,
+			ParentDevice: []PinParentDevice{
+				{ParentID: 1, Direction: PinDirectionInput, State: PinStateConnected, Prio: prio(6)},
+			},
+		})
+	})
+}
+
+func TestBuildPinRows_WithPackageLabel(t *testing.T) {
+	pins := []*PinInfo{
+		{
+			ID: 5, ClockID: 0xDD, BoardLabel: "SDP0", PackageLabel: "U1901",
+			ParentDevice: []PinParentDevice{
+				{ParentID: 0, Direction: PinDirectionInput, State: PinStateSelectable, Operstate: PinOperstateStandby, Prio: prio(3)},
+			},
+		},
+	}
+	rows := buildPinRows(pins, 0xDD, 0, DpllLockStatusUnlocked)
+	assert.Len(t, rows, 1)
+	assert.Equal(t, "SDP0", rows[0].boardLabel)
+	assert.Equal(t, "U1901", rows[0].packageLabel)
+}

--- a/pkg/dpll/dpll.go
+++ b/pkg/dpll/dpll.go
@@ -386,6 +386,8 @@ func (d *DpllConfig) nlUpdateState(devices []*nl.DoDeviceGetReply, pins []*nl.Pi
 				glog.Infof("%s (%#x) updating pps to %s (%d)", d.iface, d.clockId, stateName(d.phaseStatus), d.phaseStatus)
 				valid = true
 			}
+			nl.LogPinTable(fmt.Sprintf("%s %s->%s", d.iface, nl.GetDpllType(reply.Type), stateName(int64(reply.LockStatus))),
+				reply.ClockID, reply.ID, reply.LockStatus)
 		}
 	}
 	for _, pin := range pins {

--- a/pkg/hardwareconfig/utils.go
+++ b/pkg/hardwareconfig/utils.go
@@ -7,7 +7,6 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/golang/glog"
 
@@ -479,18 +478,16 @@ func BatchPinSet(commands []dpll.PinParentDeviceCtl) error {
 			glog.Error("failed to send pin command: ", err)
 			return err
 		}
+		// Read back the pin to confirm the command was applied, and log it as a
+		// table (see LogPinConfirmation) since LogPinTable never shows output
+		// pins and reflects state as of the next notification, not this write.
 		info, getErr := conn.DoPinGet(dpll.DoPinGetRequest{ID: command.ID})
 		if getErr != nil {
 			glog.Error("failed to get pin: ", getErr)
 			//TODO: handle properly after RHEL-137801 is fixed
 			return nil
 		}
-		reply, replyErr := dpll.GetPinInfoHR(info, time.Now())
-		if replyErr != nil {
-			glog.Error("failed to convert pin reply to human readable: ", replyErr)
-			return replyErr
-		}
-		glog.Info("pin reply: ", string(reply))
+		dpll.LogPinConfirmation(info)
 	}
 	return nil
 }

--- a/vendor/github.com/rodaine/table/license
+++ b/vendor/github.com/rodaine/table/license
@@ -1,0 +1,9 @@
+The MIT License (MIT)
+
+Copyright (c) 2015 Chris Roche (rodaine+github@gmail.com)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/vendor/github.com/rodaine/table/readme.md
+++ b/vendor/github.com/rodaine/table/readme.md
@@ -1,0 +1,57 @@
+# table <br/> [![GoDoc](https://godoc.org/github.com/rodaine/table?status.svg)](https://godoc.org/github.com/rodaine/table)
+
+![Example Table Output With ANSI Colors](http://res.cloudinary.com/rodaine/image/upload/v1442524799/go-table-example0.png)
+
+Package table provides a convenient way to generate tabular output of any data, primarily useful for CLI tools.
+
+## Features
+
+- Accepts all data types (`string`, `int`, `interface{}`, everything!) and will use the `String() string` method of a type if available.
+- Can specify custom formatting for the header and first column cells for better readability.
+- Columns are left-aligned and sized to fit the data, with customizable padding.
+- The printed output can be sent to any `io.Writer`, defaulting to `os.Stdout`.
+- Built to an interface, so you can roll your own `Table` implementation.
+- Works well with ANSI colors ([fatih/color](https://github.com/fatih/color) in the example)!
+- Can provide a custom `WidthFunc` to accomodate multi- and zero-width characters (such as [runewidth](https://github.com/mattn/go-runewidth))
+
+## Usage
+
+**Download the package:**
+
+```sh
+go get github.com/rodaine/table
+```
+
+**Example:**
+
+```go
+package main
+
+import (
+  "fmt"
+  "strings"
+
+  "github.com/fatih/color"
+  "github.com/rodaine/table"
+)
+
+func main() {
+  headerFmt := color.New(color.FgGreen, color.Underline).SprintfFunc()
+  columnFmt := color.New(color.FgYellow).SprintfFunc()
+
+  tbl := table.New("ID", "Name", "Score", "Added")
+  tbl.WithHeaderFormatter(headerFmt).WithFirstColumnFormatter(columnFmt)
+
+  for _, widget := range getWidgets() {
+    tbl.AddRow(widget.ID, widget.Name, widget.Cost, widget.Added)
+  }
+
+  tbl.Print()
+}
+```
+
+_Consult the [documentation](https://godoc.org/github.com/rodaine/table) for further examples and usage information_
+
+## License
+
+table is released under the MIT License (Expat). See the [full license](https://github.com/rodaine/table/blob/master/license).

--- a/vendor/github.com/rodaine/table/table.go
+++ b/vendor/github.com/rodaine/table/table.go
@@ -1,0 +1,363 @@
+// Package table provides a convenient way to generate tabular output of any
+// data, primarily useful for CLI tools.
+//
+// Columns are left-aligned and padded to accomodate the largest cell in that
+// column.
+//
+// Source: https://github.com/rodaine/table
+//
+//	table.DefaultHeaderFormatter = func(format string, vals ...interface{}) string {
+//	  return strings.ToUpper(fmt.Sprintf(format, vals...))
+//	}
+//
+//	tbl := table.New("ID", "Name", "Cost ($)")
+//
+//	for _, widget := range Widgets {
+//	  tbl.AddRow(widget.ID, widget.Name, widget.Cost)
+//	}
+//
+//	tbl.Print()
+//
+//	// Output:
+//	// ID  NAME      COST ($)
+//	// 1   Foobar    1.23
+//	// 2   Fizzbuzz  4.56
+//	// 3   Gizmo     78.90
+package table
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"unicode/utf8"
+)
+
+// These are the default properties for all Tables created from this package
+// and can be modified.
+var (
+	// DefaultPadding specifies the number of spaces between columns in a table.
+	DefaultPadding = 2
+
+	// DefaultWriter specifies the output io.Writer for the Table.Print method.
+	DefaultWriter io.Writer = os.Stdout
+
+	// DefaultHeaderFormatter specifies the default Formatter for the table header.
+	DefaultHeaderFormatter Formatter
+
+	// DefaultFirstColumnFormatter specifies the default Formatter for the first column cells.
+	DefaultFirstColumnFormatter Formatter
+
+	// DefaultWidthFunc specifies the default WidthFunc for calculating column widths
+	DefaultWidthFunc WidthFunc = utf8.RuneCountInString
+
+	// DefaultPrintHeaders specifies if headers should be printed
+	DefaultPrintHeaders = true
+)
+
+// Formatter functions expose a fmt.Sprintf signature that can be used to modify
+// the display of the text in either the header or first column of a Table.
+// The formatter should not change the width of original text as printed since
+// column widths are calculated pre-formatting (though this issue can be mitigated
+// with increased padding).
+//
+//	tbl.WithHeaderFormatter(func(format string, vals ...interface{}) string {
+//	  return strings.ToUpper(fmt.Sprintf(format, vals...))
+//	})
+//
+// A good use case for formatters is to use ANSI escape codes to color the cells
+// for a nicer interface. The package color (https://github.com/fatih/color) makes
+// it easy to generate these automatically: http://godoc.org/github.com/fatih/color#Color.SprintfFunc
+type Formatter func(string, ...interface{}) string
+
+// A WidthFunc calculates the width of a string. By default, the number of runes
+// is used but this may not be appropriate for certain character sets. The
+// package runewidth (https://github.com/mattn/go-runewidth) could be used to
+// accomodate multi-cell characters (such as emoji or CJK characters).
+type WidthFunc func(string) int
+
+// Table describes the interface for building up a tabular representation of data.
+// It exposes fluent/chainable methods for convenient table building.
+//
+// WithHeaderFormatter and WithFirstColumnFormatter sets the Formatter for the
+// header and first column, respectively. If nil is passed in (the default), no
+// formatting will be applied.
+//
+//	New("foo", "bar").WithFirstColumnFormatter(func(f string, v ...interface{}) string {
+//	  return strings.ToUpper(fmt.Sprintf(f, v...))
+//	})
+//
+// WithPadding specifies the minimum padding between cells in a row and defaults
+// to DefaultPadding. Padding values less than or equal to zero apply no extra
+// padding between the columns.
+//
+//	New("foo", "bar").WithPadding(3)
+//
+// WithWriter modifies the writer which Print outputs to, defaulting to DefaultWriter
+// when instantiated. If nil is passed, os.Stdout will be used.
+//
+//	New("foo", "bar").WithWriter(os.Stderr)
+//
+// WithWidthFunc sets the function used to calculate the width of the string in
+// a column. By default, the number of utf8 runes in the string is used.
+//
+// WithPrintHeaders specifies whether if the headers of the table should be
+// printed or not, which might be useful if the output is being piped to other
+// processes. By default, they are printed.
+//
+// AddRow adds another row of data to the table. Any values can be passed in and
+// will be output as its string representation as described in the fmt standard
+// package. Rows can have less cells than the total number of columns in the table;
+// subsequent cells will be rendered empty. Rows with more cells than the total
+// number of columns will be truncated. References to the data are not held, so
+// the passed in values can be modified without affecting the table's output.
+//
+//	New("foo", "bar").AddRow("fizz", "buzz").AddRow(time.Now()).AddRow(1, 2, 3).Print()
+//	// Output:
+//	// foo                              bar
+//	// fizz                             buzz
+//	// 2006-01-02 15:04:05.0 -0700 MST
+//	// 1                                2
+//
+// Print writes the string representation of the table to the provided writer.
+// Print can be called multiple times, even after subsequent mutations of the
+// provided data. The output is always preceded and followed by a new line.
+type Table interface {
+	WithHeaderFormatter(f Formatter) Table
+	WithFirstColumnFormatter(f Formatter) Table
+	WithPadding(p int) Table
+	WithWriter(w io.Writer) Table
+	WithWidthFunc(f WidthFunc) Table
+	WithHeaderSeparatorRow(r rune) Table
+	WithPrintHeaders(b bool) Table
+
+	AddRow(vals ...interface{}) Table
+	SetRows(rows [][]string) Table
+	Print()
+}
+
+// New creates a Table instance with the specified header(s) provided. The number
+// of columns is fixed at this point to len(columnHeaders) and the defined defaults
+// are set on the instance.
+func New(columnHeaders ...interface{}) Table {
+	t := table{header: make([]string, len(columnHeaders))}
+
+	t.WithPadding(DefaultPadding)
+	t.WithWriter(DefaultWriter)
+	t.WithHeaderFormatter(DefaultHeaderFormatter)
+	t.WithFirstColumnFormatter(DefaultFirstColumnFormatter)
+	t.WithWidthFunc(DefaultWidthFunc)
+	t.WithPrintHeaders(DefaultPrintHeaders)
+
+	for i, col := range columnHeaders {
+		t.header[i] = fmt.Sprint(col)
+	}
+
+	return &t
+}
+
+type table struct {
+	FirstColumnFormatter Formatter
+	HeaderFormatter      Formatter
+	Padding              int
+	Writer               io.Writer
+	Width                WidthFunc
+	HeaderSeparatorRune  rune
+	PrintHeaders         bool
+
+	header []string
+	rows   [][]string
+	widths []int
+}
+
+func (t *table) WithHeaderFormatter(f Formatter) Table {
+	t.HeaderFormatter = f
+	return t
+}
+
+func (t *table) WithHeaderSeparatorRow(r rune) Table {
+	t.HeaderSeparatorRune = r
+	return t
+}
+
+func (t *table) WithFirstColumnFormatter(f Formatter) Table {
+	t.FirstColumnFormatter = f
+	return t
+}
+
+func (t *table) WithPadding(p int) Table {
+	if p < 0 {
+		p = 0
+	}
+
+	t.Padding = p
+	return t
+}
+
+func (t *table) WithWriter(w io.Writer) Table {
+	if w == nil {
+		w = os.Stdout
+	}
+
+	t.Writer = w
+	return t
+}
+
+func (t *table) WithWidthFunc(f WidthFunc) Table {
+	t.Width = f
+	return t
+}
+
+func (t *table) WithPrintHeaders(b bool) Table {
+	t.PrintHeaders = b
+	return t
+}
+
+func (t *table) AddRow(vals ...interface{}) Table {
+	maxNumNewlines := 0
+	for _, val := range vals {
+		maxNumNewlines = max(strings.Count(fmt.Sprint(val), "\n"), maxNumNewlines)
+	}
+	for i := 0; i <= maxNumNewlines; i++ {
+		row := make([]string, len(t.header))
+		for j, val := range vals {
+			if j >= len(t.header) {
+				break
+			}
+			v := strings.Split(fmt.Sprint(val), "\n")
+			row[j] = safeOffset(v, i)
+		}
+		t.rows = append(t.rows, row)
+	}
+
+	return t
+}
+
+func (t *table) SetRows(rows [][]string) Table {
+	t.rows = [][]string{}
+	headerLength := len(t.header)
+
+	for _, row := range rows {
+		if len(row) > headerLength {
+			t.rows = append(t.rows, row[:headerLength])
+		} else {
+			t.rows = append(t.rows, row)
+		}
+	}
+
+	return t
+}
+
+func (t *table) Print() {
+	format := strings.Repeat("%s", len(t.header)) + "\n"
+	t.calculateWidths()
+
+  if t.PrintHeaders {
+    t.printHeader(format)
+
+    if t.HeaderSeparatorRune != 0 {
+      t.printHeaderSeparator(format)
+    }
+  }
+
+	for _, row := range t.rows {
+		t.printRow(format, row)
+	}
+}
+
+func (t *table) printHeaderSeparator(format string) {
+	separators := make([]string, len(t.header))
+
+	// The separator could be any unicode char. Since some chars take up more
+	// than one cell in a monospace context, we can get a number higher than 1
+	// here. Am example would be this emoji 🤣.
+	separatorCellWidth := t.Width(string([]rune{t.HeaderSeparatorRune}))
+	for index, headerName := range t.header {
+		headerCellWidth := t.Width(headerName)
+		// Note that this might not be evenly divisble. In this case we'll get a
+		// separator that is at least 1 cell shorter than the header. This was
+		// an intentional design decision in order to prevent widening the cell
+		// or overstepping the column bounds.
+		repeatCharTimes := headerCellWidth / separatorCellWidth
+		separator := make([]rune, repeatCharTimes)
+		for i := 0; i < repeatCharTimes; i++ {
+			separator[i] = t.HeaderSeparatorRune
+		}
+		separators[index] = string(separator)
+	}
+
+	vals := t.applyWidths(separators, t.widths)
+	if t.HeaderFormatter != nil {
+		txt := t.HeaderFormatter(format, vals...)
+		fmt.Fprint(t.Writer, txt)
+	} else {
+		fmt.Fprintf(t.Writer, format, vals...)
+	}
+}
+
+func (t *table) printHeader(format string) {
+	vals := t.applyWidths(t.header, t.widths)
+	if t.HeaderFormatter != nil {
+		txt := t.HeaderFormatter(format, vals...)
+		fmt.Fprint(t.Writer, txt)
+	} else {
+		fmt.Fprintf(t.Writer, format, vals...)
+	}
+}
+
+func (t *table) printRow(format string, row []string) {
+	vals := t.applyWidths(row, t.widths)
+
+	if t.FirstColumnFormatter != nil {
+		vals[0] = t.FirstColumnFormatter("%s", vals[0])
+	}
+
+	fmt.Fprintf(t.Writer, format, vals...)
+}
+
+func (t *table) calculateWidths() {
+	t.widths = make([]int, len(t.header))
+	for _, row := range t.rows {
+		for i, v := range row {
+			if w := t.Width(v) + t.Padding; w > t.widths[i] {
+				t.widths[i] = w
+			}
+		}
+	}
+
+	for i, v := range t.header {
+		if w := t.Width(v) + t.Padding; w > t.widths[i] {
+			t.widths[i] = w
+		}
+	}
+}
+
+func (t *table) applyWidths(row []string, widths []int) []interface{} {
+	out := make([]interface{}, len(row))
+	for i, s := range row {
+		out[i] = s + t.lenOffset(s, widths[i])
+	}
+	return out
+}
+
+func (t *table) lenOffset(s string, w int) string {
+	l := w - t.Width(s)
+	if l <= 0 {
+		return ""
+	}
+	return strings.Repeat(" ", l)
+}
+
+func max(i1, i2 int) int {
+	if i1 > i2 {
+		return i1
+	}
+	return i2
+}
+
+func safeOffset(sarr []string, idx int) string {
+	if idx >= len(sarr) {
+		return ""
+	}
+	return sarr[idx]
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -212,6 +212,9 @@ github.com/redhat-cne/sdk-go/pkg/event/ptp
 github.com/redhat-cne/sdk-go/pkg/event/redfish
 github.com/redhat-cne/sdk-go/pkg/pubsub
 github.com/redhat-cne/sdk-go/pkg/types
+# github.com/rodaine/table v1.3.1
+## explicit; go 1.21
+github.com/rodaine/table
 # github.com/sirupsen/logrus v1.9.3
 ## explicit; go 1.13
 github.com/sirupsen/logrus


### PR DESCRIPTION
## Summary
- Add PoC plan for dual time receiver (TR) port validation on BC/T-BC boundary clocks, covering 4 scenarios (port disconnect, quality degradation with A-BMCA internal clock comparison, holdover entry, holdover recovery) across two phases (WPC E810 → WPC E810, then WPC E810 → GNR-D)
- Add PtpConfig and HardwareConfig manifests for E810 T-BC, E810 BC, and GNR-D T-BC dual-TR configurations
jira-ticket: [CNF-22709](https://redhat.atlassian.net/browse/CNF-22709) 

## Test plan
- [x] Review PoC plan scenarios (S1, S2a, S2b, S3, S4a, S4b) for completeness
- [x] Validate PtpConfig YAMLs can be applied to target clusters
- [x] Phase 1: Execute scenarios on WPC E810 DUT (P1-A: T-BC+HwConfig, P1-B: T-BC no HwConfig, P1-C: BC with clockType)
- [x] Phase 2: Execute scenarios on GNR-D DUT (P2-A: T-BC+HwConfig)
- [ ] Verify exploratory scenarios S2b/S4b — determine if `clock_class_threshold 135` prevents locking to degraded sources
