### PR TITLE
fix: display original profile names in config headers and logs

### DIFF
--- a/pkg/controller/hardwareconfig_controller.go
+++ b/pkg/controller/hardwareconfig_controller.go
@@ -407,6 +407,21 @@ func (r *HardwareConfigReconciler) recordUpdateFailure(ctx context.Context, conf
 	// For now, we rely on events for error reporting
 }
 
+// formatQualifiedProfiles formats qualified profile names (ptpconfig_profileName)
+// into human-readable strings: "profile 'X' (ptpconfig 'Y'), ..."
+func formatQualifiedProfiles(qualifiedNames []string) string {
+	parts := make([]string, 0, len(qualifiedNames))
+	for _, qn := range qualifiedNames {
+		crName, profileName := hc.SplitQualifiedName(qn)
+		if crName != "" {
+			parts = append(parts, fmt.Sprintf("profile '%s' (ptpconfig '%s')", profileName, crName))
+		} else {
+			parts = append(parts, fmt.Sprintf("profile '%s'", qn))
+		}
+	}
+	return "[" + strings.Join(parts, ", ") + "]"
+}
+
 // ptpProfileNameMatchesActive reports whether relatedProfile is considered active.
 func ptpProfileNameMatchesActive(relatedProfile string, activePTPProfiles map[string]bool) bool {
 	for activeProfile := range activePTPProfiles {
@@ -432,7 +447,7 @@ func (r *HardwareConfigReconciler) calculateNodeHardwareConfigs(_ context.Contex
 		for _, profile := range activeProfiles {
 			activePTPProfiles[profile] = true
 		}
-		glog.Infof("Filtering hardware configs by active PTP profiles: %v", activeProfiles)
+		glog.Infof("Filtering hardware configs by active PTP profiles: %s", formatQualifiedProfiles(activeProfiles))
 	} else {
 		// No active profiles - exclude all hardware configs
 		activePTPProfiles = make(map[string]bool) // Empty map to trigger filtering
@@ -503,7 +518,7 @@ func (r *HardwareConfigReconciler) checkIfChangedConfigsAffectActiveProfiles(dif
 		}
 	}
 
-	glog.V(2).Infof("Changed hardware configs are not associated with active PTP profiles %v", activePTPProfiles)
+	glog.V(2).Infof("Changed hardware configs are not associated with active PTP profiles %s", formatQualifiedProfiles(activePTPProfiles))
 	return false
 }
 

--- a/pkg/daemon/config.go
+++ b/pkg/daemon/config.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/alias"
+	hc "github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/hardwareconfig"
 	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/network"
 	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/synce"
 
@@ -62,6 +63,24 @@ func (l *LinuxPTPConfUpdate) TriggerRestartForHardwareChange() error {
 	}
 }
 
+// DisplayProfileName strips the PtpConfig CR name prefix from a qualified
+// profile name (crName_profileName) and returns the original user-facing name.
+// If the name does not contain the separator it is returned as-is.
+func DisplayProfileName(qualifiedName string) string {
+	_, profile := hc.SplitQualifiedName(qualifiedName)
+	return profile
+}
+
+// formatProfileHeader formats a qualified profile name for config file headers.
+// Returns "profileName from ptpconfig crName" when qualified, or just the name otherwise.
+func formatProfileHeader(qualifiedName string) string {
+	crName, profile := hc.SplitQualifiedName(qualifiedName)
+	if crName != "" {
+		return fmt.Sprintf("%s from ptpconfig %s", profile, crName)
+	}
+	return profile
+}
+
 // GetCurrentPTPProfiles implements HardwareConfigRestartTrigger interface
 // Returns the names of currently active PTP profiles
 func (l *LinuxPTPConfUpdate) GetCurrentPTPProfiles() []string {
@@ -76,7 +95,11 @@ func (l *LinuxPTPConfUpdate) GetCurrentPTPProfiles() []string {
 		}
 	}
 
-	glog.Infof("Current active PTP profiles: %v", profileNames)
+	displayNames := make([]string, 0, len(profileNames))
+	for _, n := range profileNames {
+		displayNames = append(displayNames, fmt.Sprintf("%s (%s)", DisplayProfileName(n), n))
+	}
+	glog.Infof("Current active PTP profiles: %v", displayNames)
 	return profileNames
 }
 
@@ -404,7 +427,7 @@ func (conf *Ptp4lConf) extractSynceRelations() *synce.Relations {
 
 // RenderSyncE4lConf outputs synce4l config as string
 func (conf *Ptp4lConf) RenderSyncE4lConf(ptpSettings map[string]string) (configOut string, relations *synce.Relations) {
-	configOut = fmt.Sprintf("#profile: %s\n", conf.profile_name)
+	configOut = fmt.Sprintf("#profile: %s\n", formatProfileHeader(conf.profile_name))
 	relations = conf.extractSynceRelations()
 	relations.AddClockIds(ptpSettings)
 	deviceIdx := 0
@@ -434,7 +457,7 @@ func getSectionName(name string) string {
 
 // RenderPtp4lConf outputs ptp4l config as string
 func (conf *Ptp4lConf) RenderPtp4lConf() (configOut string, ifaces config.IFaces) {
-	configOut = fmt.Sprintf("#profile: %s\n", conf.profile_name)
+	configOut = fmt.Sprintf("#profile: %s\n", formatProfileHeader(conf.profile_name))
 	var nmea_source event.EventSource
 
 	for _, section := range conf.sections {

--- a/pkg/daemon/config.go
+++ b/pkg/daemon/config.go
@@ -71,14 +71,14 @@ func DisplayProfileName(qualifiedName string) string {
 	return profile
 }
 
-// formatProfileHeader formats a qualified profile name for config file headers.
-// Returns "profileName from ptpconfig crName" when qualified, or just the name otherwise.
-func formatProfileHeader(qualifiedName string) string {
-	crName, profile := hc.SplitQualifiedName(qualifiedName)
+// profileHeader returns the config file header string for a profile name.
+// For qualified names it appends the decomposed parts; unqualified names are returned as-is.
+func profileHeader(name string) string {
+	crName, profileName := hc.SplitQualifiedName(name)
 	if crName != "" {
-		return fmt.Sprintf("%s from ptpconfig %s", profile, crName)
+		return fmt.Sprintf("%s, original profile name %s defined in ptpconfig %s", name, profileName, crName)
 	}
-	return profile
+	return name
 }
 
 // GetCurrentPTPProfiles implements HardwareConfigRestartTrigger interface
@@ -95,11 +95,7 @@ func (l *LinuxPTPConfUpdate) GetCurrentPTPProfiles() []string {
 		}
 	}
 
-	displayNames := make([]string, 0, len(profileNames))
-	for _, n := range profileNames {
-		displayNames = append(displayNames, fmt.Sprintf("%s (%s)", DisplayProfileName(n), n))
-	}
-	glog.Infof("Current active PTP profiles: %v", displayNames)
+	glog.Infof("Current active PTP profiles: %v", profileNames)
 	return profileNames
 }
 
@@ -427,7 +423,7 @@ func (conf *Ptp4lConf) extractSynceRelations() *synce.Relations {
 
 // RenderSyncE4lConf outputs synce4l config as string
 func (conf *Ptp4lConf) RenderSyncE4lConf(ptpSettings map[string]string) (configOut string, relations *synce.Relations) {
-	configOut = fmt.Sprintf("#profile: %s\n", formatProfileHeader(conf.profile_name))
+	configOut = fmt.Sprintf("#profile: %s\n", profileHeader(conf.profile_name))
 	relations = conf.extractSynceRelations()
 	relations.AddClockIds(ptpSettings)
 	deviceIdx := 0
@@ -457,7 +453,7 @@ func getSectionName(name string) string {
 
 // RenderPtp4lConf outputs ptp4l config as string
 func (conf *Ptp4lConf) RenderPtp4lConf() (configOut string, ifaces config.IFaces) {
-	configOut = fmt.Sprintf("#profile: %s\n", formatProfileHeader(conf.profile_name))
+	configOut = fmt.Sprintf("#profile: %s\n", profileHeader(conf.profile_name))
 	var nmea_source event.EventSource
 
 	for _, section := range conf.sections {

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -413,7 +413,7 @@ func (dn *Daemon) getInterfacesFromHardwareConfig(nodeProfile *ptpv1.PtpProfile)
 	// Get hardware configs for this profile
 	hwProfiles := dn.hardwareConfigManager.GetHardwareConfigsForProfile(nodeProfile)
 	if len(hwProfiles) == 0 {
-		glog.V(2).Infof("No hardware configs found for profile %s (%s)", DisplayProfileName(*nodeProfile.Name), *nodeProfile.Name)
+		glog.V(2).Infof("No hardware configs found for profile %s", *nodeProfile.Name)
 		return config.IFaces{}
 	}
 
@@ -718,38 +718,38 @@ func (dn *Daemon) applyNodePTPProfiles() error {
 	// TODO: resolve clock IDs, clockType, leadingInterface and upstreamPort from hardware config
 	// (needed to keep code compatibility elsewhere and allow it to work both with hardware config and plugins)
 	for _, profile := range dn.ptpUpdate.NodeProfiles {
-		displayName := DisplayProfileName(*profile.Name)
-		glog.Infof("Processing profile: %s (%s)", displayName, *profile.Name)
+		crName, profileName := hardwareconfig.SplitQualifiedName(*profile.Name)
+		glog.Infof("Processing profile: %s, original profile name %s defined in ptpconfig %s", *profile.Name, profileName, crName)
 
 		// Log profile details for debugging
 		if profile.Interface != nil {
-			glog.Infof("Profile %s (%s) interface: %s", displayName, *profile.Name, *profile.Interface)
+			glog.Infof("Profile %s interface: %s", *profile.Name, *profile.Interface)
 		} else {
-			glog.Infof("Profile %s (%s) has no interface field (nil)", displayName, *profile.Name)
+			glog.Infof("Profile %s has no interface field (nil)", *profile.Name)
 		}
 		if profile.Ptp4lOpts != nil {
-			glog.Infof("Profile %s (%s) ptp4lOpts: %s", displayName, *profile.Name, *profile.Ptp4lOpts)
+			glog.Infof("Profile %s ptp4lOpts: %s", *profile.Name, *profile.Ptp4lOpts)
 		}
 		if profile.Phc2sysOpts != nil {
-			glog.Infof("Profile %s (%s) phc2sysOpts: %s", displayName, *profile.Name, *profile.Phc2sysOpts)
+			glog.Infof("Profile %s phc2sysOpts: %s", *profile.Name, *profile.Phc2sysOpts)
 		}
 		if profile.Ts2PhcOpts != nil {
-			glog.Infof("Profile %s (%s) ts2phcOpts: %s", displayName, *profile.Name, *profile.Ts2PhcOpts)
+			glog.Infof("Profile %s ts2phcOpts: %s", *profile.Name, *profile.Ts2PhcOpts)
 		}
 		if profile.ChronydOpts != nil {
-			glog.Infof("Profile %s (%s) chronydOpts: %s", displayName, *profile.Name, *profile.ChronydOpts)
+			glog.Infof("Profile %s chronydOpts: %s", *profile.Name, *profile.ChronydOpts)
 		}
 		if controlledID, ok := relations[*profile.Name]; ok {
 			profile.PtpSettings["controlledId"] = strconv.Itoa(controlledID)
 		}
 
-		glog.Infof("Calling applyNodePtpProfile for profile %s (%s) with runID %d", displayName, *profile.Name, runID)
+		glog.Infof("Calling applyNodePtpProfile for profile %s with runID %d, original profile name %s defined in ptpconfig %s", *profile.Name, runID, profileName, crName)
 		err := dn.applyNodePtpProfile(runID, &profile)
 		if err != nil {
-			glog.Errorf("Failed to apply profile %s (%s): %v", displayName, *profile.Name, err)
+			glog.Errorf("Failed to apply profile %s: %v", *profile.Name, err)
 			return err
 		}
-		glog.Infof("Successfully applied profile: %s (%s)", displayName, *profile.Name)
+		glog.Infof("Successfully applied profile: %s", *profile.Name)
 		runID++
 	}
 
@@ -819,9 +819,7 @@ func reconcileRelatedProfiles(profiles []ptpv1.PtpProfile) map[string]int {
 
 func printNodeProfile(nodeProfile *ptpv1.PtpProfile) {
 	glog.Infof("------------------------------------")
-	if nodeProfile.Name != nil {
-		glog.Infof("Profile Name: %s (%s)", DisplayProfileName(*nodeProfile.Name), *nodeProfile.Name)
-	}
+	printWhenNotNil(nodeProfile.Name, "Profile Name")
 	printWhenNotNil(nodeProfile.Interface, "Interface")
 	printWhenNotNil(nodeProfile.Ptp4lOpts, "Ptp4lOpts")
 	printWhenNotNil(nodeProfile.Ptp4lConf, "Ptp4lConf")
@@ -861,20 +859,20 @@ func (dn *Daemon) applyNodePtpProfile(runID int, nodeProfile *ptpv1.PtpProfile) 
 		}
 	}
 
-	displayName := DisplayProfileName(*nodeProfile.Name)
+	crName, profileName := hardwareconfig.SplitQualifiedName(*nodeProfile.Name)
 
 	// Check if hardware configs are available for this profile
 	// If hardware configs arrive later, reconciliation will re-apply the profile
 	if dn.hardwareConfigManager.ReadyHardwareConfigForProfile(*nodeProfile.Name) {
-		glog.Infof("Using hardware configs for PTP profile %s (%s) instead of plugins", displayName, *nodeProfile.Name)
+		glog.Infof("Using hardware configs for PTP profile %s instead of plugins, original profile name %s defined in ptpconfig %s", *nodeProfile.Name, profileName, crName)
 		if err := dn.hardwareConfigManager.ApplyHardwareConfigsForProfile(nodeProfile); err != nil {
-			glog.Errorf("Failed to apply hardware configs for profile %s (%s): %v", displayName, *nodeProfile.Name, err)
+			glog.Errorf("Failed to apply hardware configs for profile %s: %v", *nodeProfile.Name, err)
 			// Fall back to plugins
 			errs := dn.pluginManager.OnPTPConfigChange(nodeProfile)
 			pluginErrors = append(pluginErrors, errs...)
 		}
 	} else {
-		glog.Infof("No hardware configs found for PTP profile %s (%s), using plugins", displayName, *nodeProfile.Name)
+		glog.Infof("No hardware configs found for PTP profile %s, using plugins", *nodeProfile.Name)
 		errs := dn.pluginManager.OnPTPConfigChange(nodeProfile)
 		pluginErrors = append(pluginErrors, errs...)
 	}
@@ -1014,10 +1012,10 @@ func (dn *Daemon) applyNodePtpProfile(runID int, nodeProfile *ptpv1.PtpProfile) 
 		}
 
 		if configOpts == nil || *configOpts == "" {
-			glog.Infof("configOpts empty for profile %s (%s), skipping process: %s", displayName, *nodeProfile.Name, pProcess)
+			glog.Infof("configOpts empty for profile %s, skipping process: %s", *nodeProfile.Name, pProcess)
 			continue
 		}
-		glog.Infof("Processing %s for profile %s (%s) with opts: %s", pProcess, displayName, *nodeProfile.Name, *configOpts)
+		glog.Infof("Processing %s for profile %s with opts: %s", pProcess, *nodeProfile.Name, *configOpts)
 
 		if nodeProfile.Interface != nil && *nodeProfile.Interface != "" {
 			output.AddInterfaceSection(*nodeProfile.Interface)
@@ -1121,7 +1119,7 @@ func (dn *Daemon) applyNodePtpProfile(runID int, nodeProfile *ptpv1.PtpProfile) 
 			// Skip PMC creation for controlled profiles
 			if controllingProfile, isControlled := (*nodeProfile).PtpSettings["controllingProfile"]; isControlled && controllingProfile != "" {
 				// See DownstreamIWF
-				glog.Infof("Skipping PMC monitoring for controlled profile %s (%s)", displayName, *nodeProfile.Name)
+				glog.Infof("Skipping PMC monitoring for controlled profile %s", *nodeProfile.Name)
 			} else if clockType == event.GM {
 				glog.Infof("Skipping PMC monitoring for GM")
 			} else {
@@ -1206,9 +1204,9 @@ func (dn *Daemon) applyNodePtpProfile(runID int, nodeProfile *ptpv1.PtpProfile) 
 			if profileClockType == TBC && dn.hardwareConfigManager.ReadyHardwareConfigForProfile(*nodeProfile.Name) {
 				interfacesToUse = dn.getInterfacesFromHardwareConfig(nodeProfile)
 				if len(interfacesToUse) > 0 {
-					glog.Infof("Using interfaces from hardwareconfig for T-BC profile %s (%s): %v", displayName, *nodeProfile.Name, interfacesToUse)
+					glog.Infof("Using interfaces from hardwareconfig for T-BC profile %s: %v", *nodeProfile.Name, interfacesToUse)
 				} else {
-					glog.Warningf("Failed to derive interfaces from hardwareconfig for T-BC profile %s (%s), falling back to ts2phc config", displayName, *nodeProfile.Name)
+					glog.Warningf("Failed to derive interfaces from hardwareconfig for T-BC profile %s, falling back to ts2phc config", *nodeProfile.Name)
 					interfacesToUse = dprocess.ifaces
 				}
 			} else {
@@ -1305,10 +1303,10 @@ func (dn *Daemon) applyNodePtpProfile(runID int, nodeProfile *ptpv1.PtpProfile) 
 		printNodeProfile(nodeProfile)
 		dn.processManager.process = append(dn.processManager.process, &dprocess)
 		dn.pluginManager.RegisterEnableCallback(dprocess.name, dprocess.cmdSetEnabled)
-		glog.Infof("Added %s process to process manager for profile %s (%s)", pProcess, displayName, *nodeProfile.Name)
+		glog.Infof("Added %s process to process manager for profile %s", pProcess, *nodeProfile.Name)
 
 	}
-	glog.Infof("Completed applyNodePtpProfile for profile %s (%s), total processes in manager: %d", displayName, *nodeProfile.Name, len(dn.processManager.process))
+	glog.Infof("Completed applyNodePtpProfile for profile %s, total processes in manager: %d, original profile name %s defined in ptpconfig %s", *nodeProfile.Name, len(dn.processManager.process), profileName, crName)
 	return nil
 }
 
@@ -1941,10 +1939,10 @@ func (p *ptpProcess) announceHAFailOver(c net.Conn, output string) {
 			inActiveProfiles = append(inActiveProfiles, profile)
 		}
 	}
-	// log both active and inactive profiles with display names and qualified names
-	logString := []string{fmt.Sprintf("%s[%d]:[%s] ptp_ha_profile %s (%s) state %d\n", p.name, time.Now().Unix(), p.configName, DisplayProfileName(currentProfile), currentProfile, activeState)}
+	// log both active and inactive profiles
+	logString := []string{fmt.Sprintf("%s[%d]:[%s] ptp_ha_profile %s state %d\n", p.name, time.Now().Unix(), p.configName, currentProfile, activeState)}
 	for _, inActive := range inActiveProfiles {
-		logString = append(logString, fmt.Sprintf("%s[%d]:[%s] ptp_ha_profile %s (%s) state %d\n", p.name, time.Now().Unix(), p.configName, DisplayProfileName(inActive), inActive, 0))
+		logString = append(logString, fmt.Sprintf("%s[%d]:[%s] ptp_ha_profile %s state %d\n", p.name, time.Now().Unix(), p.configName, inActive, 0))
 	}
 	if c == nil {
 		for _, logProfile := range logString {

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -413,7 +413,7 @@ func (dn *Daemon) getInterfacesFromHardwareConfig(nodeProfile *ptpv1.PtpProfile)
 	// Get hardware configs for this profile
 	hwProfiles := dn.hardwareConfigManager.GetHardwareConfigsForProfile(nodeProfile)
 	if len(hwProfiles) == 0 {
-		glog.V(2).Infof("No hardware configs found for profile %s", *nodeProfile.Name)
+		glog.V(2).Infof("No hardware configs found for profile %s (%s)", DisplayProfileName(*nodeProfile.Name), *nodeProfile.Name)
 		return config.IFaces{}
 	}
 
@@ -718,37 +718,38 @@ func (dn *Daemon) applyNodePTPProfiles() error {
 	// TODO: resolve clock IDs, clockType, leadingInterface and upstreamPort from hardware config
 	// (needed to keep code compatibility elsewhere and allow it to work both with hardware config and plugins)
 	for _, profile := range dn.ptpUpdate.NodeProfiles {
-		glog.Infof("Processing profile: %s", *profile.Name)
+		displayName := DisplayProfileName(*profile.Name)
+		glog.Infof("Processing profile: %s (%s)", displayName, *profile.Name)
 
 		// Log profile details for debugging
 		if profile.Interface != nil {
-			glog.Infof("Profile %s interface: %s", *profile.Name, *profile.Interface)
+			glog.Infof("Profile %s (%s) interface: %s", displayName, *profile.Name, *profile.Interface)
 		} else {
-			glog.Infof("Profile %s has no interface field (nil)", *profile.Name)
+			glog.Infof("Profile %s (%s) has no interface field (nil)", displayName, *profile.Name)
 		}
 		if profile.Ptp4lOpts != nil {
-			glog.Infof("Profile %s ptp4lOpts: %s", *profile.Name, *profile.Ptp4lOpts)
+			glog.Infof("Profile %s (%s) ptp4lOpts: %s", displayName, *profile.Name, *profile.Ptp4lOpts)
 		}
 		if profile.Phc2sysOpts != nil {
-			glog.Infof("Profile %s phc2sysOpts: %s", *profile.Name, *profile.Phc2sysOpts)
+			glog.Infof("Profile %s (%s) phc2sysOpts: %s", displayName, *profile.Name, *profile.Phc2sysOpts)
 		}
 		if profile.Ts2PhcOpts != nil {
-			glog.Infof("Profile %s ts2phcOpts: %s", *profile.Name, *profile.Ts2PhcOpts)
+			glog.Infof("Profile %s (%s) ts2phcOpts: %s", displayName, *profile.Name, *profile.Ts2PhcOpts)
 		}
 		if profile.ChronydOpts != nil {
-			glog.Infof("Profile %s chronydOpts: %s", *profile.Name, *profile.ChronydOpts)
+			glog.Infof("Profile %s (%s) chronydOpts: %s", displayName, *profile.Name, *profile.ChronydOpts)
 		}
 		if controlledID, ok := relations[*profile.Name]; ok {
 			profile.PtpSettings["controlledId"] = strconv.Itoa(controlledID)
 		}
 
-		glog.Infof("Calling applyNodePtpProfile for profile %s with runID %d", *profile.Name, runID)
+		glog.Infof("Calling applyNodePtpProfile for profile %s (%s) with runID %d", displayName, *profile.Name, runID)
 		err := dn.applyNodePtpProfile(runID, &profile)
 		if err != nil {
-			glog.Errorf("Failed to apply profile %s: %v", *profile.Name, err)
+			glog.Errorf("Failed to apply profile %s (%s): %v", displayName, *profile.Name, err)
 			return err
 		}
-		glog.Infof("Successfully applied profile: %s", *profile.Name)
+		glog.Infof("Successfully applied profile: %s (%s)", displayName, *profile.Name)
 		runID++
 	}
 
@@ -818,7 +819,9 @@ func reconcileRelatedProfiles(profiles []ptpv1.PtpProfile) map[string]int {
 
 func printNodeProfile(nodeProfile *ptpv1.PtpProfile) {
 	glog.Infof("------------------------------------")
-	printWhenNotNil(nodeProfile.Name, "Profile Name")
+	if nodeProfile.Name != nil {
+		glog.Infof("Profile Name: %s (%s)", DisplayProfileName(*nodeProfile.Name), *nodeProfile.Name)
+	}
 	printWhenNotNil(nodeProfile.Interface, "Interface")
 	printWhenNotNil(nodeProfile.Ptp4lOpts, "Ptp4lOpts")
 	printWhenNotNil(nodeProfile.Ptp4lConf, "Ptp4lConf")
@@ -858,18 +861,20 @@ func (dn *Daemon) applyNodePtpProfile(runID int, nodeProfile *ptpv1.PtpProfile) 
 		}
 	}
 
+	displayName := DisplayProfileName(*nodeProfile.Name)
+
 	// Check if hardware configs are available for this profile
 	// If hardware configs arrive later, reconciliation will re-apply the profile
 	if dn.hardwareConfigManager.ReadyHardwareConfigForProfile(*nodeProfile.Name) {
-		glog.Infof("Using hardware configs for PTP profile %s instead of plugins", *nodeProfile.Name)
+		glog.Infof("Using hardware configs for PTP profile %s (%s) instead of plugins", displayName, *nodeProfile.Name)
 		if err := dn.hardwareConfigManager.ApplyHardwareConfigsForProfile(nodeProfile); err != nil {
-			glog.Errorf("Failed to apply hardware configs for profile %s: %v", *nodeProfile.Name, err)
+			glog.Errorf("Failed to apply hardware configs for profile %s (%s): %v", displayName, *nodeProfile.Name, err)
 			// Fall back to plugins
 			errs := dn.pluginManager.OnPTPConfigChange(nodeProfile)
 			pluginErrors = append(pluginErrors, errs...)
 		}
 	} else {
-		glog.Infof("No hardware configs found for PTP profile %s, using plugins", *nodeProfile.Name)
+		glog.Infof("No hardware configs found for PTP profile %s (%s), using plugins", displayName, *nodeProfile.Name)
 		errs := dn.pluginManager.OnPTPConfigChange(nodeProfile)
 		pluginErrors = append(pluginErrors, errs...)
 	}
@@ -1009,10 +1014,10 @@ func (dn *Daemon) applyNodePtpProfile(runID int, nodeProfile *ptpv1.PtpProfile) 
 		}
 
 		if configOpts == nil || *configOpts == "" {
-			glog.Infof("configOpts empty for profile %s, skipping process: %s", *nodeProfile.Name, pProcess)
+			glog.Infof("configOpts empty for profile %s (%s), skipping process: %s", displayName, *nodeProfile.Name, pProcess)
 			continue
 		}
-		glog.Infof("Processing %s for profile %s with opts: %s", pProcess, *nodeProfile.Name, *configOpts)
+		glog.Infof("Processing %s for profile %s (%s) with opts: %s", pProcess, displayName, *nodeProfile.Name, *configOpts)
 
 		if nodeProfile.Interface != nil && *nodeProfile.Interface != "" {
 			output.AddInterfaceSection(*nodeProfile.Interface)
@@ -1116,7 +1121,7 @@ func (dn *Daemon) applyNodePtpProfile(runID int, nodeProfile *ptpv1.PtpProfile) 
 			// Skip PMC creation for controlled profiles
 			if controllingProfile, isControlled := (*nodeProfile).PtpSettings["controllingProfile"]; isControlled && controllingProfile != "" {
 				// See DownstreamIWF
-				glog.Infof("Skipping PMC monitoring for controlled profile %s", *nodeProfile.Name)
+				glog.Infof("Skipping PMC monitoring for controlled profile %s (%s)", displayName, *nodeProfile.Name)
 			} else if clockType == event.GM {
 				glog.Infof("Skipping PMC monitoring for GM")
 			} else {
@@ -1201,9 +1206,9 @@ func (dn *Daemon) applyNodePtpProfile(runID int, nodeProfile *ptpv1.PtpProfile) 
 			if profileClockType == TBC && dn.hardwareConfigManager.ReadyHardwareConfigForProfile(*nodeProfile.Name) {
 				interfacesToUse = dn.getInterfacesFromHardwareConfig(nodeProfile)
 				if len(interfacesToUse) > 0 {
-					glog.Infof("Using interfaces from hardwareconfig for T-BC profile %s: %v", *nodeProfile.Name, interfacesToUse)
+					glog.Infof("Using interfaces from hardwareconfig for T-BC profile %s (%s): %v", displayName, *nodeProfile.Name, interfacesToUse)
 				} else {
-					glog.Warningf("Failed to derive interfaces from hardwareconfig for T-BC profile %s, falling back to ts2phc config", *nodeProfile.Name)
+					glog.Warningf("Failed to derive interfaces from hardwareconfig for T-BC profile %s (%s), falling back to ts2phc config", displayName, *nodeProfile.Name)
 					interfacesToUse = dprocess.ifaces
 				}
 			} else {
@@ -1300,10 +1305,10 @@ func (dn *Daemon) applyNodePtpProfile(runID int, nodeProfile *ptpv1.PtpProfile) 
 		printNodeProfile(nodeProfile)
 		dn.processManager.process = append(dn.processManager.process, &dprocess)
 		dn.pluginManager.RegisterEnableCallback(dprocess.name, dprocess.cmdSetEnabled)
-		glog.Infof("Added %s process to process manager for profile %s", pProcess, *nodeProfile.Name)
+		glog.Infof("Added %s process to process manager for profile %s (%s)", pProcess, displayName, *nodeProfile.Name)
 
 	}
-	glog.Infof("Completed applyNodePtpProfile for profile %s, total processes in manager: %d", *nodeProfile.Name, len(dn.processManager.process))
+	glog.Infof("Completed applyNodePtpProfile for profile %s (%s), total processes in manager: %d", displayName, *nodeProfile.Name, len(dn.processManager.process))
 	return nil
 }
 
@@ -1936,10 +1941,10 @@ func (p *ptpProcess) announceHAFailOver(c net.Conn, output string) {
 			inActiveProfiles = append(inActiveProfiles, profile)
 		}
 	}
-	// log both active and inactive profiles
-	logString := []string{fmt.Sprintf("%s[%d]:[%s] ptp_ha_profile %s state %d\n", p.name, time.Now().Unix(), p.configName, currentProfile, activeState)}
+	// log both active and inactive profiles with display names and qualified names
+	logString := []string{fmt.Sprintf("%s[%d]:[%s] ptp_ha_profile %s (%s) state %d\n", p.name, time.Now().Unix(), p.configName, DisplayProfileName(currentProfile), currentProfile, activeState)}
 	for _, inActive := range inActiveProfiles {
-		logString = append(logString, fmt.Sprintf("%s[%d]:[%s] ptp_ha_profile %s state %d\n", p.name, time.Now().Unix(), p.configName, inActive, 0))
+		logString = append(logString, fmt.Sprintf("%s[%d]:[%s] ptp_ha_profile %s (%s) state %d\n", p.name, time.Now().Unix(), p.configName, DisplayProfileName(inActive), inActive, 0))
 	}
 	if c == nil {
 		for _, logProfile := range logString {

--- a/pkg/daemon/daemon_test.go
+++ b/pkg/daemon/daemon_test.go
@@ -911,3 +911,31 @@ func TestDaemon_PopulateAndRenderPtp4lConf(t *testing.T) {
 		assert.Equal(t, tc.expectedOutput, actualOutput, fmt.Sprintf("Rendered output doesn't match expected: %s", tc.testName))
 	}
 }
+
+func TestDaemon_DisplayProfileName(t *testing.T) {
+	tests := []struct {
+		qualified string
+		expected  string
+	}{
+		{"crName_profileName", "profileName"},
+		{"my-config_my-profile", "my-profile"},
+		{"cr_profile_with_underscores", "profile_with_underscores"},
+		{"noprefix", "noprefix"},
+		{"", ""},
+	}
+	for _, tt := range tests {
+		result := daemon.DisplayProfileName(tt.qualified)
+		assert.Equal(t, tt.expected, result, "DisplayProfileName(%q)", tt.qualified)
+	}
+}
+
+func TestDaemon_RenderPtp4lConfStripsQualifiedProfileName(t *testing.T) {
+	conf := &daemon.Ptp4lConf{}
+	testConf := "[global]\nslaveOnly 1"
+	conf.PopulatePtp4lConf(&testConf, nil)
+	conf.AddInterfaceSection("ens2f0")
+	conf.ExtendGlobalSection("my-ptpconfig_OC", "tag", "/var/run/ptp4l.0.socket", "")
+	actualOutput, _ := conf.RenderPtp4lConf()
+	expected := "#profile: OC from ptpconfig my-ptpconfig\n\n[global]\nslaveOnly 1\nmessage_tag tag\nuds_address /var/run/ptp4l.0.socket\n[ens2f0]"
+	assert.Equal(t, expected, actualOutput, "Config header should show profile name and ptpconfig origin")
+}

--- a/pkg/daemon/daemon_test.go
+++ b/pkg/daemon/daemon_test.go
@@ -929,13 +929,13 @@ func TestDaemon_DisplayProfileName(t *testing.T) {
 	}
 }
 
-func TestDaemon_RenderPtp4lConfStripsQualifiedProfileName(t *testing.T) {
+func TestDaemon_RenderPtp4lConfProfileHeader(t *testing.T) {
 	conf := &daemon.Ptp4lConf{}
 	testConf := "[global]\nslaveOnly 1"
 	conf.PopulatePtp4lConf(&testConf, nil)
 	conf.AddInterfaceSection("ens2f0")
 	conf.ExtendGlobalSection("my-ptpconfig_OC", "tag", "/var/run/ptp4l.0.socket", "")
 	actualOutput, _ := conf.RenderPtp4lConf()
-	expected := "#profile: OC from ptpconfig my-ptpconfig\n\n[global]\nslaveOnly 1\nmessage_tag tag\nuds_address /var/run/ptp4l.0.socket\n[ens2f0]"
-	assert.Equal(t, expected, actualOutput, "Config header should show profile name and ptpconfig origin")
+	expected := "#profile: my-ptpconfig_OC, original profile name OC defined in ptpconfig my-ptpconfig\n\n[global]\nslaveOnly 1\nmessage_tag tag\nuds_address /var/run/ptp4l.0.socket\n[ens2f0]"
+	assert.Equal(t, expected, actualOutput, "Config header should contain qualified name and decomposed parts")
 }

--- a/pkg/hardwareconfig/clockchain_resolution.go
+++ b/pkg/hardwareconfig/clockchain_resolution.go
@@ -157,17 +157,27 @@ func findLeadingInterfaceFromUpstreamPortWithResolver(upstreamPort string, resol
 	return leadingInterface, nil
 }
 
+// SplitQualifiedName decomposes a qualified profile name ("crName_profileName")
+// into its two parts. If the name has no prefix, crName is empty.
+func SplitQualifiedName(qualified string) (crName, profileName string) {
+	if parts := strings.SplitN(qualified, "_", 2); len(parts) == 2 {
+		return parts[0], parts[1]
+	}
+	return "", qualified
+}
+
 // ProfileNamesMatch reports whether a PtpConfig profile name (stored) matches a
 // HardwareConfig's RelatedPtpProfileName (requested).
+// The stored name must be qualified (contain a "_" prefix); unqualified names never match.
 func ProfileNamesMatch(stored, requested string) bool {
 	if strings.TrimSpace(requested) == "" {
 		return false
 	}
-	parts := strings.SplitN(stored, "_", 2)
-	if len(parts) > 1 && parts[1] == requested {
-		return true
+	crName, profile := SplitQualifiedName(stored)
+	if crName == "" {
+		return false
 	}
-	return false
+	return profile == requested
 }
 
 // ResolveClockChain resolves a minimal hardwareconfig by deriving structure and behavior

--- a/pkg/hardwareconfig/clockchain_resolution_test.go
+++ b/pkg/hardwareconfig/clockchain_resolution_test.go
@@ -430,6 +430,25 @@ func findConditionByName(conditions []ptpv2alpha1.Condition, name string) *ptpv2
 	return nil
 }
 
+func TestSplitQualifiedName(t *testing.T) {
+	tests := []struct {
+		input       string
+		wantCR      string
+		wantProfile string
+	}{
+		{"crName_profileName", "crName", "profileName"},
+		{"my-cr_my-profile", "my-cr", "my-profile"},
+		{"cr_profile_with_underscores", "cr", "profile_with_underscores"},
+		{"noprefix", "", "noprefix"},
+		{"", "", ""},
+	}
+	for _, tt := range tests {
+		cr, profile := SplitQualifiedName(tt.input)
+		assert.Equal(t, tt.wantCR, cr, "SplitQualifiedName(%q) crName", tt.input)
+		assert.Equal(t, tt.wantProfile, profile, "SplitQualifiedName(%q) profileName", tt.input)
+	}
+}
+
 func TestProfileNamesMatch(t *testing.T) {
 	tests := []struct {
 		stored    string


### PR DESCRIPTION
### Summary
1. **ptp4l/synce4l** config files now render the #profile: header with the original profile name instead of the internal qualified form (ptpconfig_profileName).
2. **Daemon logs** across profile apply, HA failover, and hardwareconfig controller now display human-readable profile names — stripping the internal ptpconfig_ prefix so they match what the user originally configured.