### PR TITLE
CNF-22056: Resolve zl3073x DPLL clock ID via pin parent chain

### DIFF
--- a/pkg/hardwareconfig/hardware-vendor/dell/XR8720t/defaults.yaml
+++ b/pkg/hardwareconfig/hardware-vendor/dell/XR8720t/defaults.yaml
@@ -1,0 +1,4 @@
+# Clock ID resolution method for this hardware (E825-based)
+# "devlinkPinChain" - trace NIC DPLL pin parent chain to external DPLL module
+clockIdTransformation:
+  method: devlinkPinChain

--- a/pkg/hardwareconfig/hardware-vendor/hpe/EL140-Gen12/defaults.yaml
+++ b/pkg/hardwareconfig/hardware-vendor/hpe/EL140-Gen12/defaults.yaml
@@ -1,0 +1,4 @@
+# Clock ID resolution method for this hardware (E825-based)
+# "devlinkPinChain" - trace NIC DPLL pin parent chain to external DPLL module
+clockIdTransformation:
+  method: devlinkPinChain

--- a/pkg/hardwareconfig/hardware-vendor/intel/e825/defaults.yaml
+++ b/pkg/hardwareconfig/hardware-vendor/intel/e825/defaults.yaml
@@ -1,9 +1,9 @@
-# Clock ID transformation method for this hardware
-# "direct" - use serial number bytes directly (keeps ff-ff in middle)
-# "eui64" - remove bytes 3-4 (ff-ff) and insert ff-fe (EUI-64 format)
-# Note: Based on actual hardware data from PERLA2 board, e825 uses direct transformation
+# Clock ID resolution method for this hardware
+# "direct" - use NIC PCI serial number bytes directly (E810)
+# "eui64" - EUI-64 transform of NIC PCI serial number
+# "devlinkPinChain" - trace NIC DPLL pin parent chain to external DPLL module (E825/zl3073x)
 clockIdTransformation:
-  method: direct
+  method: devlinkPinChain
 
 pinDefaults:
   # REF0P

--- a/pkg/hardwareconfig/hardwareconfig_gnrd_test.go
+++ b/pkg/hardwareconfig/hardwareconfig_gnrd_test.go
@@ -339,7 +339,7 @@ func validateGNRDVendorDefaults(t *testing.T) {
 
 	// Validate key fields from e825/defaults.yaml
 	assert.NotNil(t, hwSpec.ClockIDTransformation, "Clock ID transformation should be defined")
-	assert.Equal(t, "direct", hwSpec.ClockIDTransformation.Method, "Should use direct transformation (based on actual PERLA2 hardware)")
+	assert.Equal(t, "devlinkPinChain", hwSpec.ClockIDTransformation.Method, "E825 should use devlinkPinChain to resolve clock ID via NIC pin parent chain")
 	t.Logf("  ✓ Clock ID transformation method: %s", hwSpec.ClockIDTransformation.Method)
 
 	assert.NotEmpty(t, hwSpec.PinDefaults, "Pin defaults should not be empty")

--- a/pkg/hardwareconfig/pin_parent_chain_test.go
+++ b/pkg/hardwareconfig/pin_parent_chain_test.go
@@ -1,0 +1,370 @@
+package hardwareconfig
+
+import (
+	"fmt"
+	"testing"
+
+	dpll "github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/dpll-netlink"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	testModuleIce     = "ice"
+	testModuleZl3073x = "zl3073x"
+	testIfaceE825     = "eno5"
+	testIfaceE810     = "ens4f0"
+	testBusE825       = "0000:51:00.0"
+	testBusE810       = "0000:13:00.0"
+)
+
+func TestGetClockIDFromPinParentChain(t *testing.T) {
+	const (
+		nicPinID         = uint32(5)
+		zlParentPinID    = uint32(18)
+		zlParentPinID2   = uint32(19)
+		expectedClockID  = uint64(3549816820761526005)
+		expectedClockID2 = uint64(9876543210123456789)
+	)
+
+	tests := []struct {
+		name             string
+		mockNetdevPin    func(string) (uint32, bool, error)
+		mockPinQuerier   func(uint32) (*dpll.PinInfo, error)
+		wantClockID      uint64
+		wantErr          bool
+		wantErrSubstring string
+	}{
+		{
+			name: "happy path: NIC pin has zl3073x parent",
+			mockNetdevPin: func(_ string) (uint32, bool, error) {
+				return nicPinID, true, nil
+			},
+			mockPinQuerier: func(pinID uint32) (*dpll.PinInfo, error) {
+				switch pinID {
+				case nicPinID:
+					return &dpll.PinInfo{
+						ID:         nicPinID,
+						ModuleName: testModuleIce,
+						ClockID:    13036154006041183120,
+						ParentPin: []dpll.PinParentPin{
+							{ParentID: zlParentPinID, State: dpll.PinStateDisconnected},
+							{ParentID: zlParentPinID2, State: dpll.PinStateDisconnected},
+						},
+					}, nil
+				case zlParentPinID:
+					return &dpll.PinInfo{
+						ID:         zlParentPinID,
+						ModuleName: testModuleZl3073x,
+						ClockID:    expectedClockID,
+					}, nil
+				case zlParentPinID2:
+					return &dpll.PinInfo{
+						ID:         zlParentPinID2,
+						ModuleName: testModuleZl3073x,
+						ClockID:    expectedClockID,
+					}, nil
+				default:
+					return nil, fmt.Errorf("unexpected pin ID %d", pinID)
+				}
+			},
+			wantClockID: expectedClockID,
+		},
+		{
+			name: "multiple parents: first non-ice parent wins",
+			mockNetdevPin: func(_ string) (uint32, bool, error) {
+				return nicPinID, true, nil
+			},
+			mockPinQuerier: func(pinID uint32) (*dpll.PinInfo, error) {
+				switch pinID {
+				case nicPinID:
+					return &dpll.PinInfo{
+						ID:         nicPinID,
+						ModuleName: testModuleIce,
+						ParentPin: []dpll.PinParentPin{
+							{ParentID: zlParentPinID},
+							{ParentID: zlParentPinID2},
+						},
+					}, nil
+				case zlParentPinID:
+					return &dpll.PinInfo{
+						ID:         zlParentPinID,
+						ModuleName: testModuleZl3073x,
+						ClockID:    expectedClockID,
+					}, nil
+				case zlParentPinID2:
+					return &dpll.PinInfo{
+						ID:         zlParentPinID2,
+						ModuleName: "other_dpll",
+						ClockID:    expectedClockID2,
+					}, nil
+				default:
+					return nil, fmt.Errorf("unexpected pin ID %d", pinID)
+				}
+			},
+			wantClockID: expectedClockID,
+		},
+		{
+			name: "non-zl3073x parent module still returns clock ID",
+			mockNetdevPin: func(_ string) (uint32, bool, error) {
+				return nicPinID, true, nil
+			},
+			mockPinQuerier: func(pinID uint32) (*dpll.PinInfo, error) {
+				switch pinID {
+				case nicPinID:
+					return &dpll.PinInfo{
+						ID:         nicPinID,
+						ModuleName: testModuleIce,
+						ParentPin: []dpll.PinParentPin{
+							{ParentID: zlParentPinID},
+						},
+					}, nil
+				case zlParentPinID:
+					return &dpll.PinInfo{
+						ID:         zlParentPinID,
+						ModuleName: "other_dpll",
+						ClockID:    expectedClockID2,
+					}, nil
+				default:
+					return nil, fmt.Errorf("unexpected pin ID %d", pinID)
+				}
+			},
+			wantClockID: expectedClockID2,
+		},
+		{
+			name: "no IFLA_DPLL_PIN on NIC",
+			mockNetdevPin: func(_ string) (uint32, bool, error) {
+				return 0, false, nil
+			},
+			wantErr:          true,
+			wantErrSubstring: "no DPLL pin found",
+		},
+		{
+			name: "netdev pin getter error",
+			mockNetdevPin: func(_ string) (uint32, bool, error) {
+				return 0, false, fmt.Errorf("netlink route failed")
+			},
+			wantErr:          true,
+			wantErrSubstring: "failed to get DPLL pin",
+		},
+		{
+			name: "DPLL pin query fails",
+			mockNetdevPin: func(_ string) (uint32, bool, error) {
+				return nicPinID, true, nil
+			},
+			mockPinQuerier: func(_ uint32) (*dpll.PinInfo, error) {
+				return nil, fmt.Errorf("DPLL netlink connection failed")
+			},
+			wantErr:          true,
+			wantErrSubstring: "failed to query DPLL pin",
+		},
+		{
+			name: "pin has no parent pins",
+			mockNetdevPin: func(_ string) (uint32, bool, error) {
+				return nicPinID, true, nil
+			},
+			mockPinQuerier: func(_ uint32) (*dpll.PinInfo, error) {
+				return &dpll.PinInfo{
+					ID:         nicPinID,
+					ModuleName: testModuleIce,
+					ParentPin:  nil,
+				}, nil
+			},
+			wantErr:          true,
+			wantErrSubstring: "has no parent pins",
+		},
+		{
+			name: "all parents share same module as NIC",
+			mockNetdevPin: func(_ string) (uint32, bool, error) {
+				return nicPinID, true, nil
+			},
+			mockPinQuerier: func(pinID uint32) (*dpll.PinInfo, error) {
+				return &dpll.PinInfo{
+					ID:         pinID,
+					ModuleName: testModuleIce,
+					ParentPin: []dpll.PinParentPin{
+						{ParentID: zlParentPinID},
+					},
+				}, nil
+			},
+			wantErr:          true,
+			wantErrSubstring: "no external DPLL parent found",
+		},
+		{
+			name: "parent pin query fails but next parent succeeds",
+			mockNetdevPin: func(_ string) (uint32, bool, error) {
+				return nicPinID, true, nil
+			},
+			mockPinQuerier: func(pinID uint32) (*dpll.PinInfo, error) {
+				switch pinID {
+				case nicPinID:
+					return &dpll.PinInfo{
+						ID:         nicPinID,
+						ModuleName: testModuleIce,
+						ParentPin: []dpll.PinParentPin{
+							{ParentID: zlParentPinID},
+							{ParentID: zlParentPinID2},
+						},
+					}, nil
+				case zlParentPinID:
+					return nil, fmt.Errorf("transient error")
+				case zlParentPinID2:
+					return &dpll.PinInfo{
+						ID:         zlParentPinID2,
+						ModuleName: testModuleZl3073x,
+						ClockID:    expectedClockID,
+					}, nil
+				default:
+					return nil, fmt.Errorf("unexpected pin ID %d", pinID)
+				}
+			},
+			wantClockID: expectedClockID,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			origNetdev := netdevDpllPinGetter
+			origQuerier := dpllPinQuerier
+			defer func() {
+				netdevDpllPinGetter = origNetdev
+				dpllPinQuerier = origQuerier
+			}()
+
+			netdevDpllPinGetter = tt.mockNetdevPin
+			if tt.mockPinQuerier != nil {
+				dpllPinQuerier = tt.mockPinQuerier
+			}
+
+			clockID, err := getClockIDFromPinParentChain("eno8303")
+			if tt.wantErr {
+				require.Error(t, err)
+				if tt.wantErrSubstring != "" {
+					assert.Contains(t, err.Error(), tt.wantErrSubstring)
+				}
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantClockID, clockID)
+		})
+	}
+}
+
+func TestGetClockIDFromInterfaceWithCache_E825Derivation(t *testing.T) {
+	const expectedClockID = uint64(3549816820761526005)
+
+	origNetdev := netdevDpllPinGetter
+	origQuerier := dpllPinQuerier
+	origCmd := commandExecutor
+	defer func() {
+		netdevDpllPinGetter = origNetdev
+		dpllPinQuerier = origQuerier
+		commandExecutor = origCmd
+	}()
+
+	setupE825PinMocks := func() {
+		netdevDpllPinGetter = func(_ string) (uint32, bool, error) {
+			return 5, true, nil
+		}
+		dpllPinQuerier = func(pinID uint32) (*dpll.PinInfo, error) {
+			if pinID == 5 {
+				return &dpll.PinInfo{
+					ID: 5, ModuleName: testModuleIce,
+					ParentPin: []dpll.PinParentPin{{ParentID: 18}},
+				}, nil
+			}
+			return &dpll.PinInfo{
+				ID: 18, ModuleName: testModuleZl3073x, ClockID: expectedClockID,
+			}, nil
+		}
+	}
+
+	t.Run("legacy detection: E825 via lspci uses pin chain when no hwDefPath", func(t *testing.T) {
+		mockCmd := NewMockCommandExecutor()
+		mockCmd.SetResponse("ethtool", []string{"-i", testIfaceE825}, "driver: ice\nbus-info: "+testBusE825)
+		mockCmd.SetResponse("lspci", []string{"-s", testBusE825}, testBusE825+" Ethernet controller: Intel Corporation Ethernet Controller E825-C")
+		commandExecutor = mockCmd
+		setupE825PinMocks()
+
+		clockID, err := GetClockIDFromInterfaceWithCache(testIfaceE825, "", nil)
+		require.NoError(t, err)
+		assert.Equal(t, expectedClockID, clockID)
+	})
+
+	t.Run("config-driven: hwDefPath with devlinkPinChain method", func(t *testing.T) {
+		mockCmd := NewMockCommandExecutor()
+		mockCmd.SetResponse("ethtool", []string{"-i", testIfaceE825}, "driver: ice\nbus-info: "+testBusE825)
+		commandExecutor = mockCmd
+		setupE825PinMocks()
+
+		clockID, err := GetClockIDFromInterfaceWithCache(testIfaceE825, HwDefIntelE825, nil)
+		require.NoError(t, err)
+		assert.Equal(t, expectedClockID, clockID)
+	})
+
+	t.Run("fallback to module-name scan on derivation failure", func(t *testing.T) {
+		mockCmd := NewMockCommandExecutor()
+		mockCmd.SetResponse("ethtool", []string{"-i", testIfaceE825}, "driver: ice\nbus-info: "+testBusE825)
+		commandExecutor = mockCmd
+
+		netdevDpllPinGetter = func(_ string) (uint32, bool, error) {
+			return 0, false, fmt.Errorf("IFLA_DPLL_PIN not supported")
+		}
+
+		mockPins := []*dpll.PinInfo{
+			{ID: 10, ModuleName: testModuleZl3073x, ClockID: expectedClockID, BoardLabel: "REF1P"},
+		}
+		SetupMockDpllPinsForTestsWithData(mockPins)
+		defer TeardownMockDpllPinsForTests()
+
+		clockID, err := GetClockIDFromInterfaceWithCache(testIfaceE825, HwDefIntelE825, nil)
+		require.NoError(t, err)
+		assert.Equal(t, expectedClockID, clockID)
+	})
+
+	t.Run("config-driven: direct method uses serial number", func(t *testing.T) {
+		mockCmd := NewMockCommandExecutor()
+		mockCmd.SetResponse("ethtool", []string{"-i", testIfaceE810}, "driver: ice\nbus-info: "+testBusE810)
+		mockCmd.SetResponse("devlink", []string{"dev", "info", "pci/" + testBusE810}, //nolint:goconst
+			"pci/"+testBusE810+":\n  serial_number 50-7c-6f-ff-ff-1f-b5-80")
+		commandExecutor = mockCmd
+
+		clockID, err := GetClockIDFromInterfaceWithCache(testIfaceE810, HwDefIntelE810, nil)
+		require.NoError(t, err)
+		assert.Equal(t, uint64(0x507c6fffff1fb580), clockID)
+	})
+}
+
+func TestGetClockIDResolutionMethod(t *testing.T) {
+	origCmd := commandExecutor
+	defer func() { commandExecutor = origCmd }()
+
+	t.Run("hwDefPath with devlinkPinChain returns devlinkPinChain", func(t *testing.T) {
+		method := getClockIDResolutionMethod(HwDefIntelE825, testBusE825)
+		assert.Equal(t, ClockIDMethodDevlinkPinChain, method)
+	})
+
+	t.Run("hwDefPath with direct returns direct", func(t *testing.T) {
+		method := getClockIDResolutionMethod(HwDefIntelE810, testBusE810)
+		assert.Equal(t, ClockIDMethodDirect, method)
+	})
+
+	t.Run("no hwDefPath with E825 lspci falls back to devlinkPinChain", func(t *testing.T) {
+		mockCmd := NewMockCommandExecutor()
+		mockCmd.SetResponse("lspci", []string{"-s", testBusE825}, "E825-C controller")
+		commandExecutor = mockCmd
+
+		method := getClockIDResolutionMethod("", testBusE825)
+		assert.Equal(t, ClockIDMethodDevlinkPinChain, method)
+	})
+
+	t.Run("no hwDefPath with non-E825 lspci falls back to direct", func(t *testing.T) {
+		mockCmd := NewMockCommandExecutor()
+		mockCmd.SetResponse("lspci", []string{"-s", testBusE810}, "E810-XXVDA4T controller")
+		commandExecutor = mockCmd
+
+		method := getClockIDResolutionMethod("", testBusE810)
+		assert.Equal(t, ClockIDMethodDirect, method)
+	})
+}

--- a/pkg/hardwareconfig/utils.go
+++ b/pkg/hardwareconfig/utils.go
@@ -1,7 +1,9 @@
 package hardwareconfig
 
 import (
+	"encoding/binary"
 	"fmt"
+	"net"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -10,9 +12,19 @@ import (
 	"time"
 
 	"github.com/golang/glog"
+	"github.com/mdlayher/netlink"
 
 	dpll "github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/dpll-netlink"
 	ptpv2alpha1 "github.com/k8snetworkplumbingwg/ptp-operator/api/v2alpha1"
+)
+
+// Stable kernel UAPI constants for DPLL pin resolution via RTM_GETLINK.
+const (
+	netlinkRoute    = 0  // NETLINK_ROUTE
+	rtmGetLink      = 18 // RTM_GETLINK
+	rtmNewLink      = 16 // RTM_NEWLINK
+	sizeofIfInfomsg = 16 // sizeof(struct ifinfomsg)
+	iflaDpllPin     = 65 // IFLA_DPLL_PIN
 )
 
 // DpllPinsGetter is a function type for getting DPLL pins
@@ -204,6 +216,144 @@ func GetClockIDFromInterface(iface string, hwDefPath string) (uint64, error) {
 	return GetClockIDFromInterfaceWithCache(iface, hwDefPath, nil)
 }
 
+// getNetdevDpllPin retrieves the DPLL pin ID associated with a network interface
+// via the kernel's IFLA_DPLL_PIN netlink attribute.
+func getNetdevDpllPin(ifname string) (uint32, bool, error) {
+	iface, err := net.InterfaceByName(ifname)
+	if err != nil {
+		return 0, false, fmt.Errorf("could not find interface %s: %w", ifname, err)
+	}
+
+	conn, err := netlink.Dial(netlinkRoute, nil)
+	if err != nil {
+		return 0, false, fmt.Errorf("failed to dial netlink route: %w", err)
+	}
+	defer conn.Close()
+
+	b := make([]byte, sizeofIfInfomsg)
+	binary.NativeEndian.PutUint32(b[4:8], uint32(iface.Index))
+
+	msg := netlink.Message{
+		Header: netlink.Header{
+			Type:  rtmGetLink,
+			Flags: netlink.Request,
+		},
+		Data: b,
+	}
+
+	replyMsgs, err := conn.Execute(msg)
+	if err != nil {
+		return 0, false, fmt.Errorf("failed to execute netlink request for %s: %w", ifname, err)
+	}
+
+	if len(replyMsgs) != 1 {
+		return 0, false, fmt.Errorf("expected 1 reply message for %s, got %d", ifname, len(replyMsgs))
+	}
+	reply := replyMsgs[0]
+
+	if reply.Header.Type != rtmNewLink {
+		return 0, false, fmt.Errorf("expected RTM_NEWLINK for %s, got %d", ifname, reply.Header.Type)
+	}
+	if len(reply.Data) < sizeofIfInfomsg {
+		return 0, false, fmt.Errorf("reply too short for %s", ifname)
+	}
+
+	ad, err := netlink.NewAttributeDecoder(reply.Data[sizeofIfInfomsg:])
+	if err != nil {
+		return 0, false, fmt.Errorf("failed to create attribute decoder: %w", err)
+	}
+
+	var dpllPinID uint32
+	var found bool
+
+	for ad.Next() {
+		if ad.Type() == iflaDpllPin {
+			ad.Nested(func(nad *netlink.AttributeDecoder) error {
+				for nad.Next() {
+					if nad.Type() == dpll.DpllPinID {
+						dpllPinID = nad.Uint32()
+						found = true
+						return nil
+					}
+				}
+				return nad.Err()
+			})
+			if found {
+				break
+			}
+		}
+	}
+
+	if adErr := ad.Err(); adErr != nil {
+		return 0, false, fmt.Errorf("attribute decoding failed for %s: %w", ifname, adErr)
+	}
+
+	return dpllPinID, found, nil
+}
+
+// netdevDpllPinGetter is swappable for testing.
+var netdevDpllPinGetter = getNetdevDpllPin
+
+// queryDpllPin queries a single DPLL pin by ID using a new DPLL netlink connection.
+func queryDpllPin(pinID uint32) (*dpll.PinInfo, error) {
+	conn, err := dpll.Dial(nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to dial DPLL: %w", err)
+	}
+	defer conn.Close()
+	return conn.DoPinGet(dpll.DoPinGetRequest{ID: pinID})
+}
+
+// dpllPinQuerier is swappable for testing.
+var dpllPinQuerier = queryDpllPin
+
+// getClockIDFromPinParentChain derives the external DPLL clock ID for a NIC
+// by tracing the DPLL pin parentage chain: NIC → DPLL pin → parent pins →
+// external DPLL module → clock ID.
+func getClockIDFromPinParentChain(ifname string) (uint64, error) {
+	glog.Infof("Attempting NIC-to-DPLL derivation for interface %s", ifname)
+
+	pinID, found, err := netdevDpllPinGetter(ifname)
+	if err != nil {
+		return 0, fmt.Errorf("failed to get DPLL pin for %s: %w", ifname, err)
+	}
+	if !found {
+		return 0, fmt.Errorf("no DPLL pin found for interface %s", ifname)
+	}
+	glog.Infof("NIC %s DPLL pin ID: %d", ifname, pinID)
+
+	nicPin, err := dpllPinQuerier(pinID)
+	if err != nil {
+		return 0, fmt.Errorf("failed to query DPLL pin %d: %w", pinID, err)
+	}
+
+	if len(nicPin.ParentPin) == 0 {
+		return 0, fmt.Errorf("DPLL pin %d for %s has no parent pins", pinID, ifname)
+	}
+
+	parentIDs := make([]uint32, len(nicPin.ParentPin))
+	for i, p := range nicPin.ParentPin {
+		parentIDs[i] = p.ParentID
+	}
+	glog.Infof("DPLL pin %d has %d parent pins: %v", pinID, len(nicPin.ParentPin), parentIDs)
+
+	for _, parent := range nicPin.ParentPin {
+		parentPin, parentErr := dpllPinQuerier(parent.ParentID)
+		if parentErr != nil {
+			glog.Warningf("Failed to query parent pin %d: %v, trying next", parent.ParentID, parentErr)
+			continue
+		}
+		if parentPin.ModuleName != nicPin.ModuleName {
+			glog.Infof("Found external DPLL parent pin %d (module=%s) with clock ID %d for interface %s",
+				parent.ParentID, parentPin.ModuleName, parentPin.ClockID, ifname)
+			return parentPin.ClockID, nil
+		}
+	}
+
+	return 0, fmt.Errorf("no external DPLL parent found for pin %d on %s (all parents share module %q)",
+		pinID, ifname, nicPin.ModuleName)
+}
+
 func getPERLAClockIDFromPinCache(cache *PinCache) (uint64, error) {
 	if cache == nil {
 		var cacheErr error
@@ -230,16 +380,43 @@ func getPERLAClockIDFromPinCache(cache *PinCache) (uint64, error) {
 	return 0, fmt.Errorf("no zl3073x DPLL found in pin cache")
 }
 
+// Clock ID resolution methods configurable via defaults.yaml clockIdTransformation.method
+const (
+	ClockIDMethodDirect          = "direct"          // PCI serial number bytes used directly (E810)
+	ClockIDMethodEUI64           = "eui64"           // EUI-64 transform of serial number
+	ClockIDMethodDevlinkPinChain = "devlinkPinChain" // Trace NIC DPLL pin parent chain (E825/zl3073x)
+)
+
+// getClockIDResolutionMethod loads the hardware defaults and returns the configured method.
+// Falls back to lspci-based detection when no hwDefPath is provided (legacy compatibility).
+func getClockIDResolutionMethod(hwDefPath string, busAddr string) string {
+	if hwDefPath != "" {
+		spec, err := LoadHardwareDefaults(hwDefPath, nil)
+		if err == nil && spec != nil && spec.ClockIDTransformation != nil && spec.ClockIDTransformation.Method != "" {
+			return spec.ClockIDTransformation.Method
+		}
+	}
+
+	// Legacy fallback: detect E825 via lspci when no hwDefPath or no method configured
+	lspciOutput, err := commandExecutor.Execute("lspci", "-s", busAddr)
+	if err == nil && strings.Contains(lspciOutput, "E825") {
+		glog.Infof("Legacy detection: E825 device on %s, using devlinkPinChain method", busAddr)
+		return ClockIDMethodDevlinkPinChain
+	}
+
+	return ClockIDMethodDirect
+}
+
 // GetClockIDFromInterfaceWithCache resolves clock ID with an optional pre-loaded pin cache.
-// This avoids repeatedly fetching the pin cache for PERLA workaround.
+// The resolution method is determined by the hardware definition's clockIdTransformation.method:
+//   - "direct" / "eui64": derive clock ID from NIC's PCI serial number (devlink)
+//   - "devlinkPinChain": trace NIC's DPLL pin parent chain to external DPLL module
 func GetClockIDFromInterfaceWithCache(iface string, hwDefPath string, pinCache *PinCache) (uint64, error) {
-	// Step 1: Get bus address using ethtool
 	ethtoolOutput, err := commandExecutor.Execute("ethtool", "-i", iface)
 	if err != nil {
 		return 0, fmt.Errorf("failed to get bus info for interface %s: %w", iface, err)
 	}
 
-	// Extract bus-info
 	busAddr := ""
 	for _, line := range strings.Split(ethtoolOutput, "\n") {
 		if strings.HasPrefix(line, "bus-info:") {
@@ -251,37 +428,47 @@ func GetClockIDFromInterfaceWithCache(iface string, hwDefPath string, pinCache *
 	}
 	glog.V(4).Infof("ClockID: iface=%s bus=%s hwDef=%s", iface, busAddr, hwDefPath)
 
-	// Step 2: PERLA workaround - Check if this is an E825 device
-	// For E825 devices, there's no direct NIC-DPLL association, so we look for the zl3073x DPLL
-	lspciOutput, err := commandExecutor.Execute("lspci", "-s", busAddr)
-	if err != nil {
-		return 0, fmt.Errorf("failed to run lspci -s %s, output: %s, err: %w", busAddr, lspciOutput, err)
-	}
+	method := getClockIDResolutionMethod(hwDefPath, busAddr)
+	glog.Infof("ClockID resolution for %s: method=%s (hwDef=%s)", iface, method, hwDefPath)
 
-	if strings.Contains(lspciOutput, "E825") {
-		glog.Infof("Detected E825 device on %s (interface %s), using PERLA workaround", busAddr, iface)
-		var clockID uint64
-		clockID, err = getPERLAClockIDFromPinCache(pinCache)
-		if err != nil {
-			return 0, fmt.Errorf("PERLA workaround: failed to get clock ID from pin cache: %v, falling back to serial number approach", err)
-		}
+	switch method {
+	case ClockIDMethodDevlinkPinChain:
+		return resolveClockIDViaPinChain(iface, pinCache)
+	default:
+		return resolveClockIDViaSerialNumber(iface, busAddr, hwDefPath)
+	}
+}
+
+// resolveClockIDViaPinChain traces the NIC's DPLL pin parent chain to find the
+// external DPLL clock ID. Falls back to module-name scan on failure.
+func resolveClockIDViaPinChain(iface string, pinCache *PinCache) (uint64, error) {
+	clockID, derivErr := getClockIDFromPinParentChain(iface)
+	if derivErr == nil {
 		return clockID, nil
 	}
+	glog.Warningf("NIC-to-DPLL derivation failed for %s: %v; falling back to module-name scan", iface, derivErr)
 
-	// Step 3: Standard approach - Get serial number using devlink
+	clockID, err := getPERLAClockIDFromPinCache(pinCache)
+	if err != nil {
+		return 0, fmt.Errorf("clock ID resolution failed for %s: derivation: %v, fallback: %w", iface, derivErr, err)
+	}
+	return clockID, nil
+}
+
+// resolveClockIDViaSerialNumber derives clock ID from the NIC's PCI serial number
+// using the hardware-specific transformer (direct or EUI-64).
+func resolveClockIDViaSerialNumber(iface, busAddr, hwDefPath string) (uint64, error) {
 	devlinkOutput, err := commandExecutor.Execute("devlink", "dev", "info", fmt.Sprintf("pci/%s", busAddr))
 	if err != nil {
 		return 0, fmt.Errorf("failed to get devlink info for bus %s: %w", busAddr, err)
 	}
 
-	// Extract serial number
 	serialNumber := ""
 	for _, line := range strings.Split(devlinkOutput, "\n") {
 		if strings.Contains(line, "serial_number") {
-			// Format is typically "  serial_number 64-4c-36-ff-ff-5c-4a-e8"
 			parts := strings.Fields(line)
 			if len(parts) >= 2 {
-				serialNumber = parts[len(parts)-1] // Get the last field
+				serialNumber = parts[len(parts)-1]
 				break
 			}
 		}
@@ -291,20 +478,13 @@ func GetClockIDFromInterfaceWithCache(iface string, hwDefPath string, pinCache *
 	}
 	glog.V(4).Infof("ClockID: iface=%s bus=%s serial=%s hwDef=%s", iface, busAddr, serialNumber, hwDefPath)
 
-	// Step 4: Select hardware-specific transformer based on hardware defaults (when provided)
-	if hwDefPath == "" {
-		glog.V(3).Infof("No hardware definition path provided for interface %s; using fallback transformer", iface)
-	}
 	transformer := getClockIDTransformer(hwDefPath)
-
-	// Step 5: Process serial number to get clock ID
 	clockID, err := transformer(serialNumber)
 	if err != nil {
 		return 0, fmt.Errorf("failed to parse serial number %s for interface %s: %w", serialNumber, iface, err)
 	}
 
 	glog.Infof("Resolved clock ID %#x for interface %s (bus: %s, serial: %s)", clockID, iface, busAddr, serialNumber)
-	glog.V(4).Infof("ClockID detail: iface=%s bus=%s serial=%s hwDef=%s clockID=%#x", iface, busAddr, serialNumber, hwDefPath, clockID)
 	return clockID, nil
 }
 

--- a/pkg/hardwareconfig/vendor_embedded.go
+++ b/pkg/hardwareconfig/vendor_embedded.go
@@ -4,6 +4,14 @@ import (
 	_ "embed"
 )
 
+// Hardware definition path constants used across the package.
+const (
+	HwDefIntelE810     = "intel/e810"
+	HwDefIntelE825     = "intel/e825"
+	HwDefDellXR8720t   = "dell/XR8720t"
+	HwDefHPEEL140Gen12 = "hpe/EL140-Gen12"
+)
+
 // Embedded hardware-vendor defaults baked into the binary.
 // Add new hardware models here as needed.
 
@@ -12,6 +20,12 @@ var intelE810DefaultsYAML []byte
 
 //go:embed hardware-vendor/intel/e825/defaults.yaml
 var intelE825DefaultsYAML []byte
+
+//go:embed hardware-vendor/dell/XR8720t/defaults.yaml
+var dellXR8720tDefaultsYAML []byte
+
+//go:embed hardware-vendor/hpe/EL140-Gen12/defaults.yaml
+var hpeEL140Gen12DefaultsYAML []byte
 
 //go:embed hardware-vendor/intel/e825/behavior-profiles.yaml
 var intelE825BehaviorProfilesYAML []byte
@@ -34,22 +48,24 @@ var hpeEL140Gen12DelaysYAML []byte
 // embeddedDefaults maps hwDefPath -> raw YAML contents.
 // Example key: "intel/e810"
 var embeddedDefaults = map[string][]byte{
-	"intel/e810": intelE810DefaultsYAML,
-	"intel/e825": intelE825DefaultsYAML,
+	HwDefIntelE810:     intelE810DefaultsYAML,
+	HwDefIntelE825:     intelE825DefaultsYAML,
+	HwDefDellXR8720t:   dellXR8720tDefaultsYAML,
+	HwDefHPEEL140Gen12: hpeEL140Gen12DefaultsYAML,
 }
 
 // embeddedBehaviorProfiles maps hwDefPath -> raw YAML contents for behavior profiles.
 // Example key: "intel/e825"
 var embeddedBehaviorProfiles = map[string][]byte{
-	"intel/e825":      intelE825BehaviorProfilesYAML,
-	"dell/XR8720t":    dellXR8720tBehaviorProfilesYAML,
-	"hpe/EL140-Gen12": hpeEL140Gen12BehaviorProfilesYAML,
+	HwDefIntelE825:     intelE825BehaviorProfilesYAML,
+	HwDefDellXR8720t:   dellXR8720tBehaviorProfilesYAML,
+	HwDefHPEEL140Gen12: hpeEL140Gen12BehaviorProfilesYAML,
 }
 
 // embeddedDelays maps hwDefPath -> raw YAML contents for delay compensation models.
 // Example key: "intel/e825"
 var embeddedDelays = map[string][]byte{
-	"intel/e825":      intelE825DelaysYAML,
-	"dell/XR8720t":    dellXR8720tDelaysYAML,
-	"hpe/EL140-Gen12": hpeEL140Gen12DelaysYAML,
+	HwDefIntelE825:     intelE825DelaysYAML,
+	HwDefDellXR8720t:   dellXR8720tDelaysYAML,
+	HwDefHPEEL140Gen12: hpeEL140Gen12DelaysYAML,
 }


### PR DESCRIPTION
Replace the hardcoded lspci E825 check with a config-driven clockIdTransformation.method field:
- "devlinkPinChain": trace NIC DPLL pin parent chain to external DPLL
- "direct"/"eui64": derive from PCI serial number (E810/E830)

The new derivation correctly resolves clock IDs on zl3073x platforms by following each NIC's own pin parentage. Falls back to the existing module-name scan on any failure.

Adds defaults.yaml with devlinkPinChain for intel/e825, dell/XR8720t, and hpe/EL140-Gen12.

/cc @nocturnalastro @lack @jzding @sebsoto 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for resolving hardware clock IDs through a new pin-chain-based method for compatible devices.
  * Expanded hardware defaults for additional Dell and HPE models, so they can use the updated clock resolution behavior.
  * Embedded the new vendor defaults so they are available at runtime.

* **Bug Fixes**
  * Improved clock ID detection and fallback handling for edge cases where the preferred resolution path is unavailable.
  * Updated existing device behavior to use the new resolution method where appropriate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->