### PR TITLE
Raise replay-fix log verbosity above production threshold

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -367,7 +367,7 @@ func (l *liveGate) Reset() {
 	l.once = sync.OnceFunc(func() {
 		close(l.c)
 	})
-	glog.Info("liveGate: reset (blocked)")
+	glog.V(14).Info("liveGate: reset (blocked)")
 }
 
 // Open unblocks all ptp4l process connections waiting on the gate.
@@ -394,7 +394,7 @@ func (l *liveGate) Wait(timeout time.Duration) {
 	}
 	select {
 	case <-l.c:
-		glog.V(4).Info("waitForLiveGate: gate opened, proceeding")
+		glog.V(14).Info("waitForLiveGate: gate opened, proceeding")
 	case <-time.After(timeout):
 		glog.Warning("liveGate: timeout after 60s, proceeding without replay guarantee")
 	}
@@ -1420,11 +1420,11 @@ func processStatus(c net.Conn, processName, messageTag string, status int64) {
 	// ptp4l[5196819.100]: [ptp4l.0.config] PTP_PROCESS_STOPPED:0/1
 
 	if c == nil {
-		glog.V(4).Infof("processStatus: process=%s config=%s status=%d via=prometheus", processName, cfgName, status)
+		glog.V(14).Infof("processStatus: process=%s config=%s status=%d via=prometheus", processName, cfgName, status)
 		UpdateProcessStatusMetrics(processName, cfgName, status)
 		return
 	}
-	glog.V(4).Infof("processStatus: process=%s config=%s status=%d via=socket", processName, cfgName, status)
+	glog.V(14).Infof("processStatus: process=%s config=%s status=%d via=socket", processName, cfgName, status)
 	logProcessStatus(processName, cfgName, status, c)
 }
 
@@ -1650,27 +1650,27 @@ func (p *ptpProcess) runScanner(cmdReader io.Reader, lineCh chan<- string, pm *p
 func (p *ptpProcess) runSocketWriter(lineCh <-chan string, doneCh chan<- struct{}) {
 	var err error
 connect:
-	glog.V(4).Infof("socket-writer[%s]: attempting dial to event socket", p.name)
+	glog.V(14).Infof("socket-writer[%s]: attempting dial to event socket", p.name)
 	select {
 	case <-p.exitCh:
-		glog.V(4).Infof("socket-writer[%s]: exitCh during dial, returning", p.name)
+		glog.V(14).Infof("socket-writer[%s]: exitCh during dial, returning", p.name)
 		doneCh <- struct{}{}
 		return
 	default:
 		p.c, err = dialSocket()
 		if err != nil {
-			glog.V(4).Infof("socket-writer[%s]: dial failed: %v, retrying", p.name, err)
+			glog.V(14).Infof("socket-writer[%s]: dial failed: %v, retrying", p.name, err)
 			goto connect
 		}
 	}
-	glog.V(4).Infof("socket-writer[%s]: dial succeeded, waiting for liveGate", p.name)
+	glog.V(14).Infof("socket-writer[%s]: dial succeeded, waiting for liveGate", p.name)
 	p.dn.liveGate.Wait(liveGateTimeout)
-	glog.V(4).Infof("socket-writer[%s]: liveGate passed, sending LIVE_START", p.name)
+	glog.V(14).Infof("socket-writer[%s]: liveGate passed, sending LIVE_START", p.name)
 	if _, err2 := fmt.Fprintf(p.c, "%s\n", liveStartCommand); err2 != nil {
 		glog.Errorf("failed to write LIVE_START marker: %v", err2)
 		goto connect
 	}
-	glog.V(4).Infof("socket-writer[%s]: LIVE_START sent, draining stale buffer", p.name)
+	glog.V(14).Infof("socket-writer[%s]: LIVE_START sent, draining stale buffer", p.name)
 	{
 		drained := 0
 	drainLoop:
@@ -1678,7 +1678,7 @@ connect:
 			select {
 			case _, ok := <-lineCh:
 				if !ok {
-					glog.V(4).Infof("socket-writer[%s]: lineCh closed during drain", p.name)
+					glog.V(14).Infof("socket-writer[%s]: lineCh closed during drain", p.name)
 					doneCh <- struct{}{}
 					return
 				}
@@ -1687,7 +1687,7 @@ connect:
 				break drainLoop
 			}
 		}
-		glog.V(4).Infof("socket-writer[%s]: drained %d stale lines, sending processStatus UP", p.name, drained)
+		glog.V(14).Infof("socket-writer[%s]: drained %d stale lines, sending processStatus UP", p.name, drained)
 	}
 
 	processStatus(p.c, p.name, p.messageTag, PtpProcessUp)
@@ -1696,7 +1696,7 @@ connect:
 			d.ProcessStatus(p.c, PtpProcessUp)
 		}
 	}
-	glog.V(4).Infof("socket-writer[%s]: starting line forwarding loop", p.name)
+	glog.V(14).Infof("socket-writer[%s]: starting line forwarding loop", p.name)
 
 	for output := range lineCh {
 		if p.name == phc2sysProcessName && len(p.haProfile) > 0 {
@@ -1705,11 +1705,11 @@ connect:
 		line := removeMessageSuffix(output) + "\n"
 		_, err2 := p.c.Write([]byte(line))
 		if err2 != nil {
-			glog.V(4).Infof("socket-writer[%s]: write error: %v, reconnecting. line=%s", p.name, err2, output)
+			glog.Errorf("socket-writer[%s]: write error: %v, reconnecting. line=%s", p.name, err2, output)
 			goto connect
 		}
 	}
-	glog.V(4).Infof("socket-writer[%s]: lineCh closed, forwarding done", p.name)
+	glog.V(14).Infof("socket-writer[%s]: lineCh closed, forwarding done", p.name)
 	doneCh <- struct{}{}
 }
 
@@ -1777,10 +1777,10 @@ func (p *ptpProcess) cmdRun(stdoutToSocket bool, pm *plugin.PluginManager) {
 				glog.Errorf("CmdRun() error waiting for %s: %v", p.name, err)
 			}
 			if stdoutToSocket && p.c != nil {
-				glog.V(4).Infof("cmdRun[%s]: process ended, sending DOWN via socket", p.name)
+				glog.V(14).Infof("cmdRun[%s]: process ended, sending DOWN via socket", p.name)
 				processStatus(p.c, p.name, p.messageTag, PtpProcessDown)
 			} else {
-				glog.V(4).Infof("cmdRun[%s]: process ended, sending DOWN via prometheus", p.name)
+				glog.V(14).Infof("cmdRun[%s]: process ended, sending DOWN via prometheus", p.name)
 				processStatus(nil, p.name, p.messageTag, PtpProcessDown)
 			}
 			p.updateGMStatusOnProcessDown(p.name)
@@ -1799,7 +1799,7 @@ func (p *ptpProcess) cmdRun(stdoutToSocket bool, pm *plugin.PluginManager) {
 			cmd = newCmd
 		}
 		if stdoutToSocket && p.c != nil {
-			glog.V(4).Infof("cmdRun[%s]: closing old socket connection before restart", p.name)
+			glog.V(14).Infof("cmdRun[%s]: closing old socket connection before restart", p.name)
 			if err2 := p.c.Close(); err2 != nil {
 				glog.Errorf("closing connection returned error %s", err2)
 			}

--- a/pkg/daemon/metrics.go
+++ b/pkg/daemon/metrics.go
@@ -263,7 +263,7 @@ func updatePTPMetrics(from, process, iface string, ptpOffset, maxPtpOffset, freq
 
 // extractMetrics ...
 func extractMetrics(messageTag string, processName string, ifaces config.IFaces, output string, updateMetrics bool) (configName, source string, offset float64, state string, iface string) {
-	glog.V(4).Infof("DEBUG extractMetrics: process=%s updateMetrics=%v tag=%s", processName, updateMetrics, messageTag)
+	glog.V(14).Infof("DEBUG extractMetrics: process=%s updateMetrics=%v tag=%s", processName, updateMetrics, messageTag)
 	configName = strings.Replace(strings.Replace(messageTag, "]", "", 1), "[", "", 1)
 	if configName != "" {
 		configName = strings.Split(configName, MessageTagSuffixSeperator)[0] // remove any suffix added to the configName
@@ -528,7 +528,7 @@ func updateClockStateMetrics(process, iface string, state string) {
 	if !utils.CheckMetricSanity("ClockState", process, iface) {
 		return
 	}
-	glog.V(4).Infof("updateClockStateMetrics: process=%s iface=%s state=%s", process, iface, state)
+	glog.V(14).Infof("updateClockStateMetrics: process=%s iface=%s state=%s", process, iface, state)
 	if state == LOCKED {
 		ClockState.With(prometheus.Labels{
 			"process": process, "node": NodeName, "iface": iface}).Set(1)

--- a/pkg/daemon/ready.go
+++ b/pkg/daemon/ready.go
@@ -83,9 +83,9 @@ type metricHandler struct {
 }
 
 func (h metricHandler) ServeHTTP(w http.ResponseWriter, _ *http.Request) {
-	glog.V(4).Info("/emit-logs: handler invoked")
+	glog.V(14).Info("/emit-logs: handler invoked")
 	if isReady, _ := h.tracker.Ready(); !isReady {
-		glog.V(4).Info("/emit-logs: not ready, opening gate early and returning 204")
+		glog.V(14).Info("/emit-logs: not ready, opening gate early and returning 204")
 		w.WriteHeader(http.StatusNoContent)
 		// Open the gate even when not ready: processes need to start writing
 		// to collect metrics and become ready. No stale state exists yet, so
@@ -99,11 +99,11 @@ func (h metricHandler) ServeHTTP(w http.ResponseWriter, _ *http.Request) {
 
 	// Emit replay data synchronously so the live gate is only opened after
 	// all replay state has been written to the socket.
-	glog.V(4).Info("/emit-logs: starting synchronous replay (EmitClockSyncLogs + EmitPortRoleLogs)")
+	glog.V(14).Info("/emit-logs: starting synchronous replay (EmitClockSyncLogs + EmitPortRoleLogs)")
 	eventHandler := h.tracker.processManager.ptpEventHandler
 	eventHandler.EmitClockSyncLogs()
 	eventHandler.EmitPortRoleLogs()
-	glog.V(4).Info("/emit-logs: synchronous replay complete, opening liveGate")
+	glog.V(14).Info("/emit-logs: synchronous replay complete, opening liveGate")
 
 	// Open the live gate: ptp4l processes may now write to the socket.
 	if dn := h.tracker.processManager.daemon; dn != nil {
@@ -111,7 +111,7 @@ func (h metricHandler) ServeHTTP(w http.ResponseWriter, _ *http.Request) {
 	}
 
 	// Non-critical emits can remain async.
-	glog.V(4).Info("/emit-logs: firing async emits (ProcessStatusLogs, ClockClassLogs)")
+	glog.V(14).Info("/emit-logs: firing async emits (ProcessStatusLogs, ClockClassLogs)")
 	processManager := h.tracker.processManager
 	go processManager.EmitProcessStatusLogs()
 	go processManager.EmitClockClassLogs()


### PR DESCRIPTION
The live gate and socket-writer logs introduced by the replay-fix (PR #216)
use glog.V(4), which fires at the production pod setting of -v=10. This
creates excessive log noise in normal operation.

Raise all new replay-fix debug logs from V(4) to V(14) so they remain silent
at production verbosity but are still available for troubleshooting with
-v=14 or higher.

Pre-existing logs that were inadvertently downgraded during the refactoring
(socket write errors) are restored to their original Error level.