### PR TITLE
Track active TR port during dual-upstream T-BC switchover for correct event reporting

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -1589,6 +1589,11 @@ func (p *ptpProcess) processTBCTransitionLegacy(output string, pm *plugin.Plugin
 	}
 	if portMatched {
 		if strings.Contains(output, "to SLAVE on MASTER_CLOCK_SELECTED") {
+			portName := parser.ExtractPortName(output)
+			if portName != "" {
+				p.tBCAttributes.activePort = portName
+				glog.Infof("T-BC active upstream port: %s", portName)
+			}
 			p.tBCAttributes.lastReportedState = event.PTP_LOCKED
 			p.tBCAttributes.offsetFilter = utils.NewWindow(offsetFilterSize)
 		} else if strings.Contains(output, "to MASTER on ANNOUNCE_RECEIPT_TIMEOUT_EXPIRES") ||

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -1591,8 +1591,12 @@ func (p *ptpProcess) processTBCTransitionLegacy(output string, pm *plugin.Plugin
 		if strings.Contains(output, "to SLAVE on MASTER_CLOCK_SELECTED") {
 			portName := parser.ExtractPortName(output)
 			if portName != "" {
-				p.tBCAttributes.activePort = portName
-				glog.Infof("T-BC active upstream port: %s", portName)
+				if len(p.tBCAttributes.trIfaceNames) > 1 && !slices.Contains(p.tBCAttributes.trIfaceNames, portName) {
+					glog.Warningf("Ignoring non-TR port in legacy MASTER_CLOCK_SELECTED event: %s", portName)
+				} else {
+					p.tBCAttributes.activePort = portName
+					glog.Infof("T-BC active upstream port: %s", portName)
+				}
 			}
 			p.tBCAttributes.lastReportedState = event.PTP_LOCKED
 			p.tBCAttributes.offsetFilter = utils.NewWindow(offsetFilterSize)

--- a/pkg/daemon/daemon_internal_test.go
+++ b/pkg/daemon/daemon_internal_test.go
@@ -1819,6 +1819,41 @@ func TestTBCLegacy_ActiveTRPort_ReportsCorrectInterface(t *testing.T) {
 		"activeTRPort should reflect the newly selected backup port")
 }
 
+func TestTBCLegacy_ActivePort_IgnoresNonTRPort(t *testing.T) {
+	pmStruct, _ := registerPlugins([]string{})
+	pm := &pmStruct
+
+	oldValue := vTbcHasHardwareConfig
+	vTbcHasHardwareConfig = false
+	defer func() { vTbcHasHardwareConfig = oldValue }()
+
+	process := &ptpProcess{
+		tBCAttributes: tBCProcessAttributes{
+			trIfaceNames:      []string{testDUTUpstream1, testDUTUpstream2},
+			perPortState:      map[string]event.PTPState{testDUTUpstream1: event.PTP_LOCKED, testDUTUpstream2: event.PTP_NOTSET},
+			activePort:        testDUTUpstream1,
+			trPortsConfigFile: "test-config",
+			lastReportedState: event.PTP_LOCKED,
+			lastAppliedState:  event.PTP_LOCKED,
+			offsetThreshold:   10.0,
+		},
+		nodeProfile: ptpv1.PtpProfile{
+			Name:        stringPointer("test-profile"),
+			PtpSettings: map[string]string{"leadingInterface": testDUTLeadingIface, testDUTClockIDKey: "123456789"},
+		},
+		eventCh:    make(chan event.Event, 10),
+		configName: "test-config",
+		clockType:  event.BC,
+	}
+
+	// A port with a prefix-colliding name (ens2f10 vs tracked ens2f1) fires MASTER_CLOCK_SELECTED.
+	// The log line contains "ens2f1" as a substring so portMatched is true, but
+	// ExtractPortName returns "ens2f10" which is NOT in trIfaceNames.
+	process.tBCTransitionCheck("ptp4l[300]: [test-config.0.config] port 3 (ens2f10): UNCALIBRATED to SLAVE on MASTER_CLOCK_SELECTED", pm)
+	assert.Equal(t, testDUTUpstream1, process.tBCAttributes.activePort,
+		"activePort must not change to a non-TR port with a prefix-colliding name")
+}
+
 // TestPtp4lConf_PopulatePtp4lConf_ClockTypeWithCliArgs tests clock_type detection with cliArgs parameter
 func TestPtp4lConf_PopulatePtp4lConf_ClockTypeWithCliArgs(t *testing.T) {
 	tests := []struct {

--- a/pkg/daemon/daemon_internal_test.go
+++ b/pkg/daemon/daemon_internal_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/event"
 	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/hardwareconfig"
 	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/leap"
+	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/utils"
 	ptpv1 "github.com/k8snetworkplumbingwg/ptp-operator/api/v1"
 	ptpv2alpha1 "github.com/k8snetworkplumbingwg/ptp-operator/api/v2alpha1"
 	"github.com/stretchr/testify/assert"
@@ -32,6 +33,13 @@ import (
 )
 
 const testPtp4lOffsetLine = "ptp4l[1.000]: [ptp4l.0.config] master offset 5 s2 freq -1000 path delay 100"
+
+const (
+	testDUTLeadingIface = "ens2f0"
+	testDUTUpstream1    = "ens2f1"
+	testDUTUpstream2    = "ens2f3"
+	testDUTClockIDKey   = "clockId[ens2f0]"
+)
 
 // vendor defaults are embedded; no filesystem setup needed
 
@@ -1651,6 +1659,164 @@ func TestTBCDualUpstream_ActiveTRPort_Helper(t *testing.T) {
 		attrs := &tBCProcessAttributes{}
 		assert.Equal(t, "", attrs.activeTRPort())
 	})
+}
+
+func TestTBCLegacy_Switchover_ActivePortUpdated(t *testing.T) {
+	pmStruct, _ := registerPlugins([]string{})
+	pm := &pmStruct
+
+	oldValue := vTbcHasHardwareConfig
+	vTbcHasHardwareConfig = false
+	defer func() { vTbcHasHardwareConfig = oldValue }()
+
+	process := &ptpProcess{
+		tBCAttributes: tBCProcessAttributes{
+			trIfaceNames:      []string{testDUTUpstream1, testDUTUpstream2},
+			perPortState:      map[string]event.PTPState{testDUTUpstream1: event.PTP_LOCKED, testDUTUpstream2: event.PTP_NOTSET},
+			activePort:        testDUTUpstream1,
+			trPortsConfigFile: "test-config",
+			lastReportedState: event.PTP_LOCKED,
+			lastAppliedState:  event.PTP_LOCKED,
+			offsetThreshold:   10.0,
+		},
+		nodeProfile: ptpv1.PtpProfile{
+			Name:        stringPointer("test-profile"),
+			PtpSettings: map[string]string{"leadingInterface": testDUTLeadingIface, testDUTClockIDKey: "123456789"},
+		},
+		eventCh:    make(chan event.Event, 10),
+		configName: "test-config",
+		clockType:  event.BC,
+		offset:     5.0,
+	}
+
+	// ens2f1 goes down — enters holdover
+	process.tBCTransitionCheck("ptp4l[100]: [test-config.0.config] port 1 ("+testDUTUpstream1+"): SLAVE to FAULTY on FAULT_DETECTED (FT_UNSPECIFIED)", pm)
+	assert.Equal(t, event.PTP_FREERUN, process.tBCAttributes.lastReportedState)
+	assert.Equal(t, event.PTP_HOLDOVER, process.tBCAttributes.lastAppliedState)
+
+	// ens2f3 takes over as SLAVE — activePort should update
+	process.tBCTransitionCheck("ptp4l[200]: [test-config.0.config] port 2 ("+testDUTUpstream2+"): UNCALIBRATED to SLAVE on MASTER_CLOCK_SELECTED", pm)
+	assert.Equal(t, event.PTP_LOCKED, process.tBCAttributes.lastReportedState)
+	assert.Equal(t, testDUTUpstream2, process.tBCAttributes.activePort,
+		"activePort should update to backup port after switchover")
+	assert.NotNil(t, process.tBCAttributes.offsetFilter)
+}
+
+func TestTBCLegacy_AllPortsLost_EntersHoldover(t *testing.T) {
+	pmStruct, _ := registerPlugins([]string{})
+	pm := &pmStruct
+
+	oldValue := vTbcHasHardwareConfig
+	vTbcHasHardwareConfig = false
+	defer func() { vTbcHasHardwareConfig = oldValue }()
+
+	process := &ptpProcess{
+		tBCAttributes: tBCProcessAttributes{
+			trIfaceNames:      []string{testDUTUpstream1, testDUTUpstream2},
+			perPortState:      map[string]event.PTPState{testDUTUpstream1: event.PTP_LOCKED, testDUTUpstream2: event.PTP_NOTSET},
+			activePort:        testDUTUpstream1,
+			trPortsConfigFile: "test-config",
+			lastReportedState: event.PTP_LOCKED,
+			lastAppliedState:  event.PTP_LOCKED,
+			offsetThreshold:   10.0,
+		},
+		nodeProfile: ptpv1.PtpProfile{
+			Name:        stringPointer("test-profile"),
+			PtpSettings: map[string]string{"leadingInterface": testDUTLeadingIface, testDUTClockIDKey: "123456789"},
+		},
+		eventCh:    make(chan event.Event, 10),
+		configName: "test-config",
+		clockType:  event.BC,
+	}
+
+	// Active port loses SLAVE via ANNOUNCE timeout — enters holdover
+	process.tBCTransitionCheck("ptp4l[100]: [test-config.0.config] port 1 ("+testDUTUpstream1+"): SLAVE to MASTER on ANNOUNCE_RECEIPT_TIMEOUT_EXPIRES", pm)
+	assert.Equal(t, event.PTP_FREERUN, process.tBCAttributes.lastReportedState)
+	assert.Equal(t, event.PTP_HOLDOVER, process.tBCAttributes.lastAppliedState)
+	assert.Nil(t, process.tBCAttributes.offsetFilter)
+}
+
+func TestTBCLegacy_RecoveryFromHoldover(t *testing.T) {
+	pmStruct, _ := registerPlugins([]string{})
+	pm := &pmStruct
+
+	oldValue := vTbcHasHardwareConfig
+	vTbcHasHardwareConfig = false
+	defer func() { vTbcHasHardwareConfig = oldValue }()
+
+	process := &ptpProcess{
+		tBCAttributes: tBCProcessAttributes{
+			trIfaceNames:      []string{testDUTUpstream1, testDUTUpstream2},
+			perPortState:      map[string]event.PTPState{testDUTUpstream1: event.PTP_FREERUN, testDUTUpstream2: event.PTP_NOTSET},
+			trPortsConfigFile: "test-config",
+			lastReportedState: event.PTP_FREERUN,
+			lastAppliedState:  event.PTP_HOLDOVER,
+			offsetThreshold:   10.0,
+		},
+		nodeProfile: ptpv1.PtpProfile{
+			Name:        stringPointer("test-profile"),
+			PtpSettings: map[string]string{"leadingInterface": testDUTLeadingIface, testDUTClockIDKey: "123456789"},
+		},
+		eventCh:    make(chan event.Event, 10),
+		configName: "test-config",
+		clockType:  event.BC,
+		offset:     5.0,
+	}
+
+	// Backup port becomes SLAVE — starts recovery
+	process.tBCTransitionCheck("ptp4l[200]: [test-config.0.config] port 2 ("+testDUTUpstream2+"): UNCALIBRATED to SLAVE on MASTER_CLOCK_SELECTED", pm)
+	assert.Equal(t, event.PTP_LOCKED, process.tBCAttributes.lastReportedState)
+	assert.Equal(t, testDUTUpstream2, process.tBCAttributes.activePort)
+	assert.NotNil(t, process.tBCAttributes.offsetFilter)
+	assert.Equal(t, event.PTP_HOLDOVER, process.tBCAttributes.lastAppliedState,
+		"should remain in holdover until offset filter converges")
+
+	// Fill offset filter (64 samples) to complete recovery
+	for i := 0; i < 64; i++ {
+		process.tBCTransitionCheck("ptp4l[300]: [test-config.0.config] master offset 5 s2 freq 0 path delay 100", pm)
+	}
+	assert.Equal(t, event.PTP_LOCKED, process.tBCAttributes.lastAppliedState,
+		"should exit holdover after offset filter converges")
+}
+
+func TestTBCLegacy_ActiveTRPort_ReportsCorrectInterface(t *testing.T) {
+	pmStruct, _ := registerPlugins([]string{})
+	pm := &pmStruct
+
+	oldValue := vTbcHasHardwareConfig
+	vTbcHasHardwareConfig = false
+	defer func() { vTbcHasHardwareConfig = oldValue }()
+
+	process := &ptpProcess{
+		tBCAttributes: tBCProcessAttributes{
+			trIfaceNames:      []string{testDUTUpstream1, testDUTUpstream2},
+			perPortState:      map[string]event.PTPState{testDUTUpstream1: event.PTP_NOTSET, testDUTUpstream2: event.PTP_NOTSET},
+			trPortsConfigFile: "test-config",
+			lastAppliedState:  event.PTP_NOTSET,
+			offsetThreshold:   10.0,
+			offsetEventWindow: utils.NewWindow(16),
+		},
+		nodeProfile: ptpv1.PtpProfile{
+			Name:        stringPointer("test-profile"),
+			PtpSettings: map[string]string{"leadingInterface": testDUTLeadingIface, testDUTClockIDKey: "123456789"},
+		},
+		eventCh:    make(chan event.Event, 10),
+		configName: "test-config",
+		clockType:  event.BC,
+		offset:     3.0,
+	}
+
+	// Initially activePort is empty — activeTRPort() returns trIfaceNames[0]
+	assert.Equal(t, testDUTUpstream1, process.tBCAttributes.activeTRPort())
+
+	// testDUTUpstream1 becomes SLAVE
+	process.tBCTransitionCheck("ptp4l[100]: [test-config.0.config] port 1 ("+testDUTUpstream1+"): UNCALIBRATED to SLAVE on MASTER_CLOCK_SELECTED", pm)
+	assert.Equal(t, testDUTUpstream1, process.tBCAttributes.activeTRPort())
+
+	// Switchover: testDUTUpstream2 becomes SLAVE
+	process.tBCTransitionCheck("ptp4l[200]: [test-config.0.config] port 2 ("+testDUTUpstream2+"): UNCALIBRATED to SLAVE on MASTER_CLOCK_SELECTED", pm)
+	assert.Equal(t, testDUTUpstream2, process.tBCAttributes.activeTRPort(),
+		"activeTRPort should reflect the newly selected backup port")
 }
 
 // TestPtp4lConf_PopulatePtp4lConf_ClockTypeWithCliArgs tests clock_type detection with cliArgs parameter


### PR DESCRIPTION
# Track active TR port on SLAVE selection for correct event/log reporting

## Summary

In T-BC deployments with two upstream (TR) ports, when the A-BMCA selects a backup port as SLAVE during switchover, the daemon continues reporting the original port in events and logs because `activePort` is never updated. This patch updates `activePort` on every `MASTER_CLOCK_SELECTED` transition so that `activeTRPort()` — used by both `sendPtp4lEvent()` and `sendPtp4lOffsetEvent()` — returns the correct active interface.
Jira Ticket: [CNF-25167](https://redhat.atlassian.net/browse/CNF-25167)

## Problem

When a T-BC profile has two TR-facing interfaces (dual-upstream for redundancy), the `processTBCTransitionLegacy` function never sets `activePort` when a port is selected as SLAVE. The `activeTRPort()` method falls back to `trIfaceNames[0]` (always the first configured port), so events and logs always report the main port — even after the system has switched over to the backup.

## Changes

### `daemon.go`

When ptp4l logs `"to SLAVE on MASTER_CLOCK_SELECTED"`, extract the port name and update `activePort`. This ensures `activeTRPort()` returns the correct interface for all downstream event and log paths.

### `daemon_internal_test.go`

Four new tests covering dual-upstream switchover scenarios:

- **Switchover with activePort update** — active port goes FAULTY, enters holdover, backup becomes SLAVE, verifies `activePort` updates to the backup interface
- **All ports lost enters holdover** — active port loses SLAVE via announce timeout, verifies holdover entry
- **Recovery from holdover** — starting from holdover, backup becomes SLAVE, offset filter fills and converges, verifies holdover exit to LOCKED
- **Correct interface reporting** — verifies `activeTRPort()` returns the correct port after initial selection and after switchover

## Testing

- Verified on cnfdg42 with dual-upstream T-BC configuration (ens2f1, ens2f3)
- Confirmed events and logs report the correct active interface after switchover
- Confirmed holdover entry on port loss and recovery via offset filter convergence
- All existing and new unit tests pass



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved legacy precision time protocol failover handling by more reliably detecting and updating the active upstream port from ptp-related output, including avoiding incorrect updates from non-relevant port name matches.

* **Tests**
  * Expanded legacy-mode test coverage for upstream switchover, failed switchover behavior, transition into holdover when all upstreams are lost, and the convergence requirements to recover from holdover, plus active port/interface reporting checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->