### PR TITLE
ci: use ptp-operator main branch in netdevsim CI

### DIFF
--- a/.github/workflows/netdevsim-ci.yml
+++ b/.github/workflows/netdevsim-ci.yml
@@ -17,7 +17,7 @@ env:
   DKMS_REPO: https://github.com/redhat-cne/netdevsim-dkms.git
   DKMS_BRANCH: main
   PTP_REPO: https://github.com/edcdavid/ptp-operator-upstream.git
-  PTP_BRANCH: netdevsim-dkms
+  PTP_BRANCH: main
 
 jobs:
   # ------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Switch `PTP_BRANCH` from `netdevsim-dkms` to `main` in the netdevsim CI workflow
- Ensures CI picks up the serialized image build fix and stays in sync with upstream ptp-operator

## Test plan
- [ ] Verify netdevsim CI triggers and clones the correct ptp-operator branch
- [ ] Confirm image build completes without podman crashes