### PR TITLE
fix: scope DPLL pin control to configured NICs in clock chain

### DIFF
--- a/addons/intel/clock-chain.go
+++ b/addons/intel/clock-chain.go
@@ -245,12 +245,17 @@ func (c *ClockChain) SetPinsControl(pins []PinControl) ([]dpll.PinParentDeviceCt
 // Returns nil when no clock IDs have been resolved yet (leading NIC is zero
 // and no other NICs), which tells the caller to skip filtering.
 func (c *ClockChain) configuredClockIDs() map[uint64]bool {
-	if c.LeadingNIC.DpllClockID == 0 && len(c.OtherNICs) == 0 {
-		return nil
+	ids := make(map[uint64]bool)
+	if c.LeadingNIC.DpllClockID != 0 {
+		ids[c.LeadingNIC.DpllClockID] = true
 	}
-	ids := map[uint64]bool{c.LeadingNIC.DpllClockID: true}
 	for _, nic := range c.OtherNICs {
-		ids[nic.DpllClockID] = true
+		if nic.DpllClockID != 0 {
+			ids[nic.DpllClockID] = true
+		}
+	}
+	if len(ids) == 0 {
+		return nil
 	}
 	return ids
 }

--- a/addons/intel/clock-chain.go
+++ b/addons/intel/clock-chain.go
@@ -241,11 +241,27 @@ func (c *ClockChain) SetPinsControl(pins []PinControl) ([]dpll.PinParentDeviceCt
 	return pinCommands, nil
 }
 
-// SetPinsControlForAllNICs sets pins across all NICs (leading + other NICs)
-// This is used specifically for initialization functions like SetPinDefaults
+// configuredClockIDs returns the DPLL clock IDs of all NICs in this clock chain.
+// Returns nil when no clock IDs have been resolved yet (leading NIC is zero
+// and no other NICs), which tells the caller to skip filtering.
+func (c *ClockChain) configuredClockIDs() map[uint64]bool {
+	if c.LeadingNIC.DpllClockID == 0 && len(c.OtherNICs) == 0 {
+		return nil
+	}
+	ids := map[uint64]bool{c.LeadingNIC.DpllClockID: true}
+	for _, nic := range c.OtherNICs {
+		ids[nic.DpllClockID] = true
+	}
+	return ids
+}
+
+// SetPinsControlForAllNICs sets pins across all NICs in the clock chain
+// (leading + other configured NICs). Pins belonging to NICs not in the
+// clock chain are left untouched.
 func (c *ClockChain) SetPinsControlForAllNICs(pins []PinControl) ([]dpll.PinParentDeviceCtl, error) {
 	pinCommands := []dpll.PinParentDeviceCtl{}
 	errs := make([]error, 0)
+	configuredIDs := c.configuredClockIDs()
 
 	for _, pinCtl := range pins {
 		foundPins := c.DpllPins.GetAllPinsByLabel(pinCtl.Label)
@@ -258,6 +274,10 @@ func (c *ClockChain) SetPinsControlForAllNICs(pins []PinControl) ([]dpll.PinPare
 			continue
 		}
 		for _, pin := range foundPins {
+			if configuredIDs != nil && !configuredIDs[pin.ClockID] {
+				glog.Infof("skipping pin %s (clockID %d) — not in clock chain", pin.BoardLabel, pin.ClockID)
+				continue
+			}
 			pinCommands = append(pinCommands, SetPinControlData(*pin, pinCtl.ParentControl)...)
 		}
 	}

--- a/addons/intel/clock-chain_test.go
+++ b/addons/intel/clock-chain_test.go
@@ -234,7 +234,7 @@ func Test_SetPinsControlForAllNICs_SkipsUnconfiguredNICs(t *testing.T) {
 	defer restorePinSet()
 
 	cc := &ClockChain{
-		LeadingNIC: CardInfo{Name: "ens4f0", DpllClockID: configuredClockID},
+		LeadingNIC: CardInfo{Name: "test-nic", DpllClockID: configuredClockID},
 		OtherNICs:  []CardInfo{},
 		DpllPins:   DpllPins,
 	}

--- a/addons/intel/clock-chain_test.go
+++ b/addons/intel/clock-chain_test.go
@@ -210,3 +210,52 @@ func Test_SetPinDefaults_AllNICs(t *testing.T) {
 		assert.True(t, pinLabelsSeen[expectedPin], "should have command for pin %s", expectedPin)
 	}
 }
+
+func Test_SetPinsControlForAllNICs_SkipsUnconfiguredNICs(t *testing.T) {
+	unconfiguredClockID := uint64(9999999999999999999)
+	configuredClockID := uint64(5799633565432596414)
+
+	mockPins, restoreDPLLPins := setupMockDPLLPins(
+		&dpll.PinInfo{ID: 1, ClockID: configuredClockID, BoardLabel: "GNSS-1PPS",
+			ParentDevice: []dpll.PinParentDevice{
+				{ParentID: 1, Direction: dpll.PinDirectionInput},
+				{ParentID: 2, Direction: dpll.PinDirectionInput},
+			}},
+		&dpll.PinInfo{ID: 2, ClockID: unconfiguredClockID, BoardLabel: "GNSS-1PPS",
+			ParentDevice: []dpll.PinParentDevice{
+				{ParentID: 3, Direction: dpll.PinDirectionInput},
+				{ParentID: 4, Direction: dpll.PinDirectionInput},
+			}},
+	)
+	defer restoreDPLLPins()
+	_ = mockPins
+
+	mockPinSet, restorePinSet := setupBatchPinSetMock()
+	defer restorePinSet()
+
+	cc := &ClockChain{
+		LeadingNIC: CardInfo{Name: "ens4f0", DpllClockID: configuredClockID},
+		OtherNICs:  []CardInfo{},
+		DpllPins:   DpllPins,
+	}
+
+	commands, err := cc.SetPinsControlForAllNICs([]PinControl{
+		{
+			Label: "GNSS-1PPS",
+			ParentControl: PinParentControl{
+				EecPriority: PriorityDisabled,
+				PpsPriority: PriorityDisabled,
+			},
+		},
+	})
+	assert.NoError(t, err)
+	err = BatchPinSet(commands)
+	assert.NoError(t, err)
+
+	// Only the configured NIC's pin should produce commands
+	for _, cmd := range mockPinSet.commands {
+		assert.NotEqual(t, uint32(2), cmd.ID,
+			"pin ID 2 belongs to unconfigured NIC and should not have commands")
+	}
+	assert.Greater(t, len(mockPinSet.commands), 0, "should have commands for the configured NIC")
+}


### PR DESCRIPTION
## Summary 
SetPinsControlForAllNICs was applying pin commands to every NIC discovered via netlink, regardless of whether the NIC belonged to the clock chain. This caused T-BC initialization (InitPinsTBC) to disable GNSS-1PPS on NICs managed by other PtpConfig profiles (e.g. a T-GM running on a different NIC on the same node).

1. Filter pins by the clock IDs of the leading and other configured NICs so each profile only touches its own hardware. 
2. Fall back to unfiltered behavior when clock IDs have not been resolved yet.