### PR TITLE
OCPBUGS-85092: Move sendSidecarRestart before process start

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -126,8 +126,10 @@ func dialSocket() (net.Conn, error) {
 // over a short-lived dedicated connection to the event socket. The sidecar will exec itself
 // for a clean restart, then re-read all configuration from disk (ConfigMap + ptp4l config files).
 //
-// This must be called after applyNodePTPProfiles() has written all config files and started
-// all PTP processes, so that the sidecar restarts into a consistent state.
+// This must be called in applyNodePTPProfiles(), after writing config files but before
+// starting new processes. The sidecar exec's itself and re-reads all configuration
+// from disk on startup. Combined with a 1-second sleep, this ensures the sidecar
+// is listening before ptp4l emits its first log line (same guarantee as PR #29).
 func sendSidecarRestart() error {
 	c, err := net.Dial("unix", eventSocket)
 	if err != nil {
@@ -661,6 +663,7 @@ func (dn *Daemon) applyNodePTPProfiles() error {
 	glog.Infof("in applyNodePTPProfiles - starting to apply %d node profiles", len(dn.ptpUpdate.NodeProfiles))
 
 	dn.stopAllProcesses()
+
 	// All process should have been stopped,
 	// clear process in process manager.
 	// Assigning processManager.process to nil releases
@@ -752,6 +755,14 @@ func (dn *Daemon) applyNodePTPProfiles() error {
 		runID++
 	}
 
+	// Restart sidecar after config files are written but before starting processes.
+	// The sidecar exec's itself and re-reads all config from disk on startup.
+	// The sleep gives it time to bind the socket listener before ptp4l starts.
+	if err := sendSidecarRestart(); err != nil {
+		glog.Warningf("sendSidecarRestart failed (sidecar may not be running): %v", err)
+	}
+	time.Sleep(1 * time.Second)
+
 	glog.Infof("All profiles applied, starting %d processes", len(dn.processManager.process))
 	// Start all the process
 	for _, p := range dn.processManager.process {
@@ -790,7 +801,7 @@ func (dn *Daemon) applyNodePTPProfiles() error {
 	dn.pluginManager.PopulateHwConfig(dn.hwconfigs)
 	*dn.refreshNodePtpDevice = true
 	dn.readyTracker.setConfig(true)
-	return sendSidecarRestart()
+	return nil
 }
 
 func reconcileRelatedProfiles(profiles []ptpv1.PtpProfile) map[string]int {


### PR DESCRIPTION
## Summary

- Move `sendSidecarRestart()` from the end of `applyNodePTPProfiles()` to right after `stopAllProcesses()`, before config files are written and processes start.
- Add a 1-second sleep after sending CMD RESTART to allow the sidecar to exec and rebind its socket listener.
- This ensures the sidecar is ready to receive all port-state and clock-sync events from ptp4l's first log line.

## Root Cause

PR #155 (`70f8cd2c`) placed `sendSidecarRestart()` at the end of `applyNodePTPProfiles()`, after ptp4l is already running. This creates a race condition where ptp4l can emit port-state transitions (`FAULTY -> SLAVE`) while the sidecar is mid-restart. The sidecar misses these events, leaving `masterOffsetIface` empty and `openshift_ptp_clock_state` stuck at `FREERUN`.

This regresses the fix from PR #29 (OCPBUGS-54967) which correctly delays profile loading until the sidecar connection is ready.

## Fix

The fix reorders operations in `applyNodePTPProfiles()`:

**Before (broken):**
```
stopAllProcesses() → write configs → start ptp4l → sendSidecarRestart()
```

**After (fixed):**
```
stopAllProcesses() → sendSidecarRestart() → sleep(1s) → write configs → start ptp4l
```

The sidecar's `syscall.Exec` and socket rebind completes well within 1 second since the binary is already in memory and no container restart is involved.

Fixes: https://issues.redhat.com/browse/OCPBUGS-85092