### PR TITLE
Dump dpll pin's states 

### DIFF
--- a/addons/intel/clock-chain.go
+++ b/addons/intel/clock-chain.go
@@ -3,7 +3,6 @@ package intel
 import (
 	"errors"
 	"fmt"
-	"time"
 
 	"github.com/golang/glog"
 	dpll "github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/dpll-netlink"
@@ -621,17 +620,14 @@ func batchPinSet(commands []dpll.PinParentDeviceCtl) error {
 			glog.Error("failed to send pin command: ", err)
 			return err
 		}
-		info, err := conn.DoPinGet(dpll.DoPinGetRequest{ID: command.ID})
+		// Read back the pin purely to confirm the command was applied; the actual
+		// pin state is logged elsewhere (LogPinTable) when a DPLL notification
+		// reports a lock-state change, so we don't log it again here.
+		_, err = conn.DoPinGet(dpll.DoPinGetRequest{ID: command.ID})
 		if err != nil {
 			glog.Error("failed to get pin: ", err)
 			return err
 		}
-		reply, err := dpll.GetPinInfoHR(info, time.Now())
-		if err != nil {
-			glog.Error("failed to convert pin reply to human readable: ", err)
-			return err
-		}
-		glog.Info("pin reply: ", string(reply))
 	}
 	return nil
 }

--- a/addons/intel/clock-chain.go
+++ b/addons/intel/clock-chain.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/golang/glog"
 	dpll "github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/dpll-netlink"
+	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/hardwareconfig"
 
 	ptpv1 "github.com/k8snetworkplumbingwg/ptp-operator/api/v1"
 )
@@ -599,35 +600,8 @@ func (c *ClockChain) SetPinDefaults() error {
 	return errors.Join(err, fetchErr)
 }
 
-// BatchPinSet function pointer allows mocking of BatchPinSet
-var BatchPinSet = batchPinSet
-
-func batchPinSet(commands []dpll.PinParentDeviceCtl) error {
-	conn, err := dpll.Dial(nil)
-	if err != nil {
-		return fmt.Errorf("failed to dial DPLL: %v", err)
-	}
-	//nolint:errcheck
-	defer conn.Close()
-	for _, command := range commands {
-		glog.Infof("DPLL pin command %s", command.String())
-		b, err := dpll.EncodePinControl(command)
-		if err != nil {
-			return err
-		}
-		err = conn.SendCommand(dpll.DpllCmdPinSet, b)
-		if err != nil {
-			glog.Error("failed to send pin command: ", err)
-			return err
-		}
-		// Read back the pin purely to confirm the command was applied; the actual
-		// pin state is logged elsewhere (LogPinTable) when a DPLL notification
-		// reports a lock-state change, so we don't log it again here.
-		_, err = conn.DoPinGet(dpll.DoPinGetRequest{ID: command.ID})
-		if err != nil {
-			glog.Error("failed to get pin: ", err)
-			return err
-		}
-	}
-	return nil
-}
+// BatchPinSet function pointer allows mocking of BatchPinSet. Delegates to
+// hardwareconfig.BatchPinSet so both packages share one implementation
+// (dial, send, read-back-and-log-as-table, RHEL-137801 workaround) instead
+// of maintaining two near-identical copies.
+var BatchPinSet = hardwareconfig.BatchPinSet

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/mdlayher/netlink v1.8.0
 	github.com/prometheus/client_golang v1.23.2
 	github.com/redhat-cne/sdk-go v1.23.6
+	github.com/rodaine/table v1.3.1
 	github.com/sirupsen/logrus v1.9.3
 	github.com/stratoberry/go-gpsd v1.1.0
 	github.com/stretchr/testify v1.11.1

--- a/go.sum
+++ b/go.sum
@@ -12,6 +12,8 @@ github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
+github.com/clipperhouse/uax29/v2 v2.2.0 h1:ChwIKnQN3kcZteTXMgb1wztSgaU+ZemkgWdohwgs8tY=
+github.com/clipperhouse/uax29/v2 v2.2.0/go.mod h1:EFJ2TJMRUaplDxHKj1qAEhCtQPW2tJSwu5BF98AuoVM=
 github.com/cloudevents/sdk-go/v2 v2.15.2 h1:54+I5xQEnI73RBhWHxbI1XJcqOFOVJN85vb41+8mHUc=
 github.com/cloudevents/sdk-go/v2 v2.15.2/go.mod h1:lL7kSWAE/V8VI4Wh0jbL2v/jvqsm6tjmaQBSvxcv4uE=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
@@ -106,6 +108,8 @@ github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0=
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
+github.com/mattn/go-runewidth v0.0.21 h1:jJKAZiQH+2mIinzCJIaIG9Be1+0NR+5sz/lYEEjdM8w=
+github.com/mattn/go-runewidth v0.0.21/go.mod h1:XBkDxAl56ILZc9knddidhrOlY5R/pDhgLpndooCuJAs=
 github.com/mdlayher/genetlink v1.3.2 h1:KdrNKe+CTu+IbZnm/GVUMXSqBBLqcGpRDa0xkQy56gw=
 github.com/mdlayher/genetlink v1.3.2/go.mod h1:tcC3pkCrPUGIKKsCsp0B3AdaaKuHtaxoJRz3cc+528o=
 github.com/mdlayher/netlink v1.8.0 h1:e7XNIYJKD7hUct3Px04RuIGJbBxy1/c4nX7D5YyvvlM=
@@ -142,6 +146,8 @@ github.com/prometheus/procfs v0.16.1 h1:hZ15bTNuirocR6u0JZ6BAHHmwS1p8B4P6MRqxtzM
 github.com/prometheus/procfs v0.16.1/go.mod h1:teAbpZRB1iIAJYREa1LsoWUXykVXA1KlTmWl8x/U+Is=
 github.com/redhat-cne/sdk-go v1.23.6 h1:L+Rs12UihwDBJc/tj1eEMc4Otf7Lxf0bkFjdsg7FPGA=
 github.com/redhat-cne/sdk-go v1.23.6/go.mod h1:5hK1sILdB33pdMsNYTyBKV/v5GjjibmQZcyRtVrVfvs=
+github.com/rodaine/table v1.3.1 h1:jBVgg1bEu5EzEdYSrwUUlQpayDtkvtTmgFS0FPAxOq8=
+github.com/rodaine/table v1.3.1/go.mod h1:VYCJRCHa2DpD25uFALcB6hi5ECF3eEJQVhCXRjHgXc4=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=

--- a/pkg/dpll-netlink/pin_table.go
+++ b/pkg/dpll-netlink/pin_table.go
@@ -1,0 +1,135 @@
+package dpll_netlink
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/golang/glog"
+	"github.com/rodaine/table"
+)
+
+// isLockedState returns true if the lock status means the DPLL has selected
+// a single active reference (locked or locked-ho-acq), as opposed to
+// unlocked/holdover where there is no single winning input yet.
+func isLockedState(lockStatus uint32) bool {
+	return lockStatus == DpllLockStatusLocked || lockStatus == DpllLockStatusLockedHoldoverAcquired
+}
+
+// isEnabledParent returns true if the parent device admin state indicates the
+// pin is a candidate input for the DPLL (selectable or connected).
+func isEnabledParent(pd *PinParentDevice) bool {
+	return pd.State == PinStateSelectable || pd.State == PinStateConnected
+}
+
+// isActiveParent returns true if the parent device is the one currently
+// selected/used by the DPLL as its synchronization source. Mirrors
+// DpllConfig.ActivePhaseOffsetPin in pkg/dpll: legacy stacks report this via
+// admin state "connected", while newer stacks report it via operstate
+// "active" instead (in which case the admin state never exceeds
+// "selectable"). Both signals are checked since not every driver populates
+// both consistently.
+func isActiveParent(pd *PinParentDevice) bool {
+	return pd.State == PinStateConnected || pd.Operstate == PinOperstateActive
+}
+
+// pinRow holds the single relevant parent-device entry for one pin, ready to
+// be rendered as one table row.
+type pinRow struct {
+	id           uint32
+	boardLabel   string
+	packageLabel string
+	prio         string
+	admin        string
+	oper         string
+}
+
+// buildPinRows selects, among the pins belonging to clockID, the input pins
+// whose parent-device entry matches deviceID (the DPLL device that triggered
+// the notification), and returns one row per matching pin.
+//
+// Output pins are always skipped: they aren't related to a device lock-state
+// change and are logged separately whenever they are set.
+//
+// Row selection also depends on lockStatus:
+//   - locked / locked-ho-acq: only the active input pin (there's only one
+//     reference that matters once a DPLL has locked onto it). See
+//     isActiveParent for why both admin state and operstate are checked.
+//   - unlocked / holdover: all enabled (selectable or connected) input pins,
+//     to show every candidate the DPLL could pick next.
+func buildPinRows(pins []*PinInfo, clockID uint64, deviceID uint32, lockStatus uint32) []pinRow {
+	locked := isLockedState(lockStatus)
+	var rows []pinRow
+
+	for _, pin := range pins {
+		if pin.ClockID != clockID {
+			continue
+		}
+		for _, pd := range pin.ParentDevice {
+			if pd.ParentID != deviceID || pd.Direction != PinDirectionInput {
+				continue
+			}
+			include := false
+			if locked {
+				include = isActiveParent(&pd)
+			} else {
+				include = isEnabledParent(&pd)
+			}
+			if !include {
+				continue
+			}
+			prioStr := "n/a"
+			if pd.Prio != nil {
+				prioStr = fmt.Sprintf("%d", *pd.Prio)
+			}
+			rows = append(rows, pinRow{
+				id:           pin.ID,
+				boardLabel:   pin.BoardLabel,
+				packageLabel: pin.PackageLabel,
+				prio:         prioStr,
+				admin:        GetPinState(pd.State),
+				oper:         GetPinOperstate(pd.Operstate),
+			})
+			break
+		}
+	}
+	return rows
+}
+
+// LogPinTable fetches DPLL pins and logs a compact table of the input pins
+// relevant to the DPLL device (deviceID) on the given clockID that just
+// reported a lock-state change (reason is a free-form description used in
+// the log line, e.g. "eth0 eec->LOCKED").
+//
+// Only pins belonging to clockID are considered, and only the parent-device
+// entry for deviceID is looked at, so unrelated clock chips and the other
+// DPLL sharing the same chip (e.g. PPS vs EEC) don't pollute the table.
+func LogPinTable(reason string, clockID uint64, deviceID uint32, lockStatus uint32) {
+	conn, err := Dial(nil)
+	if err != nil {
+		glog.Errorf("pin table: failed to dial DPLL: %v", err)
+		return
+	}
+	defer conn.Close() //nolint:errcheck
+
+	pins, err := conn.DumpPinGet()
+	if err != nil {
+		glog.Errorf("pin table: failed to dump pins: %v", err)
+		return
+	}
+
+	rows := buildPinRows(pins, clockID, deviceID, lockStatus)
+	if len(rows) == 0 {
+		glog.Infof("=== DPLL pin table (%s) clockID=%#x: no relevant pins ===", reason, clockID)
+		return
+	}
+
+	var buf bytes.Buffer
+	tbl := table.New("id", "Brd. L", "Pkg. L", "prio", "adm.", "oper.")
+	tbl.WithWriter(&buf)
+	for _, r := range rows {
+		tbl.AddRow(r.id, r.boardLabel, r.packageLabel, r.prio, r.admin, r.oper)
+	}
+	tbl.Print()
+
+	glog.Infof("=== DPLL pin table (%s) clockID=%#x ===\n%s", reason, clockID, buf.String())
+}

--- a/pkg/dpll-netlink/pin_table.go
+++ b/pkg/dpll-netlink/pin_table.go
@@ -15,6 +15,15 @@ import (
 // table when the DPLL driver is slow/unresponsive than to stall on it.
 const pinTableNetlinkTimeout = 2 * time.Second
 
+// pinTableHeaders/pinTableHeadersWithDir are the column sets shared by every
+// pin table rendered from this file. Kept as package vars (rather than
+// inlined at each call site) so the two render paths (filtered/no-dir vs.
+// unfiltered/with-dir) stay visibly in sync.
+var (
+	pinTableHeaders        = []interface{}{"id", "Brd. L", "Pkg. L", "prio", "adm.", "oper."}
+	pinTableHeadersWithDir = []interface{}{"id", "Brd. L", "Pkg. L", "dir", "prio", "adm.", "oper."}
+)
+
 // pinTableConn is a DPLL netlink connection shared across LogPinTable calls,
 // guarded by pinTableConnMu. Reusing one connection instead of dialing fresh
 // on every device notification avoids the socket churn a per-call Dial would
@@ -98,7 +107,8 @@ func isActiveParent(pd *PinParentDevice) bool {
 }
 
 // pinRow holds the single relevant parent-device entry for one pin, ready to
-// be rendered as one table row.
+// be rendered as one table row (no "dir" column: buildPinRows only ever
+// keeps input pins, so it would be constant and redundant).
 type pinRow struct {
 	id           uint32
 	boardLabel   string
@@ -106,6 +116,79 @@ type pinRow struct {
 	prio         string
 	admin        string
 	oper         string
+}
+
+// columns renders a pinRow as a table row.
+func (r pinRow) columns() []string {
+	return []string{fmt.Sprintf("%d", r.id), r.boardLabel, r.packageLabel, r.prio, r.admin, r.oper}
+}
+
+// pinRowsToColumns converts rows to the [][]string shape renderTable expects.
+func pinRowsToColumns(rows []pinRow) [][]string {
+	cols := make([][]string, len(rows))
+	for i, r := range rows {
+		cols[i] = r.columns()
+	}
+	return cols
+}
+
+// renderTable renders headers/rows into a table string using the shared
+// rodaine/table formatting for this package. Pure function: no I/O, no
+// logging, so it's trivial to unit test and safe to reuse from any call site
+// that already has data shaped as rows of strings.
+func renderTable(headers []interface{}, rows [][]string) string {
+	var buf bytes.Buffer
+	tbl := table.New(headers...)
+	tbl.WithWriter(&buf)
+	tbl.SetRows(rows)
+	tbl.Print()
+	return buf.String()
+}
+
+// LogPins logs the given pins as a compact table, one row per parent device
+// of each pin. Unlike LogPinTable, this applies no filtering by direction,
+// clock ID, device, or lock state — every parent device of every pin passed
+// in is shown, including output pins.
+//
+// This is the shared rendering primitive behind LogPinTable and
+// LogPinConfirmation, exported so other packages that already hold a
+// []*PinInfo (their own DumpPinGet result, a single pin from DoPinGet, or a
+// test fixture) can log a consistent table without duplicating table-building
+// code or going through LogPinTable's dial/dump/notification-filtering path.
+func LogPins(title string, pins []*PinInfo) {
+	var rows [][]string
+	for _, pin := range pins {
+		for _, pd := range pin.ParentDevice {
+			prioStr := "n/a"
+			if pd.Prio != nil {
+				prioStr = fmt.Sprintf("%d", *pd.Prio)
+			}
+			rows = append(rows, []string{
+				fmt.Sprintf("%d", pin.ID),
+				pin.BoardLabel,
+				pin.PackageLabel,
+				GetPinDirection(pd.Direction),
+				prioStr,
+				GetPinState(pd.State),
+				GetPinOperstate(pd.Operstate),
+			})
+		}
+	}
+	if len(rows) == 0 {
+		glog.Infof("=== DPLL pin table (%s): no relevant pins ===", title)
+		return
+	}
+	glog.Infof("=== DPLL pin table (%s) ===\n%s", title, renderTable(pinTableHeadersWithDir, rows))
+}
+
+// LogPinConfirmation logs the current configuration of a single pin via
+// LogPins. Unlike LogPinTable, this applies no filtering by direction, clock
+// ID, device, or lock state — it's meant to show the full post-write state of
+// exactly the pin that was just set (including output pins, which
+// LogPinTable always skips), immediately after a pin-set command, for
+// confirmation purposes.
+func LogPinConfirmation(pin *PinInfo) {
+	LogPins(fmt.Sprintf("confirm pin=%d %#x", pin.ID, pin.ClockID), []*PinInfo{pin})
 }
 
 // buildPinRows selects, among the pins belonging to clockID, the input pins
@@ -170,19 +253,21 @@ func buildPinRows(pins []*PinInfo, clockID uint64, deviceID uint32, lockStatus u
 // nlUpdateState, processing notifications inline) are never blocked or
 // stalled by it.
 func LogPinTable(reason string, clockID uint64, deviceID uint32, lockStatus uint32) {
-	go logPinTable(reason, clockID, deviceID, lockStatus)
+	go fetchAndLogPinTable(reason, clockID, deviceID, lockStatus)
 }
 
-// logPinTable fetches DPLL pins and logs the table. Only pins belonging to
-// clockID are considered, and only the parent-device entry for deviceID is
-// looked at, so unrelated clock chips and the other DPLL sharing the same
-// chip (e.g. PPS vs EEC) don't pollute the table.
+// fetchAndLogPinTable dials (or reuses) a DPLL connection, dumps every pin on
+// the system, filters them down to the ones relevant to clockID/deviceID/
+// lockStatus (see buildPinRows), and logs the result as a table. Only pins
+// belonging to clockID are considered, and only the parent-device entry for
+// deviceID is looked at, so unrelated clock chips and the other DPLL sharing
+// the same chip (e.g. PPS vs EEC) don't pollute the table.
 //
 // It reuses a shared connection (see pinTableConn) rather than dialing fresh
 // every call, and bounds the dump with pinTableNetlinkTimeout so a slow or
 // unresponsive DPLL driver can't stall this indefinitely; either failure
 // mode discards the shared connection so the next call starts clean.
-func logPinTable(reason string, clockID uint64, deviceID uint32, lockStatus uint32) {
+func fetchAndLogPinTable(reason string, clockID uint64, deviceID uint32, lockStatus uint32) {
 	pinTableConnMu.Lock()
 	defer pinTableConnMu.Unlock()
 
@@ -212,13 +297,5 @@ func logPinTable(reason string, clockID uint64, deviceID uint32, lockStatus uint
 		return
 	}
 
-	var buf bytes.Buffer
-	tbl := table.New("id", "Brd. L", "Pkg. L", "prio", "adm.", "oper.")
-	tbl.WithWriter(&buf)
-	for _, r := range rows {
-		tbl.AddRow(r.id, r.boardLabel, r.packageLabel, r.prio, r.admin, r.oper)
-	}
-	tbl.Print()
-
-	glog.Infof("=== DPLL pin table (%s) clockID=%#x ===\n%s", reason, clockID, buf.String())
+	glog.Infof("=== DPLL pin table (%s) clockID=%#x ===\n%s", reason, clockID, renderTable(pinTableHeaders, pinRowsToColumns(rows)))
 }

--- a/pkg/dpll-netlink/pin_table.go
+++ b/pkg/dpll-netlink/pin_table.go
@@ -3,10 +3,75 @@ package dpll_netlink
 import (
 	"bytes"
 	"fmt"
+	"sync"
+	"time"
 
 	"github.com/golang/glog"
 	"github.com/rodaine/table"
 )
+
+// pinTableNetlinkTimeout bounds how long a single pin-table dial/dump is
+// allowed to take. Pin dumps are diagnostic-only, so it's better to skip a
+// table when the DPLL driver is slow/unresponsive than to stall on it.
+const pinTableNetlinkTimeout = 2 * time.Second
+
+// pinTableConn is a DPLL netlink connection shared across LogPinTable calls,
+// guarded by pinTableConnMu. Reusing one connection instead of dialing fresh
+// on every device notification avoids the socket churn a per-call Dial would
+// cause during lock-state flapping; the mutex also naturally serializes
+// concurrent LogPinTable calls onto a single in-flight dial/dump at a time.
+var (
+	pinTableConnMu sync.Mutex
+	pinTableConn   *Conn
+)
+
+// dialPinTableConn dials a new DPLL connection, bounded by
+// pinTableNetlinkTimeout. The dial package doesn't expose a timeout/context
+// knob, so the wait is bounded from the caller's side via a background
+// goroutine: on timeout we give up and return an error instead of blocking
+// forever, at the cost of abandoning that one dial attempt (harmless; it
+// either fails on its own or yields a connection nobody uses).
+func dialPinTableConn() (*Conn, error) {
+	type result struct {
+		conn *Conn
+		err  error
+	}
+	ch := make(chan result, 1)
+	go func() {
+		conn, err := Dial(nil)
+		ch <- result{conn, err}
+	}()
+	select {
+	case r := <-ch:
+		return r.conn, r.err
+	case <-time.After(pinTableNetlinkTimeout):
+		return nil, fmt.Errorf("timed out dialing DPLL netlink after %s", pinTableNetlinkTimeout)
+	}
+}
+
+// getPinTableConn returns the shared connection, dialing one lazily if there
+// isn't a healthy one cached yet.
+func getPinTableConn() (*Conn, error) {
+	if pinTableConn != nil {
+		return pinTableConn, nil
+	}
+	conn, err := dialPinTableConn()
+	if err != nil {
+		return nil, err
+	}
+	pinTableConn = conn
+	return conn, nil
+}
+
+// invalidatePinTableConn discards the shared connection so the next call
+// dials a fresh one. Called whenever an operation on it fails or times out,
+// since the connection may be left in a broken/indeterminate state.
+func invalidatePinTableConn() {
+	if pinTableConn != nil {
+		_ = pinTableConn.Close() //nolint:errcheck
+		pinTableConn = nil
+	}
+}
 
 // isLockedState returns true if the lock status means the DPLL has selected
 // a single active reference (locked or locked-ho-acq), as opposed to
@@ -95,25 +160,49 @@ func buildPinRows(pins []*PinInfo, clockID uint64, deviceID uint32, lockStatus u
 	return rows
 }
 
-// LogPinTable fetches DPLL pins and logs a compact table of the input pins
-// relevant to the DPLL device (deviceID) on the given clockID that just
-// reported a lock-state change (reason is a free-form description used in
-// the log line, e.g. "eth0 eec->LOCKED").
+// LogPinTable logs a compact table of the input pins relevant to the DPLL
+// device (deviceID) on the given clockID that just reported a lock-state
+// change (reason is a free-form description used in the log line, e.g.
+// "eth0 eec->LOCKED").
 //
-// Only pins belonging to clockID are considered, and only the parent-device
-// entry for deviceID is looked at, so unrelated clock chips and the other
-// DPLL sharing the same chip (e.g. PPS vs EEC) don't pollute the table.
+// This is a best-effort diagnostic: the actual netlink dial/dump happens in a
+// background goroutine so callers on latency-sensitive paths (e.g.
+// nlUpdateState, processing notifications inline) are never blocked or
+// stalled by it.
 func LogPinTable(reason string, clockID uint64, deviceID uint32, lockStatus uint32) {
-	conn, err := Dial(nil)
+	go logPinTable(reason, clockID, deviceID, lockStatus)
+}
+
+// logPinTable fetches DPLL pins and logs the table. Only pins belonging to
+// clockID are considered, and only the parent-device entry for deviceID is
+// looked at, so unrelated clock chips and the other DPLL sharing the same
+// chip (e.g. PPS vs EEC) don't pollute the table.
+//
+// It reuses a shared connection (see pinTableConn) rather than dialing fresh
+// every call, and bounds the dump with pinTableNetlinkTimeout so a slow or
+// unresponsive DPLL driver can't stall this indefinitely; either failure
+// mode discards the shared connection so the next call starts clean.
+func logPinTable(reason string, clockID uint64, deviceID uint32, lockStatus uint32) {
+	pinTableConnMu.Lock()
+	defer pinTableConnMu.Unlock()
+
+	conn, err := getPinTableConn()
 	if err != nil {
 		glog.Errorf("pin table: failed to dial DPLL: %v", err)
 		return
 	}
-	defer conn.Close() //nolint:errcheck
+
+	err = conn.GetGenetlinkConn().SetDeadline(time.Now().Add(pinTableNetlinkTimeout))
+	if err != nil {
+		glog.Errorf("pin table: failed to set netlink deadline: %v", err)
+		invalidatePinTableConn()
+		return
+	}
 
 	pins, err := conn.DumpPinGet()
 	if err != nil {
 		glog.Errorf("pin table: failed to dump pins: %v", err)
+		invalidatePinTableConn()
 		return
 	}
 

--- a/pkg/dpll-netlink/pin_table_test.go
+++ b/pkg/dpll-netlink/pin_table_test.go
@@ -196,6 +196,74 @@ func TestDialPinTableConn_ReturnsPromptly(t *testing.T) {
 	assert.Less(t, time.Since(start), pinTableNetlinkTimeout)
 }
 
+func TestRenderTable(t *testing.T) {
+	selectable := GetPinState(PinStateSelectable)
+	out := renderTable(pinTableHeaders, [][]string{
+		{"16", "REF0P", "", "6", selectable, pinOperstateActive},
+		{"17", "REF0N", "", "7", selectable, pinOperstateStandby},
+	})
+	assert.Contains(t, out, "id")
+	assert.Contains(t, out, "REF0P")
+	assert.Contains(t, out, "REF0N")
+	assert.Contains(t, out, pinOperstateActive)
+}
+
+func TestRenderTable_Empty(t *testing.T) {
+	out := renderTable(pinTableHeaders, nil)
+	// Header row should still render even with zero data rows.
+	assert.Contains(t, out, "id")
+}
+
+func TestPinRowColumns(t *testing.T) {
+	selectable := GetPinState(PinStateSelectable)
+	r := pinRow{id: 16, boardLabel: testPinREF0P, packageLabel: "", prio: "6", admin: selectable, oper: pinOperstateActive}
+	assert.Equal(t, []string{"16", testPinREF0P, "", "6", selectable, pinOperstateActive}, r.columns())
+}
+
+func TestPinRowsToColumns(t *testing.T) {
+	selectable := GetPinState(PinStateSelectable)
+	rows := []pinRow{
+		{id: 16, boardLabel: testPinREF0P, prio: "6", admin: selectable, oper: pinOperstateActive},
+		{id: 17, boardLabel: testPinREF0N, prio: "7", admin: selectable, oper: pinOperstateStandby},
+	}
+	cols := pinRowsToColumns(rows)
+	assert.Len(t, cols, 2)
+	assert.Equal(t, "16", cols[0][0])
+	assert.Equal(t, testPinREF0N, cols[1][1])
+}
+
+// TestLogPins_DoesNotPanic exercises LogPins (and, through it,
+// LogPinConfirmation) across a few shapes that could plausibly trip up the
+// row-building loop: no pins, a pin with no parent devices, and a pin with
+// multiple parents including an output direction (which LogPins, unlike
+// LogPinTable/buildPinRows, must still show).
+func TestLogPins_DoesNotPanic(t *testing.T) {
+	assert.NotPanics(t, func() { LogPins("empty", nil) })
+	assert.NotPanics(t, func() { LogPins("no-parents", []*PinInfo{{ID: 1, BoardLabel: "X"}}) })
+	assert.NotPanics(t, func() {
+		LogPins("mixed", []*PinInfo{
+			{
+				ID: 25, ClockID: 0xAA, BoardLabel: "OUT3",
+				ParentDevice: []PinParentDevice{
+					{ParentID: 1, Direction: PinDirectionOutput, State: PinStateConnected, Prio: prio(3)},
+					{ParentID: 2, Direction: PinDirectionInput, State: PinStateSelectable, Prio: nil},
+				},
+			},
+		})
+	})
+}
+
+func TestLogPinConfirmation_DoesNotPanic(t *testing.T) {
+	assert.NotPanics(t, func() {
+		LogPinConfirmation(&PinInfo{
+			ID: 16, ClockID: 0xAA, BoardLabel: testPinREF0P,
+			ParentDevice: []PinParentDevice{
+				{ParentID: 1, Direction: PinDirectionInput, State: PinStateConnected, Prio: prio(6)},
+			},
+		})
+	})
+}
+
 func TestBuildPinRows_WithPackageLabel(t *testing.T) {
 	pins := []*PinInfo{
 		{

--- a/pkg/dpll-netlink/pin_table_test.go
+++ b/pkg/dpll-netlink/pin_table_test.go
@@ -1,0 +1,188 @@
+package dpll_netlink
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	testPinREF0P = "REF0P"
+	testPinREF0N = "REF0N"
+)
+
+func prio(v uint32) *uint32 { return &v }
+
+func TestIsLockedState(t *testing.T) {
+	assert.False(t, isLockedState(DpllLockStatusUnlocked))
+	assert.False(t, isLockedState(DpllLockStatusHoldover))
+	assert.True(t, isLockedState(DpllLockStatusLocked))
+	assert.True(t, isLockedState(DpllLockStatusLockedHoldoverAcquired))
+}
+
+func TestIsEnabledParent(t *testing.T) {
+	assert.True(t, isEnabledParent(&PinParentDevice{State: PinStateSelectable}))
+	assert.True(t, isEnabledParent(&PinParentDevice{State: PinStateConnected}))
+	assert.False(t, isEnabledParent(&PinParentDevice{State: PinStateDisconnected}))
+}
+
+func TestIsActiveParent(t *testing.T) {
+	// Newer stacks: admin state stays "selectable", operstate reports "active".
+	assert.True(t, isActiveParent(&PinParentDevice{State: PinStateSelectable, Operstate: PinOperstateActive}))
+	// Legacy stacks: admin state goes to "connected", operstate may be unreported/unknown.
+	assert.True(t, isActiveParent(&PinParentDevice{State: PinStateConnected, Operstate: 0}))
+	// Neither signal present: not active.
+	assert.False(t, isActiveParent(&PinParentDevice{State: PinStateSelectable, Operstate: PinOperstateStandby}))
+	assert.False(t, isActiveParent(&PinParentDevice{State: PinStateDisconnected, Operstate: 0}))
+}
+
+func TestBuildPinRows_FiltersByClockIDAndDevice(t *testing.T) {
+	pins := []*PinInfo{
+		{
+			ID: 16, ClockID: 0xAA, BoardLabel: testPinREF0P,
+			ParentDevice: []PinParentDevice{
+				{ParentID: 1, Direction: PinDirectionInput, State: PinStateSelectable, Operstate: PinOperstateActive, Prio: prio(6)},
+				{ParentID: 2, Direction: PinDirectionInput, State: PinStateDisconnected, Operstate: PinOperstateStandby, Prio: prio(14)},
+			},
+		},
+		{
+			// Different clock ID entirely: must be excluded.
+			ID: 17, ClockID: 0xBB, BoardLabel: "OTHERCHIP",
+			ParentDevice: []PinParentDevice{
+				{ParentID: 1, Direction: PinDirectionInput, State: PinStateSelectable, Operstate: PinOperstateActive, Prio: prio(1)},
+			},
+		},
+	}
+
+	// Unlocked: pin is enabled for device 1, should be included.
+	rows := buildPinRows(pins, 0xAA, 1, DpllLockStatusUnlocked)
+	assert.Len(t, rows, 1)
+	assert.Equal(t, uint32(16), rows[0].id)
+	assert.Equal(t, testPinREF0P, rows[0].boardLabel)
+	assert.Equal(t, "6", rows[0].prio)
+
+	// Device 2's parent entry for the same pin is disconnected, so nothing shows for it.
+	rows = buildPinRows(pins, 0xAA, 2, DpllLockStatusUnlocked)
+	assert.Empty(t, rows)
+}
+
+func TestBuildPinRows_SkipsOutputPins(t *testing.T) {
+	pins := []*PinInfo{
+		{
+			ID: 25, ClockID: 0xAA, BoardLabel: "OUT3",
+			ParentDevice: []PinParentDevice{
+				{ParentID: 1, Direction: PinDirectionOutput, State: PinStateConnected, Operstate: PinOperstateActive},
+			},
+		},
+	}
+	rows := buildPinRows(pins, 0xAA, 1, DpllLockStatusLocked)
+	assert.Empty(t, rows, "output pins must never be included")
+}
+
+func TestBuildPinRows_LockedShowsOnlyActive(t *testing.T) {
+	pins := []*PinInfo{
+		{
+			ID: 16, ClockID: 0xAA, BoardLabel: testPinREF0P,
+			ParentDevice: []PinParentDevice{
+				{ParentID: 1, Direction: PinDirectionInput, State: PinStateSelectable, Operstate: PinOperstateActive, Prio: prio(6)},
+			},
+		},
+		{
+			ID: 17, ClockID: 0xAA, BoardLabel: testPinREF0N,
+			ParentDevice: []PinParentDevice{
+				{ParentID: 1, Direction: PinDirectionInput, State: PinStateSelectable, Operstate: PinOperstateStandby, Prio: prio(7)},
+			},
+		},
+	}
+
+	rows := buildPinRows(pins, 0xAA, 1, DpllLockStatusLocked)
+	assert.Len(t, rows, 1, "locked state should only show the active input")
+	assert.Equal(t, uint32(16), rows[0].id)
+
+	rows = buildPinRows(pins, 0xAA, 1, DpllLockStatusLockedHoldoverAcquired)
+	assert.Len(t, rows, 1, "locked-ho-acq state should only show the active input")
+	assert.Equal(t, uint32(16), rows[0].id)
+}
+
+// TestBuildPinRows_LockedFallsBackToLegacyConnectedState covers hardware/drivers
+// that never report Operstate as active (it stays "unknown"), but do report the
+// legacy admin state "connected" for the pin actually in use. Without this
+// fallback the table would always print "no relevant pins" once locked.
+func TestBuildPinRows_LockedFallsBackToLegacyConnectedState(t *testing.T) {
+	pins := []*PinInfo{
+		{
+			ID: 16, ClockID: 0xAA, BoardLabel: testPinREF0P,
+			ParentDevice: []PinParentDevice{
+				{ParentID: 1, Direction: PinDirectionInput, State: PinStateConnected, Operstate: 0, Prio: prio(6)},
+			},
+		},
+		{
+			ID: 17, ClockID: 0xAA, BoardLabel: testPinREF0N,
+			ParentDevice: []PinParentDevice{
+				{ParentID: 1, Direction: PinDirectionInput, State: PinStateSelectable, Operstate: 0, Prio: prio(7)},
+			},
+		},
+	}
+
+	rows := buildPinRows(pins, 0xAA, 1, DpllLockStatusLocked)
+	assert.Len(t, rows, 1, "the legacy 'connected' admin state should count as active even with an unreported operstate")
+	assert.Equal(t, uint32(16), rows[0].id)
+}
+
+func TestBuildPinRows_UnlockedShowsAllEnabled(t *testing.T) {
+	pins := []*PinInfo{
+		{
+			ID: 16, ClockID: 0xAA, BoardLabel: testPinREF0P,
+			ParentDevice: []PinParentDevice{
+				{ParentID: 1, Direction: PinDirectionInput, State: PinStateSelectable, Operstate: PinOperstateStandby, Prio: prio(6)},
+			},
+		},
+		{
+			ID: 17, ClockID: 0xAA, BoardLabel: testPinREF0N,
+			ParentDevice: []PinParentDevice{
+				{ParentID: 1, Direction: PinDirectionInput, State: PinStateDisconnected, Operstate: PinOperstateNoSignal, Prio: prio(7)},
+			},
+		},
+	}
+
+	rows := buildPinRows(pins, 0xAA, 1, DpllLockStatusUnlocked)
+	assert.Len(t, rows, 1, "only the enabled (selectable/connected) input should show")
+	assert.Equal(t, uint32(16), rows[0].id)
+
+	rows = buildPinRows(pins, 0xAA, 1, DpllLockStatusHoldover)
+	assert.Len(t, rows, 1, "holdover behaves the same as unlocked")
+	assert.Equal(t, uint32(16), rows[0].id)
+}
+
+func TestBuildPinRows_PrioNil(t *testing.T) {
+	pins := []*PinInfo{
+		{
+			ID: 5, ClockID: 0xBB, BoardLabel: "IN0",
+			ParentDevice: []PinParentDevice{
+				{ParentID: 0, Direction: PinDirectionInput, State: PinStateConnected, Operstate: PinOperstateActive, Prio: nil},
+			},
+		},
+	}
+	rows := buildPinRows(pins, 0xBB, 0, DpllLockStatusLocked)
+	assert.Len(t, rows, 1)
+	assert.Equal(t, "n/a", rows[0].prio)
+}
+
+func TestBuildPinRows_Empty(t *testing.T) {
+	assert.Empty(t, buildPinRows(nil, 0xAA, 0, DpllLockStatusUnlocked))
+}
+
+func TestBuildPinRows_WithPackageLabel(t *testing.T) {
+	pins := []*PinInfo{
+		{
+			ID: 5, ClockID: 0xDD, BoardLabel: "SDP0", PackageLabel: "U1901",
+			ParentDevice: []PinParentDevice{
+				{ParentID: 0, Direction: PinDirectionInput, State: PinStateSelectable, Operstate: PinOperstateStandby, Prio: prio(3)},
+			},
+		},
+	}
+	rows := buildPinRows(pins, 0xDD, 0, DpllLockStatusUnlocked)
+	assert.Len(t, rows, 1)
+	assert.Equal(t, "SDP0", rows[0].boardLabel)
+	assert.Equal(t, "U1901", rows[0].packageLabel)
+}

--- a/pkg/dpll-netlink/pin_table_test.go
+++ b/pkg/dpll-netlink/pin_table_test.go
@@ -2,6 +2,7 @@ package dpll_netlink
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -170,6 +171,29 @@ func TestBuildPinRows_PrioNil(t *testing.T) {
 
 func TestBuildPinRows_Empty(t *testing.T) {
 	assert.Empty(t, buildPinRows(nil, 0xAA, 0, DpllLockStatusUnlocked))
+}
+
+func TestInvalidatePinTableConn_NilSafe(t *testing.T) {
+	pinTableConnMu.Lock()
+	pinTableConn = nil
+	pinTableConnMu.Unlock()
+
+	assert.NotPanics(t, invalidatePinTableConn)
+}
+
+// TestDialPinTableConn_ReturnsPromptly guards against dialPinTableConn ever
+// silently blocking for the full pinTableNetlinkTimeout. Whether the "dpll"
+// netlink family is available depends on the environment (e.g. it fails
+// immediately on non-Linux OSes, but some Linux CI kernels register the
+// family even without real DPLL hardware behind it), so this only asserts
+// on timing, not on a specific dial outcome.
+func TestDialPinTableConn_ReturnsPromptly(t *testing.T) {
+	start := time.Now()
+	conn, err := dialPinTableConn()
+	if err == nil {
+		defer conn.Close() //nolint:errcheck
+	}
+	assert.Less(t, time.Since(start), pinTableNetlinkTimeout)
 }
 
 func TestBuildPinRows_WithPackageLabel(t *testing.T) {

--- a/pkg/dpll/dpll.go
+++ b/pkg/dpll/dpll.go
@@ -386,6 +386,8 @@ func (d *DpllConfig) nlUpdateState(devices []*nl.DoDeviceGetReply, pins []*nl.Pi
 				glog.Infof("%s (%#x) updating pps to %s (%d)", d.iface, d.clockId, stateName(d.phaseStatus), d.phaseStatus)
 				valid = true
 			}
+			nl.LogPinTable(fmt.Sprintf("%s %s->%s", d.iface, nl.GetDpllType(reply.Type), stateName(int64(reply.LockStatus))),
+				reply.ClockID, reply.ID, reply.LockStatus)
 		}
 	}
 	for _, pin := range pins {

--- a/pkg/hardwareconfig/utils.go
+++ b/pkg/hardwareconfig/utils.go
@@ -7,7 +7,6 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/golang/glog"
 
@@ -479,18 +478,14 @@ func BatchPinSet(commands []dpll.PinParentDeviceCtl) error {
 			glog.Error("failed to send pin command: ", err)
 			return err
 		}
-		info, getErr := conn.DoPinGet(dpll.DoPinGetRequest{ID: command.ID})
-		if getErr != nil {
+		// Read back the pin purely to confirm the command was applied; the actual
+		// pin state is logged elsewhere (LogPinTable) when a DPLL notification
+		// reports a lock-state change, so we don't log it again here.
+		if _, getErr := conn.DoPinGet(dpll.DoPinGetRequest{ID: command.ID}); getErr != nil {
 			glog.Error("failed to get pin: ", getErr)
 			//TODO: handle properly after RHEL-137801 is fixed
 			return nil
 		}
-		reply, replyErr := dpll.GetPinInfoHR(info, time.Now())
-		if replyErr != nil {
-			glog.Error("failed to convert pin reply to human readable: ", replyErr)
-			return replyErr
-		}
-		glog.Info("pin reply: ", string(reply))
 	}
 	return nil
 }

--- a/pkg/hardwareconfig/utils.go
+++ b/pkg/hardwareconfig/utils.go
@@ -478,14 +478,16 @@ func BatchPinSet(commands []dpll.PinParentDeviceCtl) error {
 			glog.Error("failed to send pin command: ", err)
 			return err
 		}
-		// Read back the pin purely to confirm the command was applied; the actual
-		// pin state is logged elsewhere (LogPinTable) when a DPLL notification
-		// reports a lock-state change, so we don't log it again here.
-		if _, getErr := conn.DoPinGet(dpll.DoPinGetRequest{ID: command.ID}); getErr != nil {
+		// Read back the pin to confirm the command was applied, and log it as a
+		// table (see LogPinConfirmation) since LogPinTable never shows output
+		// pins and reflects state as of the next notification, not this write.
+		info, getErr := conn.DoPinGet(dpll.DoPinGetRequest{ID: command.ID})
+		if getErr != nil {
 			glog.Error("failed to get pin: ", getErr)
 			//TODO: handle properly after RHEL-137801 is fixed
 			return nil
 		}
+		dpll.LogPinConfirmation(info)
 	}
 	return nil
 }

--- a/vendor/github.com/rodaine/table/license
+++ b/vendor/github.com/rodaine/table/license
@@ -1,0 +1,9 @@
+The MIT License (MIT)
+
+Copyright (c) 2015 Chris Roche (rodaine+github@gmail.com)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/vendor/github.com/rodaine/table/readme.md
+++ b/vendor/github.com/rodaine/table/readme.md
@@ -1,0 +1,57 @@
+# table <br/> [![GoDoc](https://godoc.org/github.com/rodaine/table?status.svg)](https://godoc.org/github.com/rodaine/table)
+
+![Example Table Output With ANSI Colors](http://res.cloudinary.com/rodaine/image/upload/v1442524799/go-table-example0.png)
+
+Package table provides a convenient way to generate tabular output of any data, primarily useful for CLI tools.
+
+## Features
+
+- Accepts all data types (`string`, `int`, `interface{}`, everything!) and will use the `String() string` method of a type if available.
+- Can specify custom formatting for the header and first column cells for better readability.
+- Columns are left-aligned and sized to fit the data, with customizable padding.
+- The printed output can be sent to any `io.Writer`, defaulting to `os.Stdout`.
+- Built to an interface, so you can roll your own `Table` implementation.
+- Works well with ANSI colors ([fatih/color](https://github.com/fatih/color) in the example)!
+- Can provide a custom `WidthFunc` to accomodate multi- and zero-width characters (such as [runewidth](https://github.com/mattn/go-runewidth))
+
+## Usage
+
+**Download the package:**
+
+```sh
+go get github.com/rodaine/table
+```
+
+**Example:**
+
+```go
+package main
+
+import (
+  "fmt"
+  "strings"
+
+  "github.com/fatih/color"
+  "github.com/rodaine/table"
+)
+
+func main() {
+  headerFmt := color.New(color.FgGreen, color.Underline).SprintfFunc()
+  columnFmt := color.New(color.FgYellow).SprintfFunc()
+
+  tbl := table.New("ID", "Name", "Score", "Added")
+  tbl.WithHeaderFormatter(headerFmt).WithFirstColumnFormatter(columnFmt)
+
+  for _, widget := range getWidgets() {
+    tbl.AddRow(widget.ID, widget.Name, widget.Cost, widget.Added)
+  }
+
+  tbl.Print()
+}
+```
+
+_Consult the [documentation](https://godoc.org/github.com/rodaine/table) for further examples and usage information_
+
+## License
+
+table is released under the MIT License (Expat). See the [full license](https://github.com/rodaine/table/blob/master/license).

--- a/vendor/github.com/rodaine/table/table.go
+++ b/vendor/github.com/rodaine/table/table.go
@@ -1,0 +1,363 @@
+// Package table provides a convenient way to generate tabular output of any
+// data, primarily useful for CLI tools.
+//
+// Columns are left-aligned and padded to accomodate the largest cell in that
+// column.
+//
+// Source: https://github.com/rodaine/table
+//
+//	table.DefaultHeaderFormatter = func(format string, vals ...interface{}) string {
+//	  return strings.ToUpper(fmt.Sprintf(format, vals...))
+//	}
+//
+//	tbl := table.New("ID", "Name", "Cost ($)")
+//
+//	for _, widget := range Widgets {
+//	  tbl.AddRow(widget.ID, widget.Name, widget.Cost)
+//	}
+//
+//	tbl.Print()
+//
+//	// Output:
+//	// ID  NAME      COST ($)
+//	// 1   Foobar    1.23
+//	// 2   Fizzbuzz  4.56
+//	// 3   Gizmo     78.90
+package table
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"unicode/utf8"
+)
+
+// These are the default properties for all Tables created from this package
+// and can be modified.
+var (
+	// DefaultPadding specifies the number of spaces between columns in a table.
+	DefaultPadding = 2
+
+	// DefaultWriter specifies the output io.Writer for the Table.Print method.
+	DefaultWriter io.Writer = os.Stdout
+
+	// DefaultHeaderFormatter specifies the default Formatter for the table header.
+	DefaultHeaderFormatter Formatter
+
+	// DefaultFirstColumnFormatter specifies the default Formatter for the first column cells.
+	DefaultFirstColumnFormatter Formatter
+
+	// DefaultWidthFunc specifies the default WidthFunc for calculating column widths
+	DefaultWidthFunc WidthFunc = utf8.RuneCountInString
+
+	// DefaultPrintHeaders specifies if headers should be printed
+	DefaultPrintHeaders = true
+)
+
+// Formatter functions expose a fmt.Sprintf signature that can be used to modify
+// the display of the text in either the header or first column of a Table.
+// The formatter should not change the width of original text as printed since
+// column widths are calculated pre-formatting (though this issue can be mitigated
+// with increased padding).
+//
+//	tbl.WithHeaderFormatter(func(format string, vals ...interface{}) string {
+//	  return strings.ToUpper(fmt.Sprintf(format, vals...))
+//	})
+//
+// A good use case for formatters is to use ANSI escape codes to color the cells
+// for a nicer interface. The package color (https://github.com/fatih/color) makes
+// it easy to generate these automatically: http://godoc.org/github.com/fatih/color#Color.SprintfFunc
+type Formatter func(string, ...interface{}) string
+
+// A WidthFunc calculates the width of a string. By default, the number of runes
+// is used but this may not be appropriate for certain character sets. The
+// package runewidth (https://github.com/mattn/go-runewidth) could be used to
+// accomodate multi-cell characters (such as emoji or CJK characters).
+type WidthFunc func(string) int
+
+// Table describes the interface for building up a tabular representation of data.
+// It exposes fluent/chainable methods for convenient table building.
+//
+// WithHeaderFormatter and WithFirstColumnFormatter sets the Formatter for the
+// header and first column, respectively. If nil is passed in (the default), no
+// formatting will be applied.
+//
+//	New("foo", "bar").WithFirstColumnFormatter(func(f string, v ...interface{}) string {
+//	  return strings.ToUpper(fmt.Sprintf(f, v...))
+//	})
+//
+// WithPadding specifies the minimum padding between cells in a row and defaults
+// to DefaultPadding. Padding values less than or equal to zero apply no extra
+// padding between the columns.
+//
+//	New("foo", "bar").WithPadding(3)
+//
+// WithWriter modifies the writer which Print outputs to, defaulting to DefaultWriter
+// when instantiated. If nil is passed, os.Stdout will be used.
+//
+//	New("foo", "bar").WithWriter(os.Stderr)
+//
+// WithWidthFunc sets the function used to calculate the width of the string in
+// a column. By default, the number of utf8 runes in the string is used.
+//
+// WithPrintHeaders specifies whether if the headers of the table should be
+// printed or not, which might be useful if the output is being piped to other
+// processes. By default, they are printed.
+//
+// AddRow adds another row of data to the table. Any values can be passed in and
+// will be output as its string representation as described in the fmt standard
+// package. Rows can have less cells than the total number of columns in the table;
+// subsequent cells will be rendered empty. Rows with more cells than the total
+// number of columns will be truncated. References to the data are not held, so
+// the passed in values can be modified without affecting the table's output.
+//
+//	New("foo", "bar").AddRow("fizz", "buzz").AddRow(time.Now()).AddRow(1, 2, 3).Print()
+//	// Output:
+//	// foo                              bar
+//	// fizz                             buzz
+//	// 2006-01-02 15:04:05.0 -0700 MST
+//	// 1                                2
+//
+// Print writes the string representation of the table to the provided writer.
+// Print can be called multiple times, even after subsequent mutations of the
+// provided data. The output is always preceded and followed by a new line.
+type Table interface {
+	WithHeaderFormatter(f Formatter) Table
+	WithFirstColumnFormatter(f Formatter) Table
+	WithPadding(p int) Table
+	WithWriter(w io.Writer) Table
+	WithWidthFunc(f WidthFunc) Table
+	WithHeaderSeparatorRow(r rune) Table
+	WithPrintHeaders(b bool) Table
+
+	AddRow(vals ...interface{}) Table
+	SetRows(rows [][]string) Table
+	Print()
+}
+
+// New creates a Table instance with the specified header(s) provided. The number
+// of columns is fixed at this point to len(columnHeaders) and the defined defaults
+// are set on the instance.
+func New(columnHeaders ...interface{}) Table {
+	t := table{header: make([]string, len(columnHeaders))}
+
+	t.WithPadding(DefaultPadding)
+	t.WithWriter(DefaultWriter)
+	t.WithHeaderFormatter(DefaultHeaderFormatter)
+	t.WithFirstColumnFormatter(DefaultFirstColumnFormatter)
+	t.WithWidthFunc(DefaultWidthFunc)
+	t.WithPrintHeaders(DefaultPrintHeaders)
+
+	for i, col := range columnHeaders {
+		t.header[i] = fmt.Sprint(col)
+	}
+
+	return &t
+}
+
+type table struct {
+	FirstColumnFormatter Formatter
+	HeaderFormatter      Formatter
+	Padding              int
+	Writer               io.Writer
+	Width                WidthFunc
+	HeaderSeparatorRune  rune
+	PrintHeaders         bool
+
+	header []string
+	rows   [][]string
+	widths []int
+}
+
+func (t *table) WithHeaderFormatter(f Formatter) Table {
+	t.HeaderFormatter = f
+	return t
+}
+
+func (t *table) WithHeaderSeparatorRow(r rune) Table {
+	t.HeaderSeparatorRune = r
+	return t
+}
+
+func (t *table) WithFirstColumnFormatter(f Formatter) Table {
+	t.FirstColumnFormatter = f
+	return t
+}
+
+func (t *table) WithPadding(p int) Table {
+	if p < 0 {
+		p = 0
+	}
+
+	t.Padding = p
+	return t
+}
+
+func (t *table) WithWriter(w io.Writer) Table {
+	if w == nil {
+		w = os.Stdout
+	}
+
+	t.Writer = w
+	return t
+}
+
+func (t *table) WithWidthFunc(f WidthFunc) Table {
+	t.Width = f
+	return t
+}
+
+func (t *table) WithPrintHeaders(b bool) Table {
+	t.PrintHeaders = b
+	return t
+}
+
+func (t *table) AddRow(vals ...interface{}) Table {
+	maxNumNewlines := 0
+	for _, val := range vals {
+		maxNumNewlines = max(strings.Count(fmt.Sprint(val), "\n"), maxNumNewlines)
+	}
+	for i := 0; i <= maxNumNewlines; i++ {
+		row := make([]string, len(t.header))
+		for j, val := range vals {
+			if j >= len(t.header) {
+				break
+			}
+			v := strings.Split(fmt.Sprint(val), "\n")
+			row[j] = safeOffset(v, i)
+		}
+		t.rows = append(t.rows, row)
+	}
+
+	return t
+}
+
+func (t *table) SetRows(rows [][]string) Table {
+	t.rows = [][]string{}
+	headerLength := len(t.header)
+
+	for _, row := range rows {
+		if len(row) > headerLength {
+			t.rows = append(t.rows, row[:headerLength])
+		} else {
+			t.rows = append(t.rows, row)
+		}
+	}
+
+	return t
+}
+
+func (t *table) Print() {
+	format := strings.Repeat("%s", len(t.header)) + "\n"
+	t.calculateWidths()
+
+  if t.PrintHeaders {
+    t.printHeader(format)
+
+    if t.HeaderSeparatorRune != 0 {
+      t.printHeaderSeparator(format)
+    }
+  }
+
+	for _, row := range t.rows {
+		t.printRow(format, row)
+	}
+}
+
+func (t *table) printHeaderSeparator(format string) {
+	separators := make([]string, len(t.header))
+
+	// The separator could be any unicode char. Since some chars take up more
+	// than one cell in a monospace context, we can get a number higher than 1
+	// here. Am example would be this emoji 🤣.
+	separatorCellWidth := t.Width(string([]rune{t.HeaderSeparatorRune}))
+	for index, headerName := range t.header {
+		headerCellWidth := t.Width(headerName)
+		// Note that this might not be evenly divisble. In this case we'll get a
+		// separator that is at least 1 cell shorter than the header. This was
+		// an intentional design decision in order to prevent widening the cell
+		// or overstepping the column bounds.
+		repeatCharTimes := headerCellWidth / separatorCellWidth
+		separator := make([]rune, repeatCharTimes)
+		for i := 0; i < repeatCharTimes; i++ {
+			separator[i] = t.HeaderSeparatorRune
+		}
+		separators[index] = string(separator)
+	}
+
+	vals := t.applyWidths(separators, t.widths)
+	if t.HeaderFormatter != nil {
+		txt := t.HeaderFormatter(format, vals...)
+		fmt.Fprint(t.Writer, txt)
+	} else {
+		fmt.Fprintf(t.Writer, format, vals...)
+	}
+}
+
+func (t *table) printHeader(format string) {
+	vals := t.applyWidths(t.header, t.widths)
+	if t.HeaderFormatter != nil {
+		txt := t.HeaderFormatter(format, vals...)
+		fmt.Fprint(t.Writer, txt)
+	} else {
+		fmt.Fprintf(t.Writer, format, vals...)
+	}
+}
+
+func (t *table) printRow(format string, row []string) {
+	vals := t.applyWidths(row, t.widths)
+
+	if t.FirstColumnFormatter != nil {
+		vals[0] = t.FirstColumnFormatter("%s", vals[0])
+	}
+
+	fmt.Fprintf(t.Writer, format, vals...)
+}
+
+func (t *table) calculateWidths() {
+	t.widths = make([]int, len(t.header))
+	for _, row := range t.rows {
+		for i, v := range row {
+			if w := t.Width(v) + t.Padding; w > t.widths[i] {
+				t.widths[i] = w
+			}
+		}
+	}
+
+	for i, v := range t.header {
+		if w := t.Width(v) + t.Padding; w > t.widths[i] {
+			t.widths[i] = w
+		}
+	}
+}
+
+func (t *table) applyWidths(row []string, widths []int) []interface{} {
+	out := make([]interface{}, len(row))
+	for i, s := range row {
+		out[i] = s + t.lenOffset(s, widths[i])
+	}
+	return out
+}
+
+func (t *table) lenOffset(s string, w int) string {
+	l := w - t.Width(s)
+	if l <= 0 {
+		return ""
+	}
+	return strings.Repeat(" ", l)
+}
+
+func max(i1, i2 int) int {
+	if i1 > i2 {
+		return i1
+	}
+	return i2
+}
+
+func safeOffset(sarr []string, idx int) string {
+	if idx >= len(sarr) {
+		return ""
+	}
+	return sarr[idx]
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -212,6 +212,9 @@ github.com/redhat-cne/sdk-go/pkg/event/ptp
 github.com/redhat-cne/sdk-go/pkg/event/redfish
 github.com/redhat-cne/sdk-go/pkg/pubsub
 github.com/redhat-cne/sdk-go/pkg/types
+# github.com/rodaine/table v1.3.1
+## explicit; go 1.21
+github.com/rodaine/table
 # github.com/sirupsen/logrus v1.9.3
 ## explicit; go 1.13
 github.com/sirupsen/logrus


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted pin configuration read-back to confirm only via raw pin-get results, avoiding human-readable formatting/logging on success.
  * Improved DPLL update diagnostics by logging interface/type and the computed lock-state name.
* **New Features**
  * Updated pin-table reporting to show only relevant input pins per DPLL and clock, with lock-state-aware parent selection and compact pin/parent state columns.
* **Tests**
  * Added unit tests validating lock-state and parent filtering logic, clock/device filtering, label rendering, and edge cases (nil/empty pins, nil priority).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->