### PR TITLE
Fix empty iface name for GNSS and GM metrics

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -32,7 +32,7 @@ type Iface struct {
 // GetLeadingInterface ... get leading clock interface
 func (i *IFaces) GetLeadingInterface() Iface {
 	for _, iface := range *i {
-		if iface.Source == event.GNSS || iface.Source == event.PTP4l {
+		if iface.Source == event.GNSS || iface.Source == event.PTP4l || iface.Source == event.PPS {
 			return iface
 		}
 	}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,0 +1,78 @@
+package config_test
+
+import (
+	"testing"
+
+	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/config"
+	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/event"
+	"github.com/stretchr/testify/assert"
+)
+
+const testIface = "eno8703"
+
+func TestGetLeadingInterface(t *testing.T) {
+	tests := []struct {
+		name      string
+		ifaces    config.IFaces
+		wantName  string
+		wantEmpty bool
+	}{
+		{
+			name: "returns GNSS iface",
+			ifaces: config.IFaces{
+				{Name: testIface, Source: event.GNSS},
+			},
+			wantName: testIface,
+		},
+		{
+			name: "returns PTP4l iface (BC case)",
+			ifaces: config.IFaces{
+				{Name: "ens2f0", Source: event.PTP4l},
+			},
+			wantName: "ens2f0",
+		},
+		{
+			// GM ts2phc slave ifaces have Source=PPS because their ts2phc.master
+			// option is 0; the [nmea] master section is excluded from the ifaces
+			// list by RenderPtp4lConf. Without PPS support here, GetLeadingInterface
+			// returns an empty Iface, causing gmInterface="" in GPSD and
+			// persistent "Sanity check failed" warnings for gnss and GM metrics.
+			name: "returns PPS iface (GM ts2phc slave case)",
+			ifaces: config.IFaces{
+				{Name: testIface, Source: event.PPS},
+				{Name: "enp108s0f0", Source: event.PPS},
+			},
+			wantName: testIface,
+		},
+		{
+			// First match wins; both PPS and GNSS qualify.
+			name: "returns first matching iface when multiple sources qualify",
+			ifaces: config.IFaces{
+				{Name: testIface, Source: event.PPS},
+				{Name: "enp108s0f0", Source: event.GNSS},
+			},
+			wantName: testIface,
+		},
+		{
+			name:      "returns empty Iface when no matching source",
+			ifaces:    config.IFaces{{Name: testIface, Source: event.MONITORING}},
+			wantEmpty: true,
+		},
+		{
+			name:      "returns empty Iface for empty list",
+			ifaces:    config.IFaces{},
+			wantEmpty: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.ifaces.GetLeadingInterface()
+			if tt.wantEmpty {
+				assert.Empty(t, got.Name)
+			} else {
+				assert.Equal(t, tt.wantName, got.Name)
+			}
+		})
+	}
+}


### PR DESCRIPTION
GetLeadingInterface() in pkg/config/config.go only matched event.GNSS
and event.PTP4l sources. For a GM ts2phc configuration, slave interfaces
(e.g. [eno8703], [enp108s0f0] with ts2phc.master 0) are assigned
event.PPS by getSource() in RenderPtp4lConf(). The GNSS master is the
[nmea] section which RenderPtp4lConf explicitly excludes from the ifaces
list (NmeaSectionName guard). As a result, GetLeadingInterface() never
found a matching interface and returned Iface{Name:""}.

This caused gmInterface="" in the GPSD struct, which propagated into
every GNSS event as IFace:"". The event handler's getLeadingInterface()
then found the GNSS data entry with Details[0].IFace="" and returned ""
as the leading interface. Since "" != LEADING_INTERFACE_UNKNOWN, the
guard at line 974 of event.go did not fire, and UpdateClockStateMetrics
was called with alias.GetAlias("")="" for both the gnss and GM process
labels, triggering the sanity check warning every second, permanently.

Fix by adding event.PPS to the GetLeadingInterface() match condition.
A ts2phc PPS slave interface is the leading interface for a GM clock --
it is the interface being synchronised from the GNSS/PPS signal -- so
it is the correct answer here.

Add pkg/config/config_test.go with TestGetLeadingInterface covering
GNSS, PTP4l, PPS (the previously broken case), mixed sources, and
empty/unmatched lists.

Assisted-by: Claude Sonnet 4.6 and pi.dev
Signed-off-by: Jim Ramsay <jramsay@redhat.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded leading clock source detection to include Pulse Per Second (PPS) alongside existing Global Navigation Satellite System (GNSS) and Precision Time Protocol (PTP4l) support.

* **Tests**
  * Added comprehensive test coverage for clock source detection, validating multiple scenarios and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->