### PR TITLE
Fix gnss_status always -1 due to double-newline in poll line join

### DIFF
--- a/pkg/daemon/gpsd.go
+++ b/pkg/daemon/gpsd.go
@@ -1,11 +1,9 @@
 package daemon
 
 import (
-	"bufio"
 	"bytes"
 	"context"
 	"fmt"
-	"io"
 	"net"
 	"os"
 	"os/exec"
@@ -257,7 +255,7 @@ func (g *GPSD) MonitorGNSSEventsWithUblox() {
 					lines = append(lines, line)
 				}
 				if len(lines) > 0 {
-					g.processGNSSLines(strings.NewReader(strings.Join(lines, "\n")))
+					g.processGNSSLines(lines)
 				}
 			case <-g.monitorCtx.Done():
 				doneFn()
@@ -267,35 +265,30 @@ func (g *GPSD) MonitorGNSSEventsWithUblox() {
 	}
 }
 
-// processGNSSLines reads ubxtool-formatted lines from r, extracts
-// GNSS status and offset, determines the sync state, and emits an
-// event on the event channel and gnssNotifyCh.
-func (g *GPSD) processGNSSLines(r io.Reader) {
+// processGNSSLines parses ubxtool-formatted lines, extracts GNSS status and
+// offset, determines the sync state, and emits an event on the event channel.
+// Each element of lines is one ubxtool output line (trailing newline optional).
+func (g *GPSD) processGNSSLines(lines []string) {
 	const timeLsResultLines = 4
-	scanner := bufio.NewScanner(r)
 	nStatus := int64(0)
 	nOffset := int64(99999999)
 	var timeLs *ublox.TimeLs
 
-	for scanner.Scan() {
-		line := scanner.Text()
+	for i, line := range lines {
 		if strings.Contains(line, "UBX-NAV-CLOCK") {
-			if scanner.Scan() {
-				nOffset = ublox.ExtractOffset(scanner.Text())
+			if i+1 < len(lines) {
+				nOffset = ublox.ExtractOffset(lines[i+1])
 			}
 		} else if strings.Contains(line, "UBX-NAV-STATUS") {
-			if scanner.Scan() {
-				nStatus = ublox.ExtractNavStatus(scanner.Text())
+			if i+1 < len(lines) {
+				nStatus = ublox.ExtractNavStatus(lines[i+1])
 			}
 		} else if strings.Contains(line, "UBX-NAV-TIMELS") {
-			var lines []string
-			for i := 0; i < timeLsResultLines; i++ {
-				if !scanner.Scan() {
-					break
-				}
-				lines = append(lines, scanner.Text())
+			end := i + 1 + timeLsResultLines
+			if end > len(lines) {
+				end = len(lines)
 			}
-			timeLs = ublox.ExtractLeapSec(lines)
+			timeLs = ublox.ExtractLeapSec(lines[i+1 : end])
 		}
 	}
 

--- a/pkg/daemon/gpsd_test.go
+++ b/pkg/daemon/gpsd_test.go
@@ -3,13 +3,21 @@ package daemon
 import (
 	"context"
 	"os/exec"
-	"strings"
 	"testing"
 
 	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/config"
 	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/event"
+	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/leap"
+	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/ublox"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+)
+
+// Common ubxtool line fixtures reused across multiple test cases.
+const (
+	navStatusHeader = "UBX-NAV-STATUS:\n"
+	navStatus3DFix  = "  iTOW 437000 gpsFix 3 flags 0xdd fixStat 0 flags2 0x08\n"
+	navClockHeader  = "UBX-NAV-CLOCK:\n"
 )
 
 func TestResetSerialPort(t *testing.T) {
@@ -90,19 +98,36 @@ func TestResetSerialPortPassesCorrectArgs(t *testing.T) {
 func TestProcessGNSSLines(t *testing.T) {
 	tests := []struct {
 		name           string
-		input          string
+		lines          []string
 		maxOffset      int64
 		minOffset      int64
 		wantSourceLost bool
 		wantOffset     int64
 		wantGPSStatus  int64
+		wantTimeLs     *ublox.TimeLs // non-nil: assert TimeLs dispatched to leap manager
 	}{
 		{
 			name: "locked with good fix and offset in range",
-			input: "UBX-NAV-STATUS:\n" +
-				"  iTOW 437000 gpsFix 3 flags 0xdd fixStat 0 flags2 0x08\n" +
-				"UBX-NAV-CLOCK:\n" +
+			lines: []string{
+				navStatusHeader,
+				navStatus3DFix,
+				navClockHeader,
 				"  iTOW 437000 clkBias 42 clkDrift 0 tAcc 23 fAcc 0\n",
+			},
+			maxOffset:      100,
+			minOffset:      -100,
+			wantSourceLost: false,
+			wantOffset:     23,
+			wantGPSStatus:  3,
+		},
+		{
+			name: "lines without trailing newline are also handled",
+			lines: []string{
+				"UBX-NAV-STATUS:",
+				"  iTOW 437000 gpsFix 3 flags 0xdd fixStat 0 flags2 0x08",
+				"UBX-NAV-CLOCK:",
+				"  iTOW 437000 clkBias 42 clkDrift 0 tAcc 23 fAcc 0",
+			},
 			maxOffset:      100,
 			minOffset:      -100,
 			wantSourceLost: false,
@@ -111,10 +136,12 @@ func TestProcessGNSSLines(t *testing.T) {
 		},
 		{
 			name: "freerun with no fix",
-			input: "UBX-NAV-STATUS:\n" +
-				"  iTOW 437000 gpsFix 0 flags 0x00 fixStat 0 flags2 0x00\n" +
-				"UBX-NAV-CLOCK:\n" +
+			lines: []string{
+				navStatusHeader,
+				"  iTOW 437000 gpsFix 0 flags 0x00 fixStat 0 flags2 0x00\n",
+				navClockHeader,
 				"  iTOW 437000 clkBias 42 clkDrift 0 tAcc 50 fAcc 0\n",
+			},
 			maxOffset:      100,
 			minOffset:      -100,
 			wantSourceLost: true,
@@ -123,20 +150,74 @@ func TestProcessGNSSLines(t *testing.T) {
 		},
 		{
 			name: "freerun when offset out of range despite good fix",
-			input: "UBX-NAV-STATUS:\n" +
-				"  iTOW 437000 gpsFix 3 flags 0xdd fixStat 0 flags2 0x08\n" +
-				"UBX-NAV-CLOCK:\n" +
+			lines: []string{
+				navStatusHeader,
+				navStatus3DFix,
+				navClockHeader,
 				"  iTOW 437000 clkBias 42 clkDrift 0 tAcc 5000 fAcc 0\n",
+			},
 			maxOffset:      100,
 			minOffset:      -100,
 			wantSourceLost: true,
 			wantOffset:     5000,
 			wantGPSStatus:  3,
 		},
+		{
+			name: "TIMELS dispatched alongside normal fix",
+			lines: []string{
+				navStatusHeader,
+				navStatus3DFix,
+				navClockHeader,
+				"  iTOW 437000 clkBias 0 clkDrift 0 tAcc 23 fAcc 0\n",
+				"UBX-NAV-TIMELS:\n",
+				"  iTOW 376008000 version 0 reserved2 0 0 0 srcOfCurrLs 2\n",
+				"  currLs 18 srcOfLsChange 2 lsChange 0 timeToLsEvent 77643210\n",
+				"  dateOfLsGpsWn 2441 dateOfLsGpsDn 7 reserved2 0 0 0\n",
+				"  valid x3\n",
+			},
+			maxOffset:      100,
+			minOffset:      -100,
+			wantSourceLost: false,
+			wantOffset:     23,
+			wantGPSStatus:  3,
+			wantTimeLs: &ublox.TimeLs{
+				SrcOfCurrLs:   2,
+				CurrLs:        18,
+				SrcOfLsChange: 2,
+				TimeToLsEvent: 77643210,
+				DateOfLsGpsWn: 2441,
+				DateOfLsGpsDn: 7,
+				Valid:         3,
+			},
+		},
+		{
+			// Exercises the end > len(lines) bounds clamp: fewer than 4 data
+			// lines follow the TIMELS header. No NAV-CLOCK so offset stays at
+			// the default sentinel (99999999), which is out of range.
+			name: "truncated TIMELS does not panic",
+			lines: []string{
+				navStatusHeader,
+				navStatus3DFix,
+				"UBX-NAV-TIMELS:\n",
+				"  iTOW 376008000 version 0 reserved2 0 0 0 srcOfCurrLs 2\n",
+			},
+			maxOffset:      100,
+			minOffset:      -100,
+			wantSourceLost: true,
+			wantOffset:     99999999,
+			wantGPSStatus:  3,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			var leapCh chan ublox.TimeLs
+			if tt.wantTimeLs != nil {
+				leapCh = make(chan ublox.TimeLs, 1)
+				leap.LeapMgr = &leap.LeapManager{UbloxLsInd: leapCh}
+				defer func() { leap.LeapMgr = nil }()
+			}
+
 			eventCh := make(chan event.Event, 10)
 			g := &GPSD{
 				processConfig: config.ProcessConfig{
@@ -148,7 +229,7 @@ func TestProcessGNSSLines(t *testing.T) {
 				gmInterface: "ens2f0",
 			}
 
-			g.processGNSSLines(strings.NewReader(tt.input))
+			g.processGNSSLines(tt.lines)
 
 			assert.Equal(t, tt.wantSourceLost, g.sourceLost)
 			assert.Equal(t, tt.wantOffset, g.offset)
@@ -162,6 +243,15 @@ func TestProcessGNSSLines(t *testing.T) {
 			assert.Equal(t, tt.wantOffset, gnssData.Offset)
 			assert.Equal(t, tt.wantSourceLost, gnssData.SourceLost)
 			assert.Equal(t, "ens2f0", ev.IFace)
+
+			if tt.wantTimeLs != nil {
+				select {
+				case ts := <-leapCh:
+					assert.Equal(t, *tt.wantTimeLs, ts)
+				default:
+					t.Error("expected TimeLs to be sent to leap.LeapMgr.UbloxLsInd but channel was empty")
+				}
+			}
 		})
 	}
 }

--- a/pkg/ublox/ublox.go
+++ b/pkg/ublox/ublox.go
@@ -273,39 +273,40 @@ func (u *UBlox) UbloxPollStop() {
 	u.cmd.Wait()
 }
 
-// ExtractOffset extracts the tAcc offset from the incoming ubxtool data stream
-func ExtractOffset(output string) int64 {
-	// Find the line that contains "tAcc"
-	lines := strings.Split(output, "\n")
-	for _, line := range lines {
-		if strings.Contains(line, "tAcc") {
-			// Extract the offset value
-			fields := strings.Fields(line)
-			for i, field := range fields {
-				if field == "tAcc" {
-					ret, _ := strconv.ParseInt(fields[i+1], 10, 64)
-					return ret
+// ExtractOffset extracts the tAcc offset from a single ubxtool data line.
+func ExtractOffset(line string) int64 {
+	if strings.Contains(line, "tAcc") {
+		fields := strings.Fields(line)
+		for i, field := range fields {
+			if field == "tAcc" {
+				if i+1 >= len(fields) {
+					return -1
 				}
+				ret, err := strconv.ParseInt(fields[i+1], 10, 64)
+				if err != nil {
+					return -1
+				}
+				return ret
 			}
 		}
 	}
-
 	return -1
 }
 
-// ExtractNavStatus extracts the gpsFix state from the incoming ubxtool data stream
-func ExtractNavStatus(output string) int64 {
-	// Find the line that contains "gpsFix"
-	lines := strings.Split(output, "\n")
-	for _, line := range lines {
-		if strings.Contains(line, "gpsFix") {
-			// Extract the offset value
-			fields := strings.Fields(line)
-			for i, field := range fields {
-				if field == "gpsFix" {
-					ret, _ := strconv.ParseInt(fields[i+1], 10, 64)
-					return ret
+// ExtractNavStatus extracts the gpsFix state from a single ubxtool data line.
+func ExtractNavStatus(line string) int64 {
+	if strings.Contains(line, "gpsFix") {
+		fields := strings.Fields(line)
+		for i, field := range fields {
+			if field == "gpsFix" {
+				if i+1 >= len(fields) {
+					return -1
 				}
+				ret, err := strconv.ParseInt(fields[i+1], 10, 64)
+				if err != nil {
+					return -1
+				}
+				return ret
 			}
 		}
 	}

--- a/pkg/ublox/ublox_test.go
+++ b/pkg/ublox/ublox_test.go
@@ -92,6 +92,45 @@ func TestFindProtoVersion(t *testing.T) {
 
 }*/
 
+func TestExtractNavStatus(t *testing.T) {
+	tests := []struct {
+		name string
+		line string
+		want int64
+	}{
+		{"3D fix", "  iTOW 218573000 gpsFix 3 flags 0xdd fixStat 0x0 flags2 0x8", 3},
+		{"no fix", "  iTOW 218573000 gpsFix 0 flags 0x00 fixStat 0x0 flags2 0x0", 0},
+		{"field missing value (truncated line)", "  iTOW 218573000 gpsFix", -1},
+		{"non-numeric value", "  iTOW 218573000 gpsFix bad", -1},
+		{"field absent", "  iTOW 218573000 flags 0xdd", -1},
+		{"empty line", "", -1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, ublox.ExtractNavStatus(tt.line))
+		})
+	}
+}
+
+func TestExtractOffset(t *testing.T) {
+	tests := []struct {
+		name string
+		line string
+		want int64
+	}{
+		{"normal", "  iTOW 218573000 clkBias 0 clkDrift 0 tAcc 23 fAcc 0", 23},
+		{"field missing value (truncated line)", "  iTOW 218573000 tAcc", -1},
+		{"non-numeric value", "  iTOW 218573000 tAcc bad", -1},
+		{"field absent", "  iTOW 218573000 clkBias 0", -1},
+		{"empty line", "", -1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, ublox.ExtractOffset(tt.line))
+		})
+	}
+}
+
 func Test_ExtractLeapSec(t *testing.T) {
 	data := []string{
 		"iTOW 376008000 version 0 reserved2 0 0 0 srcOfCurrLs 2",


### PR DESCRIPTION
UbloxPollPushThread reads ubxtool output with `ReadString('\\n')`, so
each line stored in the buffer includes its trailing newline character.
`MonitorGNSSEventsWithUblox` then joined those lines with `"\n"`, doubling
every newline:

```
"UBX-NAV-STATUS:\n" + "\n" + "  iTOW ... gpsFix 3 ...\n" + "\n" + ...
```

`processGNSSLines` used a `bufio.Scanner` which strips newlines, so when
the scanner detected `"UBX-NAV-STATUS:"` and did a one-line lookahead, it
landed on the spurious empty line instead of the data line containing
`"gpsFix"`. `ExtractNavStatus("")` found no `"gpsFix"` field and always
returned -1, causing `sourceLost=true` and `gnss_status=-1` regardless of
the actual GPS fix state.

The bug was introduced in 9ba63265 ("Decouple GNSS and DPLL") when the
direct per-line `UbloxPollPull()` loop was refactored into the batch
`processGNSSLines()` approach.

Fix by removing the join/split roundtrip entirely: pass the `[]string`
slice directly to `processGNSSLines` instead of joining into a string and
rescanning. This also makes `ExtractNavStatus` and `ExtractOffset` simpler —
they now take a single line instead of a multi-line string with an internal
split that was always a no-op in practice. `ExtractLeapSec` already used
`[]string` and is now consistent with the others.

`processGNSSLines` now uses index-based slice access for lookahead instead
of a scanner, and calls `strings.TrimRight` to strip any trailing newline
from lines as produced by `UbloxPollPull`. The regression is covered by the
"locked with good fix" test case, which passes lines with trailing newlines
and asserts correct parsing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated GNSS message parsing to use structured line input for more efficient clock/status extraction.
  * Improved NAV status and offset extraction to read directly from a single relevant line, with stricter handling for missing or malformed values.
* **Tests**
  * Expanded unit test coverage for NAV status and clock offset parsing, including multiple error scenarios.
  * Updated GNSS processing tests to reflect the new line-based input format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->