### PR TITLE
Fix source identification in ptpconfigs

### DIFF
--- a/pkg/daemon/config.go
+++ b/pkg/daemon/config.go
@@ -451,6 +451,12 @@ func (conf *Ptp4lConf) RenderPtp4lConf() (configOut string, ifaces config.IFaces
 
 			if source, ok := conf.getPtp4lConfOptionOrEmptyString(section.sectionName, "ts2phc.master"); ok {
 				iface.Source = getSource(source)
+				// when a [nmea] section with `ts2phc.master 1` exists, each interface with `ts2phc.master 0`
+				// marks a time sink whose PHC is disciplined by the [nmea] GNSS master, and should be labeled as GNSS.
+				// This requires that the [nmea] section precedes the interface section in the config
+				if iface.Source == event.PPS && nmea_source == event.GNSS {
+					iface.Source = event.GNSS
+				}
 			} else {
 				// if not defined here, use source defined at nmea section
 				iface.Source = nmea_source

--- a/pkg/daemon/daemon_internal_test.go
+++ b/pkg/daemon/daemon_internal_test.go
@@ -321,6 +321,13 @@ func Test_applyProfile_TGM(t *testing.T) {
 		}
 		assert.Contains(t, depNames, GPSD_PROCESSNAME, "gpsd must be a dependent process of ts2phc for T-GM")
 		assert.Contains(t, depNames, GPSPIPE_PROCESSNAME, "gpspipe must be a dependent process of ts2phc for T-GM")
+
+		for _, d := range ts2phcProc.depProcess {
+			if gpsd, ok := d.(*GPSD); ok {
+				assert.Equal(t, "ens7f0", gpsd.gmInterface,
+					"GPSD gmInterface should match the first interface in ts2phcConf (leading GNSS-sourced interface)")
+			}
+		}
 	}
 
 	// 2. ptp4l should NOT have a PMC dependent process for GM profiles.

--- a/pkg/daemon/daemon_test.go
+++ b/pkg/daemon/daemon_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/testhelpers"
 	ptpv1 "github.com/k8snetworkplumbingwg/ptp-operator/api/v1"
 	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
 	"k8s.io/utils/pointer"
 
 	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/config"
@@ -909,5 +910,62 @@ func TestDaemon_PopulateAndRenderPtp4lConf(t *testing.T) {
 		conf.ExtendGlobalSection(tc.profileName, tc.messageTag, tc.socketPath, tc.pProcess)
 		actualOutput, _ := conf.RenderPtp4lConf()
 		assert.Equal(t, tc.expectedOutput, actualOutput, fmt.Sprintf("Rendered output doesn't match expected: %s", tc.testName))
+	}
+}
+
+func TestRenderPtp4lConf_IfaceSource(t *testing.T) {
+	tests := []struct {
+		name           string
+		config         string
+		expectedIfaces []config.Iface
+	}{
+		{
+			name:   "ts2phc.master 0 with nmea GNSS master promotes to GNSS",
+			config: "[nmea]\nts2phc.master 1\n[global]\n[ens7f0]\nts2phc.master 0\n[ens4f0]\nts2phc.master 0",
+			expectedIfaces: []config.Iface{
+				{Name: "ens7f0", Source: event.GNSS},
+				{Name: "ens4f0", Source: event.GNSS}, //nolint:goconst
+			},
+		},
+		{
+			name:   "ts2phc.master 0 without nmea section stays PPS",
+			config: "[global]\n[ens7f0]\nts2phc.master 0\n[ens4f0]\nts2phc.master 0",
+			expectedIfaces: []config.Iface{
+				{Name: "ens7f0", Source: event.PPS},
+				{Name: "ens4f0", Source: event.PPS},
+			},
+		},
+		{
+			name:   "ts2phc.master omitted inherits nmea source",
+			config: "[nmea]\nts2phc.master 1\n[global]\n[ens7f0]\n[ens4f0]",
+			expectedIfaces: []config.Iface{
+				{Name: "ens7f0", Source: event.GNSS},
+				{Name: "ens4f0", Source: event.GNSS},
+			},
+		},
+		{
+			name:   "ts2phc.master 1 on interface is GNSS directly",
+			config: "[global]\n[ens7f0]\nts2phc.master 1\n[ens4f0]\nts2phc.master 0",
+			expectedIfaces: []config.Iface{
+				{Name: "ens7f0", Source: event.GNSS},
+				{Name: "ens4f0", Source: event.PPS},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			conf := &daemon.Ptp4lConf{}
+			err := conf.PopulatePtp4lConf(&tt.config, nil)
+			require.NoError(t, err)
+			_, ifaces := conf.RenderPtp4lConf()
+
+			if assert.Equal(t, len(tt.expectedIfaces), len(ifaces), "iface count mismatch") {
+				for i, expected := range tt.expectedIfaces {
+					assert.Equal(t, expected.Name, ifaces[i].Name, "iface %d name", i)
+					assert.Equal(t, expected.Source, ifaces[i].Source, "iface %d source", i)
+				}
+			}
+		})
 	}
 }

--- a/pkg/daemon/testdata/profile-tgm.yaml
+++ b/pkg/daemon/testdata/profile-tgm.yaml
@@ -214,6 +214,8 @@ ptp4lOpts: -2 --summary_interval -4
 ptpSchedulingPolicy: SCHED_FIFO
 ptpSchedulingPriority: 10
 ts2phcConf: |
+  [nmea]
+  ts2phc.master 1
   [global]
   use_syslog  0
   verbose 1
@@ -221,15 +223,15 @@ ts2phcConf: |
   ts2phc.pulsewidth 100000000
   leapfile  /usr/share/zoneinfo/leap-seconds.list
   [ens7f0]
+  ts2phc.master 0
   ts2phc.extts_polarity rising
   ts2phc.extts_correction 0
-  ts2phc.master 0
   [ens4f0]
+  ts2phc.master 0
   ts2phc.extts_polarity rising
   ts2phc.extts_correction 0
-  ts2phc.master 0
   [ens2f0]
+  ts2phc.master 0
   ts2phc.extts_polarity rising
   ts2phc.extts_correction 0
-  ts2phc.master 0
 ts2phcOpts: ' '


### PR DESCRIPTION
When `ts2phc.master 0` is set explicitly, the config parser would incorrectly determine that an interface had a PPS source instead of GNSS, even when a [nmea] section with `ts2phc.master 1` was present.

This commit fixes that, causing gmInterface to be set to the proper value in both the created gpsd struct, and in metrics.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved interface source selection in generated timing configuration when GNSS/NMEA settings are present.
  * Ensured interfaces correctly inherit or override their source based on nearby configuration sections.
  * Added coverage for this behavior and tightened validation in existing timing-related tests.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->