### PR TITLE
CNF-23072: Allow linking interfaces by PHC, add HPE vendor defaults

### DIFF
--- a/pkg/alias/alias.go
+++ b/pkg/alias/alias.go
@@ -32,6 +32,13 @@ func GetAllAliases() map[string]string {
 	return storeInstance.getAllAliases()
 }
 
+// GetPhcGroup returns the PHC device path for the given interface, or empty
+// string if the interface was not registered. Two interfaces with the same
+// non-empty return value share the same PHC hardware.
+func GetPhcGroup(ifname string) string {
+	return storeInstance.getPhcGroup(ifname)
+}
+
 // Debug ...
 func Debug(logF func(string, ...any)) {
 	for ifName, alias := range storeInstance.aliases {

--- a/pkg/alias/manager.go
+++ b/pkg/alias/manager.go
@@ -42,7 +42,7 @@ func (m *store) calculateAliases() {
 
 	errs := make([]error, 0)
 
-	// storeInstance.aliases = make(map[string]string)
+	m.aliases = make(map[string]string)
 
 	seenAliases := make(map[string][]string)
 	for phcID, group := range m.interfacesByPhc {

--- a/pkg/alias/manager.go
+++ b/pkg/alias/manager.go
@@ -13,6 +13,7 @@ import (
 type store struct {
 	sync.RWMutex
 	interfacesByPhc map[string][]string
+	phcByIface      map[string]string
 	aliases         map[string]string
 }
 
@@ -20,6 +21,13 @@ func (m *store) addInterface(phc string, ifName string) {
 	m.Lock()
 	defer m.Unlock()
 	m.interfacesByPhc[phc] = append(m.interfacesByPhc[phc], ifName)
+	m.phcByIface[ifName] = phc
+}
+
+func (m *store) getPhcGroup(ifName string) string {
+	m.RLock()
+	defer m.RUnlock()
+	return m.phcByIface[ifName]
 }
 
 // calculateAliases calculates and sets the aliases.
@@ -113,6 +121,7 @@ func (m *store) clear() {
 	defer m.Unlock()
 	m.aliases = make(map[string]string)
 	m.interfacesByPhc = make(map[string][]string)
+	m.phcByIface = make(map[string]string)
 }
 
 func (m *store) getAllAliases() map[string]string {
@@ -125,4 +134,8 @@ func (m *store) getAllAliases() map[string]string {
 	return result
 }
 
-var storeInstance = store{aliases: make(map[string]string), interfacesByPhc: make(map[string][]string)}
+var storeInstance = store{
+	aliases:         make(map[string]string),
+	interfacesByPhc: make(map[string][]string),
+	phcByIface:      make(map[string]string),
+}

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -441,6 +441,16 @@ func (dn *Daemon) getInterfacesFromHardwareConfig(nodeProfile *ptpv1.PtpProfile)
 			// Get PHC ID for the interface
 			phcID := ptpnetwork.GetPhcId(networkInterface)
 
+			// Register in the alias store so convergeConfig can match this
+			// interface against ptp4l interfaces that share the same PHC (e.g.
+			// eno1 vs eth3 on an 8-port NIC where naming prefixes differ).
+			if phcID != "" {
+				alias.AddInterface(phcID, networkInterface)
+				glog.Infof("getInterfacesFromHardwareConfig: registered iface %s phc %s in alias store", networkInterface, phcID)
+			} else {
+				glog.Warningf("getInterfacesFromHardwareConfig: could not get PHC ID for iface %s, convergeConfig PHC fallback will not work", networkInterface)
+			}
+
 			interfaces = append(interfaces, config.Iface{
 				Name:     networkInterface,
 				Source:   eventSource,

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -669,6 +669,12 @@ func (dn *Daemon) applyNodePTPProfiles() error {
 	// references).
 	dn.processManager.process = nil
 
+	// Purge the alias store so stale interface→PHC mappings from a previous
+	// config application do not persist. All interfaces will be re-registered
+	// by RenderPtp4lConf (and getInterfacesFromHardwareConfig) below before
+	// any event processing restarts.
+	alias.ClearAliases()
+
 	// All configs will be rebuild, and sockets recreated, so they can all be deleted
 	_ = dn.cleanupTempFiles()
 

--- a/pkg/event/event_tbc.go
+++ b/pkg/event/event_tbc.go
@@ -639,15 +639,24 @@ func (e *EventHandler) getLeadingInterfaceBC() string {
 func (e *EventHandler) convergeConfig(event EventChannel) EventChannel {
 	if event.ProcessName == PTP4lProcessName {
 		iface := event.IFace
+		ifacePhc := alias.GetPhcGroup(iface)
+		glog.Infof("convergeConfig: ptp4l iface=%s phcGroup=%q original cfgName=%s", iface, ifacePhc, event.CfgName)
 		for cfg, dd := range e.data {
 			for _, item := range dd {
 				if item.ProcessName != DPLL {
 					continue
 				}
 				for _, dp := range item.Details {
-					if alias.GetAlias(dp.IFace) == alias.GetAlias(iface) {
+					dpPhc := alias.GetPhcGroup(dp.IFace)
+					aliasMatch := alias.GetAlias(dp.IFace) == alias.GetAlias(iface)
+					samePhc := dpPhc != "" && dpPhc == ifacePhc
+					glog.Infof("convergeConfig: checking DPLL iface=%s phcGroup=%q alias=%q vs ptp4l alias=%q aliasMatch=%v samePhc=%v",
+						dp.IFace, dpPhc, alias.GetAlias(dp.IFace), alias.GetAlias(iface), aliasMatch, samePhc)
+					if aliasMatch || samePhc {
 						// We want to process ptp4l having a separate config with ts2phc and dpll events having ts2phc config
 						// so in the rare occurrence of ptp4l state change we modify the event.CfgName
+						glog.Infof("convergeConfig: remapping ptp4l event cfgName %s -> %s (iface %s matched DPLL iface %s)",
+							event.CfgName, cfg, iface, dp.IFace)
 						event.CfgName = cfg
 					}
 				}

--- a/pkg/hardwareconfig/hardware-vendor/hpe/EL140-Gen12/behavior-profiles.yaml
+++ b/pkg/hardwareconfig/hardware-vendor/hpe/EL140-Gen12/behavior-profiles.yaml
@@ -1,0 +1,96 @@
+# Behavior profiles for Intel E825 hardware
+# These templates define default behavior configurations for different clock types
+# Template variables: {subsystem}, {ptpInputPin}, {interface}
+# Hardware-specific pins (SDP2, SDP0) are hardcoded in the template
+
+behaviorProfiles:
+  t-bc:
+    # Pin role mappings - defines which pins serve which roles
+    pinRoles:
+      gnssInputPin: GNSS_1PPS_IN  # DPLL pin used for GNSS input (that should be disabled for T-BC)
+      ptpInputPin: 1PPS_IN0 # DPLL pin used for PTP input
+    
+    # Source template - will be instantiated with resolved variables
+    sources:
+      - name: PTP
+        sourceType: ptpTimeReceiver
+        subsystem: "{subsystem}"  # Will be resolved to subsystem name
+        boardLabel: "{ptpInputPin}"  # Will be resolved from pinRoles
+        # ptpTimeReceivers will be derived from ptpconfig
+    
+    # Condition templates - will be instantiated with resolved variables
+    conditions:
+      - name: "Initialize T-BC"
+        triggers:
+          - conditionType: init
+            sourceName: PTP
+        desiredStates:
+          - dpll:
+              subsystem: "{subsystem}"
+              boardLabel: "{gnssInputPin}"
+              eec:
+                state: disconnected
+              pps:
+                state: disconnected
+          - ptpPin:
+              name: SDP2
+              func: Disabled
+              chan: 0
+              sourceName: PTP
+          - ptpPin:
+              name: SDP0
+              func: Disabled
+              chan: 0
+              sourceName: PTP
+      
+      - name: "PTP Source Locked"
+        triggers:
+          - conditionType: locked
+            sourceName: PTP
+        desiredStates:
+          - ptpPin:
+              name: SDP2
+              func: TX
+              chan: 2
+              sourceName: PTP
+          - ptpPin:
+              name: SDP0
+              func: TX
+              chan: 1
+              sourceName: PTP
+          - ptpPeriod:
+              index: 1
+              period:
+                sec: 1
+                nsec: 0
+              sourceName: PTP
+          - ptpPeriod:
+              index: 2
+              period:
+                sec: 0
+                nsec: 1000000
+              sourceName: PTP
+          - dpll:
+              subsystem: "{subsystem}"
+              boardLabel: "{ptpInputPin}"
+              eec:
+                state: disconnected
+              pps:
+                state: selectable
+      
+      - name: "PTP Source Lost - Leader Holdover"
+        triggers:
+          - conditionType: lost
+            sourceName: PTP
+        desiredStates:
+          - ptpPin:
+              name: SDP0
+              func: Disabled
+              chan: 0
+              sourceName: PTP
+          - ptpPin:
+              name: SDP2
+              func: Disabled
+              chan: 0
+              sourceName: PTP
+

--- a/pkg/hardwareconfig/hardware-vendor/hpe/EL140-Gen12/delays.yaml
+++ b/pkg/hardwareconfig/hardware-vendor/hpe/EL140-Gen12/delays.yaml
@@ -1,0 +1,95 @@
+# Delay Compensation Model for Intel E825 (GNR-D)
+# This file defines the three-layer model: Topology (components), Physics (connections), and Intent (routes)
+#
+# NOTE: Delay values (delayPs) are specified with the correct sign for the target DPLL hardware.
+# Different DPLL implementations may treat phase adjustment direction differently.
+# The system sums these values directly without negation and passes them to the DPLL.
+
+# 1. Inventory - static phase transfer nodes
+components:
+# NAC-DPLL phase transfer nodes
+  - id: "NAC0 phase out 1kHz"
+  - id: "NAC0 phase out 1Hz"
+
+  - id: "NAC0 phase in 1kHz"
+  - id: "NAC0 phase in 1Hz"
+  
+  - id: "DPLL phase in 1kHz"
+    description: "DPLL phase reference input from NAC0, REF0P, Frequency - 1kHz"
+    compensationPoint:
+      name: "1PPS_IN1"
+      type: dpll
+  - id: "DPLL phase in 1Hz"
+    description: "DPLL phase reference input from NAC0, REF0N, Frequency - 1Hz"
+    compensationPoint:
+      name: "1PPS_IN0"
+      type: dpll
+
+  - id: "DPLL phase out 1Hz"
+    description: "DPLL phase signal output to NAC0, Frequency - 1Hz, OUT8N"
+    compensationPoint:
+      name: "1PPS_OUT0"
+      type: dpll  
+  - id: "DPLL phase out 1kHz"
+    description: "DPLL phase signal output to NAC0, Frequency - 1kHz, OUT8P"
+    compensationPoint:
+      name: "1PPS_OUT1"
+      type: dpll
+
+# DPLL to CF - ESync transfer nodes
+  - id: "DPLL ESync out"
+    description: "DPLL ESync output pin to CF, OUT2P"
+    compensationPoint:
+      name: "AIC_SCLK2"
+      type: dpll
+
+  - id: "CF ESync in"
+
+
+# 2. Topology: Physical connections (graph edges)
+# Each connection defines a delay segment in the signal path
+connections:
+  # NAC to Timing Module routing/wiring
+  - from: "NAC0 phase out 1kHz"
+    to: "DPLL phase in 1kHz"
+    delayPs: -2600
+  - from: "NAC0 phase out 1Hz"
+    to: "DPLL phase in 1Hz"
+    delayPs: -2600
+
+
+  # DPLL to NAC (during holdover)
+  - from: "DPLL phase out 1kHz"
+    to: "NAC0 phase in 1kHz"
+    delayPs: -7500
+  - from: "DPLL phase out 1Hz"
+    to: "NAC0 phase in 1Hz"
+    delayPs: -7500
+
+
+  - from: "DPLL ESync out"
+    to: "CF ESync in"
+    delayPs: -25000
+
+
+# 3. Logic: Where do we compensate for the delay
+# Routes define compensation strategies for specific signal paths
+# One route to many segments, one route to one compensator
+routes:
+  - name: "NAC phase out to DPLL phase in 1kHz"
+    sequence: ["NAC0 phase out 1kHz", "DPLL phase in 1kHz"]
+    compensator: "DPLL phase in 1kHz"
+  - name: "NAC phase out to DPLL phase in 1Hz"
+    sequence: ["NAC0 phase out 1Hz", "DPLL phase in 1Hz"]
+    compensator: "DPLL phase in 1Hz"
+  
+  - name: "DPLL phase out 1kHz to NAC phase in 1kHz"
+    sequence: ["DPLL phase out 1kHz", "NAC0 phase in 1kHz"]
+    compensator: "DPLL phase out 1kHz"
+  - name: "DPLL phase out 1Hz to NAC phase in 1Hz"
+    sequence: ["DPLL phase out 1Hz", "NAC0 phase in 1Hz"]
+    compensator: "DPLL phase out 1Hz"
+    
+  - name: "DPLL ESync out to CF ESync in"
+    sequence: ["DPLL ESync out", "CF ESync in"]
+    compensator: "DPLL ESync out"

--- a/pkg/hardwareconfig/vendor_embedded.go
+++ b/pkg/hardwareconfig/vendor_embedded.go
@@ -25,6 +25,12 @@ var dellXR8720tBehaviorProfilesYAML []byte
 //go:embed hardware-vendor/dell/XR8720t/delays.yaml
 var dellXR8720tDelaysYAML []byte
 
+//go:embed hardware-vendor/hpe/EL140-Gen12/behavior-profiles.yaml
+var hpeEL140Gen12BehaviorProfilesYAML []byte
+
+//go:embed hardware-vendor/hpe/EL140-Gen12/delays.yaml
+var hpeEL140Gen12DelaysYAML []byte
+
 // embeddedDefaults maps hwDefPath -> raw YAML contents.
 // Example key: "intel/e810"
 var embeddedDefaults = map[string][]byte{
@@ -35,13 +41,15 @@ var embeddedDefaults = map[string][]byte{
 // embeddedBehaviorProfiles maps hwDefPath -> raw YAML contents for behavior profiles.
 // Example key: "intel/e825"
 var embeddedBehaviorProfiles = map[string][]byte{
-	"intel/e825":   intelE825BehaviorProfilesYAML,
-	"dell/XR8720t": dellXR8720tBehaviorProfilesYAML,
+	"intel/e825":      intelE825BehaviorProfilesYAML,
+	"dell/XR8720t":    dellXR8720tBehaviorProfilesYAML,
+	"hpe/EL140-Gen12": hpeEL140Gen12BehaviorProfilesYAML,
 }
 
 // embeddedDelays maps hwDefPath -> raw YAML contents for delay compensation models.
 // Example key: "intel/e825"
 var embeddedDelays = map[string][]byte{
-	"intel/e825":   intelE825DelaysYAML,
-	"dell/XR8720t": dellXR8720tDelaysYAML,
+	"intel/e825":      intelE825DelaysYAML,
+	"dell/XR8720t":    dellXR8720tDelaysYAML,
+	"hpe/EL140-Gen12": hpeEL140Gen12DelaysYAML,
 }


### PR DESCRIPTION
Previously, interfaces were logically linked by a common name prefix. For
example, 'eno4' and 'eno5' were aliased as 'enox' and linked to the same
PTP hardware clock (PHC) island. This link is required in Telecom Boundary
Clock (T-BC) implementations to relate the upstream port to the leading
NIC port that exposes the PTP device.
    
However, some hardware implementations (such as the HPE ProLiant EL140 Gen12)
use different prefixes for ports belonging to the same NIC,
causing name-prefix association to fail.
    
Fix this by allowing the leading NIC's default interface and the upstream
port to be associated directly by their PHC.