### PR TITLE
Introduce clock objects and CEPv2 IPC sending

### DIFF
--- a/cmd/cloud-event-proxy/main.go
+++ b/cmd/cloud-event-proxy/main.go
@@ -54,6 +54,9 @@ func main() {
 	}
 	proxy := cep.NewCloudEventProxy(cache, ps)
 
+	if err := os.MkdirAll(filepath.Dir(socket), 0755); err != nil {
+		glog.Fatalf("failed to create socket directory: %v", err)
+	}
 	os.Remove(socket)
 	ln, err := net.Listen("unix", socket)
 	if err != nil {

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -129,6 +129,13 @@ func main() {
 		}
 	}
 
+	var enableCepV2 = false
+	if val, ok := os.LookupEnv("ENABLE_CEP_V2"); ok && val != "" {
+		if ret, parseErr := strconv.ParseBool(val); parseErr == nil {
+			enableCepV2 = ret
+		}
+	}
+
 	plugins := make([]string, 0)
 
 	if val, ok := os.LookupEnv("PLUGINS"); ok && val != "" {
@@ -184,6 +191,7 @@ func main() {
 		nodeName,
 		daemon.PtpNamespace,
 		stdoutToSocket,
+		enableCepV2,
 		kubeClient,
 		ptpClient,
 		ptpConfUpdate,
@@ -360,7 +368,7 @@ func runFullControllerMode(cfg *rest.Config, cp *cliParams, nodeName string, ptp
 			}
 		case sig := <-sigCh:
 			glog.Info("signal received, shutting down", sig)
-			closeProcessManager <- true
+			close(closeProcessManager)
 			cmSetup.mgrCancel() // Stop the controller manager
 			return
 		}
@@ -401,7 +409,7 @@ func runHybridMode(cfg *rest.Config, cp *cliParams, nodeName string, ptpConfUpda
 			}
 		case sig := <-sigCh:
 			glog.Info("signal received, shutting down", sig)
-			closeProcessManager <- true
+			close(closeProcessManager)
 			cmSetup.mgrCancel() // Stop the controller manager
 			return
 		}
@@ -428,7 +436,7 @@ func runLegacyMode(cp *cliParams, _ string, ptpConfUpdate *daemon.LinuxPTPConfUp
 			}
 		case sig := <-sigCh:
 			glog.Info("signal received, shutting down", sig)
-			closeProcessManager <- true
+			close(closeProcessManager)
 			return
 		}
 	}

--- a/pkg/cep/cep.go
+++ b/pkg/cep/cep.go
@@ -91,7 +91,7 @@ func buildDataValues(resourceAddr string, v ipc.Value) []event.DataValue {
 			ValueType: event.ENUMERATION,
 			Value:     val.State,
 		}
-		return []event.DataValue{dv, metricDV(resourceAddr, placeholderOffset)}
+		return []event.DataValue{dv, metricDV(resourceAddr, val.Offset)}
 	case ipc.GNSSStateValue:
 		dv := event.DataValue{
 			Resource:  resourceAddr,

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -37,6 +37,7 @@ import (
 	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/leap"
 
 	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/event"
+	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/ipc"
 	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/plugin"
 
 	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/logfilter"
@@ -62,6 +63,7 @@ const (
 	PTP4L_CONF_DIR                  = "/ptp4l-conf"
 	connectionRetryInterval         = 1 * time.Second
 	eventSocket                     = "/cloud-native/events.sock"
+	ipcSocket                       = "/var/run/ptp/ipc.sock"
 	ClockClassChangeIndicator       = "selected best master clock"
 	GPSDDefaultGNSSSerialPort       = "/dev/gnss0"
 	NMEASourceDisabledIndicator     = "nmea source timed out"
@@ -220,7 +222,7 @@ func (p *ProcessManager) SetTestData(name, msgTag string, ifaces config.IFaces) 
 	p.process[0].messageTag = msgTag
 	p.process[0].ifaces = ifaces
 	p.process[0].logParser = getParser(name)
-	p.process[0].handler = event.Init("test", false, eventSocket, eventChannel, closeManager, Offset, ClockState, ClockClassMetrics)
+	p.process[0].handler = event.Init("test", false, eventSocket, eventChannel, closeManager, Offset, ClockState, ClockClassMetrics, nil)
 	// Reset aliases for each test to avoid cross-case collisions.
 	alias.ClearAliases()
 	// Calculate aliases for the test interfaces to ensure proper aliasing
@@ -272,14 +274,15 @@ func (p *ProcessManager) EmitProcessStatusLogs() {
 	}
 }
 
-// EmitClockClassLogs ...
+// EmitClockClassLogs re-emits the last known clock class for each profile
+// that has an active PMC process. Called when a new consumer connects.
 func (p *ProcessManager) EmitClockClassLogs() {
 	for _, proc := range p.process {
 		if proc.name == ptp4lProcessName {
 			for _, dp := range proc.depProcess {
 				if dp.Name() == PMCProcessName {
 					pmc := dp.(*PMCProcess)
-					pmc.EmitClockClassLogs()
+					go p.ptpEventHandler.EmitClockClass(pmc.configFileName)
 				}
 			}
 		}
@@ -431,6 +434,7 @@ type Daemon struct {
 	namespace string
 	// write logs to socket, this will also send metrics to the socket
 	stdoutToSocket bool
+	enableCepV2    bool
 
 	// kubeClient allows interaction with Kubernetes, including the node we are running on.
 	kubeClient *kubernetes.Clientset
@@ -586,6 +590,7 @@ func New(
 	nodeName string,
 	namespace string,
 	stdoutToSocket bool,
+	enableCepV2 bool,
 	kubeClient *kubernetes.Clientset,
 	ptpClient *ptpclient.Clientset,
 	ptpUpdate *LinuxPTPConfUpdate,
@@ -603,12 +608,16 @@ func New(
 	InitializeOffsetMaps()
 	pluginManager, unknownPlugins := registerPlugins(plugins)
 	eventChannel := make(chan event.Event, 100)
+	cache := ipc.NewCache(100, enableCepV2)
 	pm := &ProcessManager{
 		process:         nil,
 		eventChannel:    eventChannel,
-		ptpEventHandler: event.Init(nodeName, stdoutToSocket, eventSocket, eventChannel, closeManager, Offset, ClockState, ClockClassMetrics),
+		ptpEventHandler: event.Init(nodeName, stdoutToSocket, eventSocket, eventChannel, closeManager, Offset, ClockState, ClockClassMetrics, cache),
 	}
 	tracker.processManager = pm
+	if enableCepV2 {
+		go ipc.NewWriter(ipcSocket, cache.Out(), closeManager).Run()
+	}
 
 	// Initialize fsnotify watcher for sa_file change detection
 	saFileWatch, err := fsnotify.NewWatcher()
@@ -633,6 +642,7 @@ func New(
 		nodeName:             nodeName,
 		namespace:            namespace,
 		stdoutToSocket:       stdoutToSocket,
+		enableCepV2:          enableCepV2,
 		kubeClient:           kubeClient,
 		ptpClient:            ptpClient,
 		ptpUpdate:            ptpUpdate,
@@ -784,6 +794,7 @@ func (dn *Daemon) applyNodePTPProfiles() error {
 	glog.Infof("in applyNodePTPProfiles - starting to apply %d node profiles", len(dn.ptpUpdate.NodeProfiles))
 
 	dn.stopAllProcesses()
+	dn.processManager.ptpEventHandler.RemoveAllClocks()
 	// All process should have been stopped,
 	// clear process in process manager.
 	// Assigning processManager.process to nil releases
@@ -1050,7 +1061,7 @@ func (dn *Daemon) applyNodePtpProfile(runID int, nodeProfile *ptpv1.PtpProfile) 
 		case TGM:
 			clockType = event.GM
 		case TBC:
-			clockType = event.BC
+			clockType = event.TBC
 			leadingNic = (*nodeProfile).PtpSettings["leadingInterface"]
 			if portsStr, ok := (*nodeProfile).PtpSettings["upstreamPort"]; ok {
 				upstreamPorts = strings.Split(portsStr, ",")
@@ -1076,7 +1087,15 @@ func (dn *Daemon) applyNodePtpProfile(runID int, nodeProfile *ptpv1.PtpProfile) 
 		clockType = ptp4lOutput.clock_type
 	}
 
+	clockCfgName := fmt.Sprintf("ptp4l.%d.config", runID)
+	if _, err = dn.processManager.ptpEventHandler.AddClock(clockCfgName, clockType); err != nil {
+		return fmt.Errorf("failed to register clock for profile %s: %v", *nodeProfile.Name, err)
+	}
+
 	for _, pProcess := range ptpProcesses {
+		if pProcess == chronydProcessName && !dn.enableCepV2 {
+			continue
+		}
 		controlledConfigFile := ""
 		switch pProcess {
 		case ptp4lProcessName:
@@ -1239,7 +1258,7 @@ func (dn *Daemon) applyNodePtpProfile(runID int, nodeProfile *ptpv1.PtpProfile) 
 		}
 
 		if pProcess == ptp4lProcessName {
-			if len(upstreamPorts) > 0 && clockType == event.BC {
+			if len(upstreamPorts) > 0 && clockType == event.TBC {
 				dprocess.tBCAttributes.trIfaceNames = upstreamPorts
 				dprocess.tBCAttributes.perPortState = make(map[string]event.PTPState, len(upstreamPorts))
 				for _, p := range upstreamPorts {
@@ -1280,7 +1299,7 @@ func (dn *Daemon) applyNodePtpProfile(runID int, nodeProfile *ptpv1.PtpProfile) 
 				if !clockTypeFound {
 					pmcClockType = string(clockType)
 				}
-				pmcProcess := NewPMCProcess(runID, dn.processManager.ptpEventHandler, pmcClockType)
+				pmcProcess := NewPMCProcess(runID, dn.processManager.eventChannel, pmcClockType)
 				pmcProcess.CmdInit()
 				// TODO addScheduling
 				dprocess.depProcess = append(dprocess.depProcess, pmcProcess)

--- a/pkg/daemon/daemon_internal_test.go
+++ b/pkg/daemon/daemon_internal_test.go
@@ -156,6 +156,7 @@ func applyTestProfile(t *testing.T, profile *ptpv1.PtpProfile) {
 		"test-node-name",
 		"openshift-ptp",
 		false,
+		false,
 		nil,
 		nil,
 		&LinuxPTPConfUpdate{
@@ -252,6 +253,7 @@ func Test_applyProfile_TBC(t *testing.T) {
 		"test-node-name",
 		"openshift-ptp",
 		false,
+		false,
 		nil,
 		nil,
 		&LinuxPTPConfUpdate{
@@ -305,6 +307,7 @@ func Test_applyProfile_TGM(t *testing.T) {
 	dn := New(
 		"test-node-name",
 		"openshift-ptp",
+		false,
 		false,
 		nil,
 		nil,
@@ -2925,19 +2928,15 @@ func TestLiveGateIntegration_TriggerLogsFailureRecovery(t *testing.T) {
 }
 
 func TestEmitClockClassLogs_EmitsWithNilParentDS(t *testing.T) {
-	// Create a minimal event handler (no socket needed — the event package
-	// tests already cover the socket write path via EmitClockClass).
 	eventChannel := make(chan event.Event)
 	closeCh := make(chan bool, 1)
-	handler := event.Init("testnode", false, "", eventChannel, closeCh, nil, nil, nil)
+	handler := event.Init("testnode", false, "", eventChannel, closeCh, nil, nil, nil, nil)
 
-	// Create a PMC process with parentDS = nil (the bug condition).
-	// Before the fix, EmitClockClassLogs skipped the call when parentDS was nil.
-	pmcProc := NewPMCProcess(0, handler, "OC")
+	pmcProc := NewPMCProcess(0, eventChannel, "OC")
 	assert.Nil(t, pmcProc.parentDS, "parentDS should be nil for this test")
 
-	// Create a ptp4l process with the PMC as a dependent process
 	pm := &ProcessManager{
+		ptpEventHandler: handler,
 		process: []*ptpProcess{
 			{
 				name:       ptp4lProcessName,
@@ -2946,10 +2945,6 @@ func TestEmitClockClassLogs_EmitsWithNilParentDS(t *testing.T) {
 		},
 	}
 
-	// EmitClockClassLogs should dispatch to pmc.EmitClockClassLogs()
-	// without panicking, even when parentDS is nil.
-	// EmitClockClass returns early (no clkSyncState data) but the key
-	// assertion is that the call is made at all — the old code skipped it.
 	assert.NotPanics(t, func() {
 		pm.EmitClockClassLogs()
 	}, "EmitClockClassLogs should not panic with nil parentDS")
@@ -3091,7 +3086,7 @@ func TestEmitLogsHandler_Ready_EmitsReplayThenOpensGate(t *testing.T) {
 					stopped:             false,
 				},
 			},
-			ptpEventHandler: event.Init("test-node", false, socketPath, nil, nil, nil, nil, nil),
+			ptpEventHandler: event.Init("test-node", false, socketPath, nil, nil, nil, nil, nil, nil),
 			daemon:          dn,
 		},
 	}

--- a/pkg/daemon/log_parsing.go
+++ b/pkg/daemon/log_parsing.go
@@ -51,6 +51,8 @@ func getParser(processName string) parser.MetricsExtractor {
 		return parser.NewPhc2SysExtractor()
 	case ts2phcProcessName:
 		return parser.NewTS2PHCExtractor()
+	case chronydProcessName:
+		return parser.NewChronydExtractor()
 	default:
 		glog.Errorf("No parser available for process: %s", processName)
 		return nil
@@ -120,7 +122,26 @@ func processParsedMetrics(process *ptpProcess, ptpMetrics *parser.Metrics) {
 		if ptpMetrics.Source == "master" && process.dn != nil {
 			process.dn.HandleDelayedPhc2sysStartup(process.name, ptpMetrics.Offset, process.nodeProfile.Name)
 		}
+		// sendPtp4lOffsetEvent handles T-BC: windowed offset averaging,
+		// rate-limited to 1/sec, using tBCAttributes. It no-ops for simple
+		// BC (offsetEventWindow is nil), so we send the event directly below.
 		process.sendPtp4lOffsetEvent()
+		if process.clockType == event.BC {
+			select {
+			case process.eventCh <- event.Event{
+				Source:    event.PTP4l,
+				CfgName:   configName,
+				IFace:     ptpMetrics.Iface,
+				ClockType: process.clockType,
+				Time:      time.Now().UnixMilli(),
+				Data: &event.PTPData{
+					State:  state,
+					Values: map[event.ValueType]interface{}{event.OFFSET: int64(ptpMetrics.Offset)},
+				},
+			}:
+			default:
+			}
+		}
 	case ts2phcProcessName:
 		if process.dn != nil {
 			process.dn.HandleDelayedPhc2sysStartup(process.name, ptpMetrics.Offset, process.nodeProfile.Name)
@@ -145,6 +166,36 @@ func processParsedMetrics(process *ptpProcess, ptpMetrics *parser.Metrics) {
 			Data: &event.PTPData{
 				State:  state,
 				Values: values,
+			},
+		}:
+		default:
+		}
+	case phc2sysProcessName:
+		select {
+		case process.eventCh <- event.Event{
+			Source:    event.PHC2SYS,
+			CfgName:   configName,
+			IFace:     ptpMetrics.Iface,
+			ClockType: process.clockType,
+			Time:      time.Now().UnixMilli(),
+			Data: &event.PTPData{
+				State:  state,
+				Values: map[event.ValueType]interface{}{event.OFFSET: int64(ptpMetrics.Offset)},
+			},
+		}:
+		default:
+		}
+	case chronydProcessName:
+		select {
+		case process.eventCh <- event.Event{
+			Source:    event.CHRONYD,
+			CfgName:   configName,
+			IFace:     ptpMetrics.Iface,
+			ClockType: process.clockType,
+			Time:      time.Now().UnixMilli(),
+			Data: &event.PTPData{
+				State:  state,
+				Values: map[event.ValueType]interface{}{event.OFFSET: int64(ptpMetrics.Offset)},
 			},
 		}:
 		default:

--- a/pkg/daemon/pmc.go
+++ b/pkg/daemon/pmc.go
@@ -7,7 +7,6 @@ import (
 	"sync"
 	"time"
 
-	fbprotocol "github.com/facebook/time/ptp/protocol"
 	"github.com/golang/glog"
 	expect "github.com/google/goexpect"
 	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/config"
@@ -24,13 +23,13 @@ const (
 )
 
 // NewPMCProcess creates a new PMC process instance for monitoring PTP events.
-func NewPMCProcess(runID int, eventHandler *event.EventHandler, clockType string) *PMCProcess {
+func NewPMCProcess(runID int, eventCh chan<- event.Event, clockType string) *PMCProcess {
 	return &PMCProcess{
 		configFileName:    fmt.Sprintf("ptp4l.%d.config", runID),
 		messageTag:        fmt.Sprintf("[ptp4l.%d.config:{level}]", runID),
 		monitorParentData: true,
 		parentDSCh:        make(chan protocol.ParentDataSet, 10),
-		eventHandler:      eventHandler,
+		eventCh:           eventCh,
 		clockType:         clockType,
 		getMonitorFn:      pmcPkg.GetPMCMontior,
 	}
@@ -51,7 +50,7 @@ type PMCProcess struct {
 	clockType         string
 	c                 net.Conn // guarded by lock
 	messageTag        string
-	eventHandler      *event.EventHandler
+	eventCh           chan<- event.Event
 
 	getMonitorFn func(string) (*expect.GExpect, <-chan error, error)
 }
@@ -137,11 +136,6 @@ func (pmc *PMCProcess) getMonitorSubcribeCommand() string {
 		btof(pmc.monitorParentData),
 		btof(pmc.monitorCMLDS),
 	)
-}
-
-// EmitClockClassLogs emits clock class change logs via the EventHandler's connection.
-func (pmc *PMCProcess) EmitClockClassLogs() {
-	go pmc.eventHandler.EmitClockClass(pmc.configFileName)
 }
 
 // CmdRun starts the PMC monitoring process.
@@ -280,23 +274,22 @@ func (pmc *PMCProcess) expectWorker(exp *expect.GExpect, parentDSCh chan<- proto
 
 func (pmc *PMCProcess) handleParentDS(parentDS protocol.ParentDataSet) {
 	if pmc.parentDS != nil && pmc.parentDS.Equal(&parentDS) {
-		glog.Infof("ParentDataSet unchanged, skipping processing for %s", pmc.configFileName)
+		glog.V(14).Infof("ParentDataSet unchanged, skipping processing for %s", pmc.configFileName)
 		return
 	}
-
 	glog.Info(parentDS.String())
-	oldParentDS := pmc.parentDS
 	pmc.parentDS = &parentDS
 
-	if pmc.clockType == TBC {
-		pmc.eventHandler.UpdateUpstreamParentDataSet(parentDS)
-	} else if oldParentDS == nil || oldParentDS.GrandmasterClockClass != parentDS.GrandmasterClockClass {
-		pmc.eventHandler.AnnounceClockClass(
-			fbprotocol.ClockClass(parentDS.GrandmasterClockClass),
-			fbprotocol.ClockAccuracy(parentDS.GrandmasterClockAccuracy),
-			pmc.configFileName,
-			event.ClockType(pmc.clockType),
-		)
+	select {
+	case pmc.eventCh <- event.Event{
+		Source:    event.PMC,
+		CfgName:   pmc.configFileName,
+		ClockType: event.ClockType(pmc.clockType),
+		Time:      time.Now().UnixMilli(),
+		Data:      &event.ParentDSData{ParentDataSet: parentDS},
+	}:
+	default:
+		glog.Warning("event channel full, dropping ParentDS update")
 	}
 }
 

--- a/pkg/daemon/pmc_internal_test.go
+++ b/pkg/daemon/pmc_internal_test.go
@@ -2,12 +2,14 @@ package daemon
 
 import (
 	expect "github.com/google/goexpect"
+	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/event"
 	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/protocol"
 )
 
 // NewTestPMCProcess creates a PMCProcess with injectable dependencies for testing.
 func NewTestPMCProcess(
 	configFileName, clockType string,
+	eventCh chan<- event.Event,
 	getMonitorFn func(string) (*expect.GExpect, <-chan error, error),
 ) *PMCProcess {
 	return &PMCProcess{
@@ -15,6 +17,7 @@ func NewTestPMCProcess(
 		messageTag:        "[" + configFileName + ":{level}]",
 		monitorParentData: true,
 		parentDSCh:        make(chan protocol.ParentDataSet, 10),
+		eventCh:           eventCh,
 		clockType:         clockType,
 		exitCh:            make(chan struct{}, 1),
 		getMonitorFn:      getMonitorFn,

--- a/pkg/daemon/pmc_test.go
+++ b/pkg/daemon/pmc_test.go
@@ -9,6 +9,7 @@ import (
 
 	expect "github.com/google/goexpect"
 	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/daemon"
+	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/event"
 	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/pmc"
 	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/protocol"
 )
@@ -122,7 +123,7 @@ func TestMonitorExitsViaCmdStop(t *testing.T) {
 	mock := newTestPMCMonitor(t, 50)
 	pmc.SetMock(mock.client())
 	defer pmc.ResetMock()
-	proc := daemon.NewTestPMCProcess("test.config", "T-BC", mock.getMonitor)
+	proc := daemon.NewTestPMCProcess("test.config", "T-BC", make(chan event.Event, 100), mock.getMonitor)
 	mock.pmc = proc
 
 	proc.CmdRun(false)
@@ -142,7 +143,7 @@ func TestMonitorNoOrphanAfterProcessDeath(t *testing.T) {
 	mock := newTestPMCMonitor(t, 50)
 	pmc.SetMock(mock.client())
 	defer pmc.ResetMock()
-	proc := daemon.NewTestPMCProcess("test.config", "T-BC", mock.getMonitor)
+	proc := daemon.NewTestPMCProcess("test.config", "T-BC", make(chan event.Event, 100), mock.getMonitor)
 	mock.pmc = proc
 
 	proc.CmdRun(false)
@@ -180,7 +181,7 @@ func TestCmdStopIdempotent(t *testing.T) {
 	mock := newTestPMCMonitor(t, 50)
 	pmc.SetMock(mock.client())
 	defer pmc.ResetMock()
-	proc := daemon.NewTestPMCProcess("test.config", "T-BC", mock.getMonitor)
+	proc := daemon.NewTestPMCProcess("test.config", "T-BC", make(chan event.Event, 100), mock.getMonitor)
 	mock.pmc = proc
 
 	proc.CmdRun(false)
@@ -202,7 +203,7 @@ func TestCmdStopBeforeCmdRun(t *testing.T) {
 	mock := newTestPMCMonitor(t, 50)
 	pmc.SetMock(mock.client())
 	defer pmc.ResetMock()
-	proc := daemon.NewTestPMCProcess("test.config", "T-BC", mock.getMonitor)
+	proc := daemon.NewTestPMCProcess("test.config", "T-BC", make(chan event.Event, 100), mock.getMonitor)
 	mock.pmc = proc
 
 	proc.CmdStop()

--- a/pkg/dpll/dpll_test.go
+++ b/pkg/dpll/dpll_test.go
@@ -183,7 +183,7 @@ func TestDpllConfig_MonitorProcessGNSS(t *testing.T) {
 	eChannel := make(chan event.Event, 10)
 	closeChn := make(chan bool)
 	// event has to be running before dpll is started
-	eventProcessor := event.Init("node", false, "/tmp/go.sock", eChannel, closeChn, nil, nil, nil)
+	eventProcessor := event.Init("node", false, "/tmp/go.sock", eChannel, closeChn, nil, nil, nil, nil)
 	d := dpll.NewDpll(clockid, 10, 2, 5, "ens01",
 		[]event.EventSource{event.GNSS}, dpll.MOCK, map[string]map[string]string{}, 0, 0, 0)
 	d.CmdInit()
@@ -225,7 +225,7 @@ func TestDpllConfig_MonitorProcessPPS(t *testing.T) {
 	eChannel := make(chan event.Event, 10)
 	closeChn := make(chan bool)
 	// event has to be running before dpll is started
-	eventProcessor := event.Init("node", false, "/tmp/go.sock", eChannel, closeChn, nil, nil, nil)
+	eventProcessor := event.Init("node", false, "/tmp/go.sock", eChannel, closeChn, nil, nil, nil, nil)
 	d := dpll.NewDpll(clockid, 10, 2, 5, "ens01",
 		[]event.EventSource{event.GNSS}, dpll.MOCK, map[string]map[string]string{}, 0, 0, 0)
 	d.CmdInit()
@@ -265,7 +265,7 @@ func TestDpllConfig_MonitorProcessPartial(t *testing.T) {
 	eChannel := make(chan event.Event, 10)
 	closeChn := make(chan bool)
 	// event has to be running before dpll is started
-	eventProcessor := event.Init("node", false, "/tmp/go.sock", eChannel, closeChn, nil, nil, nil)
+	eventProcessor := event.Init("node", false, "/tmp/go.sock", eChannel, closeChn, nil, nil, nil, nil)
 	d := dpll.NewDpll(clockid, 10, 2, 5, "ens01",
 		[]event.EventSource{event.GNSS}, dpll.MOCK, map[string]map[string]string{}, 0, 0, dpll.FlagOnlyPhaseStatus)
 	d.CmdInit()

--- a/pkg/event/clock.go
+++ b/pkg/event/clock.go
@@ -1,0 +1,150 @@
+package event
+
+import (
+	"context"
+	"fmt"
+
+	fbprotocol "github.com/facebook/time/ptp/protocol"
+	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/ipc"
+	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/pmc"
+	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/protocol"
+)
+
+// Clock represents a PTP clock instance tied to a specific config profile.
+type Clock interface {
+	ClockType() ClockType
+	ConfigName() string
+	ClockClass() fbprotocol.ClockClass
+	SystemClockUpdate(state PTPState)
+	ParentDSUpdate(parentDS protocol.ParentDataSet)
+}
+
+// clockIO is the I/O interface that clock objects use for external side effects.
+type clockIO interface {
+	Lock()
+	Unlock()
+	emitClockClass(clockClass fbprotocol.ClockClass, cfgName string)
+	sendIPC(msg ipc.Message)
+	getGMSettings(cfgName string) (protocol.GrandmasterSettings, error)
+	setGMSettings(cfgName string, g protocol.GrandmasterSettings) error
+	setExternalGMPropertiesNP(cfgName string, egp protocol.ExternalGrandmasterProperties) error
+	getParentTimeAndCurrentDS(cfgName string) (pmc.ParentTimeCurrentDS, error)
+	getUtcOffset() int
+}
+
+// GMClock is a Grand Master clock instance.
+// It owns its sync state and emits IPC messages via clockIO.
+type GMClock struct {
+	cfgName                string
+	io                     clockIO
+	data                   []*Data
+	syncState              clockSyncState
+	overallSyncState       PTPState
+	osClockState           PTPState
+	gnssState              PTPState
+	announcedClockClass    fbprotocol.ClockClass
+	announcedClockAccuracy fbprotocol.ClockAccuracy
+	lastLoggedState        PTPState
+}
+
+// ClockType returns GM.
+func (c *GMClock) ClockType() ClockType { return GM }
+
+func (c *GMClock) ClockClass() fbprotocol.ClockClass {
+	return c.syncState.clockClass
+}
+
+// ConfigName returns the config profile name.
+func (c *GMClock) ConfigName() string { return c.cfgName }
+
+// TBCClock is a Boundary Clock instance.
+// It owns its sync state and event data. State-machine methods
+// (addEvent, updateBCState, helpers) use only struct fields.
+// I/O methods (announceLocalData, etc.) use the injected clockIO interface.
+type TBCClock struct {
+	cfgName                string
+	io                     clockIO
+	syncState              clockSyncState
+	overallSyncState       PTPState
+	osClockState           PTPState
+	announcedClockClass    fbprotocol.ClockClass
+	announcedClockAccuracy fbprotocol.ClockAccuracy
+	data                   []*Data
+	leadingClockData       *LeadingClockParams
+	downstreamCancel       context.CancelFunc
+}
+
+// ClockType returns TBC.
+func (c *TBCClock) ClockType() ClockType { return TBC }
+
+func (c *TBCClock) ClockClass() fbprotocol.ClockClass {
+	return c.syncState.clockClass
+}
+
+// ConfigName returns the config profile name.
+func (c *TBCClock) ConfigName() string { return c.cfgName }
+
+// OCClock is an Ordinary Clock instance.
+type OCClock struct {
+	cfgName string
+}
+
+// ClockType returns OC.
+func (c *OCClock) ClockType() ClockType { return OC }
+
+func (c *OCClock) ClockClass() fbprotocol.ClockClass { return c.ClockClass() }
+
+func (c *OCClock) SystemClockUpdate(_ PTPState) {}
+
+func (c *OCClock) ParentDSUpdate(_ protocol.ParentDataSet) {}
+
+// ConfigName returns the config profile name.
+func (c *OCClock) ConfigName() string { return c.cfgName }
+
+// newClock creates the appropriate Clock implementation for the given clock type.
+func newClock(cfgName string, clockType ClockType, io clockIO) (Clock, error) {
+	switch clockType {
+	case GM:
+		return &GMClock{
+			cfgName: cfgName,
+			io:      io,
+			syncState: clockSyncState{
+				state:         PTP_NOTSET,
+				clockClass:    protocol.ClockClassUninitialized,
+				clockAccuracy: fbprotocol.ClockAccuracyUnknown,
+			},
+			overallSyncState:       PTP_NOTSET,
+			osClockState:           PTP_NOTSET,
+			gnssState:              PTP_NOTSET,
+			announcedClockClass:    protocol.ClockClassUninitialized,
+			announcedClockAccuracy: fbprotocol.ClockAccuracyUnknown,
+		}, nil
+	case TBC:
+		return &TBCClock{
+			cfgName: cfgName,
+			io:      io,
+			syncState: clockSyncState{
+				state:         PTP_NOTSET,
+				clockClass:    protocol.ClockClassUninitialized,
+				clockAccuracy: fbprotocol.ClockAccuracyUnknown,
+			},
+			overallSyncState:       PTP_NOTSET,
+			osClockState:           PTP_NOTSET,
+			announcedClockClass:    protocol.ClockClassUninitialized,
+			announcedClockAccuracy: fbprotocol.ClockAccuracyUnknown,
+			leadingClockData:       newLeadingClockParams(),
+		}, nil
+	case BC:
+		return &BCClock{
+			cfgName:          cfgName,
+			io:               io,
+			syncState:        PTP_NOTSET,
+			overallSyncState: PTP_NOTSET,
+			osClockState:     PTP_NOTSET,
+		}, nil
+	case OC:
+		return &OCClock{cfgName: cfgName}, nil
+	default:
+		return nil, fmt.Errorf("unsupported clock type %q for config %s", clockType, cfgName)
+	}
+}

--- a/pkg/event/event.go
+++ b/pkg/event/event.go
@@ -12,15 +12,15 @@ import (
 
 	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/alias"
 	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/debug"
+	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/ipc"
+	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/leap"
 	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/parser"
-	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/utils"
-
-	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/pmc"
+	pmc "github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/pmc"
 	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/protocol"
+	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/utils"
 
 	fbprotocol "github.com/facebook/time/ptp/protocol"
 	"github.com/golang/glog"
-	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/leap"
 	parserconstants "github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/parser/constants"
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -75,17 +75,13 @@ type ClockClassRequest struct {
 	clockAccuracy fbprotocol.ClockAccuracy
 }
 
-var (
-	//  make sure only one clock class update is tried if it fails next  try will pass
-	// this will also stop flooding
-	clockClassRequestCh = make(chan ClockClassRequest, 1)
-)
-
 const (
 	// GM ..
 	GM ClockType = "GM"
 	// BC ...
 	BC ClockType = "BC"
+	// TBC is a Telco Boundary Clock (T-BC) with DPLL, ts2phc, and E810 plugin.
+	TBC ClockType = "T-BC"
 	// OC ...
 	OC ClockType = "OC"
 	// ClockUnset ...
@@ -112,7 +108,9 @@ const (
 	PHC2SYS    EventSource = "phc2sys"
 	PPS        EventSource = "1pps"
 	SYNCE      EventSource = "synce4l"
+	CHRONYD    EventSource = "chronyd"
 	MONITORING EventSource = "monitoring"
+	PMC        EventSource = "pmc"
 )
 
 // PTPState ...
@@ -165,27 +163,23 @@ type clockSyncState struct {
 // EventHandler ... event handler to process events
 type EventHandler struct {
 	sync.Mutex
-	nodeName           string
-	stdoutSocket       string
-	stdoutToSocket     bool
-	processChannel     <-chan Event
-	closeCh            chan bool
-	conn               net.Conn   // event socket connection, guarded by connMu
-	connMu             sync.Mutex // separate mutex for conn to avoid deadlocks with embedded sync.Mutex
-	reconnectMu        sync.Mutex // serializes reconnection attempts to prevent leaked connections
-	data               map[string][]*Data
-	offsetMetric       *prometheus.GaugeVec
-	clockMetric        *prometheus.GaugeVec
-	clockClassMetric   *prometheus.GaugeVec
-	clockClass         fbprotocol.ClockClass
-	clockAccuracy      fbprotocol.ClockAccuracy
-	clkSyncState       map[string]*clockSyncState
-	downstreamCancel   map[string]context.CancelFunc // cancels in-flight downstream update goroutines per config
-	outOfSpec          bool                          // is offset out of spec, used for Lost Source,In Spec and OPut of Spec state transitions
-	frequencyTraceable bool                          // will be tru if synce is traceable
-	ReduceLog          bool                          // reduce logs for every announce
-	LeadingClockData   *LeadingClockParams
-	portRole           map[string]map[string]*parser.PTPEvent
+	nodeName         string
+	stdoutSocket     string
+	stdoutToSocket   bool
+	processChannel   <-chan Event
+	closeCh          chan bool
+	conn             net.Conn   // event socket connection, guarded by connMu
+	connMu           sync.Mutex // separate mutex for conn to avoid deadlocks with embedded sync.Mutex
+	reconnectMu      sync.Mutex // serializes reconnection attempts to prevent leaked connections
+	data             map[string][]*Data
+	offsetMetric     *prometheus.GaugeVec
+	clockMetric      *prometheus.GaugeVec
+	clockClassMetric *prometheus.GaugeVec
+	ReduceLog        bool // reduce logs for every announce
+	portRole         map[string]map[string]*parser.PTPEvent
+	clocks           map[string]Clock // cfgName → Clock
+	osClockState     PTPState
+	ipcCache         *ipc.Cache
 }
 
 // getConn returns the current event socket connection under lock.
@@ -231,6 +225,13 @@ type PTPData struct {
 
 func (*PTPData) eventData() {}
 
+// ParentDSData carries a PARENT_DATA_SET update from the PMC poller.
+type ParentDSData struct {
+	ParentDataSet protocol.ParentDataSet
+}
+
+func (*ParentDSData) eventData() {}
+
 // Event carries a process event on the event channel.
 // Common fields are inline; type-specific data is in Data.
 type Event struct {
@@ -246,26 +247,73 @@ type Event struct {
 
 // Init ... initialize event manager
 func Init(nodeName string, stdOutToSocket bool, socketName string, processChannel chan Event, closeCh chan bool,
-	offsetMetric *prometheus.GaugeVec, clockMetric *prometheus.GaugeVec, clockClassMetric *prometheus.GaugeVec) *EventHandler {
+	offsetMetric *prometheus.GaugeVec, clockMetric *prometheus.GaugeVec, clockClassMetric *prometheus.GaugeVec,
+	ipcCache *ipc.Cache) *EventHandler {
 	return &EventHandler{
-		nodeName:           nodeName,
-		stdoutSocket:       socketName,
-		stdoutToSocket:     stdOutToSocket,
-		closeCh:            closeCh,
-		processChannel:     processChannel,
-		data:               map[string][]*Data{},
-		clockMetric:        clockMetric,
-		offsetMetric:       offsetMetric,
-		clockClassMetric:   clockClassMetric,
-		clockClass:         protocol.ClockClassUninitialized,
-		clkSyncState:       map[string]*clockSyncState{},
-		downstreamCancel:   map[string]context.CancelFunc{},
-		outOfSpec:          false,
-		frequencyTraceable: false,
-		ReduceLog:          true,
-		LeadingClockData:   newLeadingClockParams(),
-		portRole:           map[string]map[string]*parser.PTPEvent{},
+		nodeName:         nodeName,
+		stdoutSocket:     socketName,
+		stdoutToSocket:   stdOutToSocket,
+		closeCh:          closeCh,
+		processChannel:   processChannel,
+		data:             map[string][]*Data{},
+		clockMetric:      clockMetric,
+		offsetMetric:     offsetMetric,
+		clockClassMetric: clockClassMetric,
+		ReduceLog:        true,
+		portRole:         map[string]map[string]*parser.PTPEvent{},
+		clocks:           map[string]Clock{},
+		osClockState:     PTP_NOTSET,
+		ipcCache:         ipcCache,
 	}
+}
+
+// AddClock creates a Clock for the given config and registers it.
+// If a clock is already registered for cfgName it is replaced.
+func (e *EventHandler) AddClock(cfgName string, clockType ClockType) (Clock, error) {
+	clk, err := newClock(cfgName, clockType, e)
+	if err != nil {
+		return nil, err
+	}
+	e.Lock()
+	defer e.Unlock()
+	if prev, exists := e.clocks[cfgName]; exists {
+		glog.Warningf("AddClock: replacing existing %s clock for config %s", prev.ClockType(), cfgName)
+	}
+	e.clocks[cfgName] = clk
+	// BC/OC events may arrive with ts2phc.{runID}.config as cfgName,
+	// so register under that key too.
+	if clockType == BC || clockType == TBC || clockType == OC || clockType == GM {
+		ts2phcName := strings.Replace(cfgName, "ptp4l.", "ts2phc.", 1)
+		e.clocks[ts2phcName] = clk
+	}
+	glog.Infof("AddClock: registered %s clock for config %s", clockType, cfgName)
+	return clk, nil
+}
+
+// RemoveAllClocks tears down all registered clocks and cleans up associated state.
+func (e *EventHandler) RemoveAllClocks() {
+	e.Lock()
+	for cfgName := range e.clocks {
+		delete(e.portRole, cfgName)
+	}
+	e.osClockState = PTP_NOTSET
+
+	for cfgName := range e.clocks {
+		e.unregisterMetrics(cfgName, "")
+		delete(e.data, cfgName)
+	}
+	e.clocks = map[string]Clock{}
+	e.Unlock()
+
+	debug.ClearState()
+	glog.Info("RemoveAllClocks: all clocks removed and state cleaned up")
+}
+
+// GetClock returns the Clock registered for the given config name, or nil.
+func (e *EventHandler) GetClock(cfgName string) Clock {
+	e.Lock()
+	defer e.Unlock()
+	return e.clocks[cfgName]
 }
 
 // GetLogData returns a formatted log line for the event.
@@ -308,307 +356,6 @@ func formatPTPLogData(source EventSource, cfgName, iface string, state PTPState,
 		time.Now().Unix(), cfgName, iface, strings.Join(logData, " "), state)
 }
 
-// getGMState ... get lowest state of all the interfaces
-/*
-GNSS State + DPLL State= DPLL State
-DPLL STate + Ts2phc State =GM State
-----------------------------------------------------------------
-GNSS| Mode              | Offset   | State
-1.  | 0-2(Source LOST)  | in Range | FREERUN
-2.  | 0-2(Source LOST ) | out Range| FREERUN
-3.  | 3                 | in Range | LOCKED
-4.  | 3                 | out Range| FREERUN
-----------------------------------------------------------------
-DPLL | Frequency/Phase  	|  Offset  | GNSS STATE |  DPLL PTP STATE
-------------------------------------------------------------------
-1.  | -1/1/0           	| in Range |  LOCKED    | FREERUN
-2.  | -1/1/0           	| out Range|  FREERUN   | FREERUN
------------------------------------------------------------------
-3.  |  2 (LOCKED)       	| in Range |  LOCKED      | LOCKED
-4.  |  2 (LOCKED)       	| in Range |  FREERUN     | LOCKED
------------------------------------------------------------------
-SL :-> Source Lost
-------------------------------------------------------------------------------------------
-DPLL| Frequency/Phase      | Offset      | GNSS STATE               | DPLL PTP State
-------------------------------------------------------------------------------------------
-5   | 2 (LOCKED)           | Out Range   | All State                | FREERUN
-6.  | 3 (LOCK_ACQ_HOLDOVER)| In Range    | LOCKED                   | LOCKED
-7.  | 3 (LOCK_ACQ_HOLDOVER)| In/Out Range| FREERUN (SL)             | FREERUN
-8.  | 3 (LOCK_ACQ_HOLDOVER)| Out Range   | LOCKED                   | FREERUN
-*9. | 3 (LOCK_ACQ_HOLDOVER)| In/Out Range| FREERUN (SL)             | HOLDOVER
-------------------------------------------------------------------------------------------
-*10.| 4 (HOLDOVER)		| IN/Out Range   | FREERUN (SL)	            | HOLDOVER
-*11.| 4 (HOLDOVER)		| in/Out Range   | FREERUN (SL)             | AFTER TIME OUT
-                                                                    FREERUN OUT OF SPEC
-
-12. | 4 (HOLDOVER)		| in Range	     | LOCKED                   | LOCKED
-13. | 4 (HOLDOVER)		| Out Range	     | LOCKED                   | FREERUN
-14. | 4 (HOLDOVER)		| in Range       | FREERUN (SL)             | LOCKED
-15. | 4 (HOLDOVER)		| Out Range      | FREERUN (SL)             | FREERUN
-------------------------------------------------------------------------------------------
-FINAL GM STATE  *SL = Source Lost
----------------------------------------------------------------------------------------------
-| DPLL PTP State        | GNSS PTP STATE    | TS2PHC PTP STATE | GM STATE  | Clock Class
----------------------------------------------------------------------------------------------
-| FREERUN               | NA                | NA                | FREERUN  | 248
-| HOLDOVER IN SPEC      | NA                | NA                | HOLDOVER | 7
-| FREERUN OUT OF SPEC   | NA                | NA                | FREERUN  | 140
-| LOCKED                | LOCKED            | LOCKED            | LOCKED   | 6
-| LOCKED                | LOCKED            | FREERUN           | FREERUN  | 248
-| LOCKED                | *FREERUN (SL)     | LOCKED            | NA       | Wait for DPLL
-                                                                           | to move to HOLDOVER
-
-| LOCKED                | *FREERUN (SL)     | FREERUN           | NA       | Wait for DPLL
-                                                                           |to move to HOLDOVER
-
-| LOCKED                | *FREERUN(offset)  | LOCKED            | FREERUN  | 248
-| LOCKED                | *FREERUN(offset)  | FREERUN           | FREERUN  | 248
- Final GM State When DPLL not available
----------------------------------------------------------------------------------------------
-DPLL PTP State |  GNSS PTP STATE  |	TS2PHC PTP STATE| GM STATE | Clock Class
----------------------------------------------------------------------------------------------
-| NA           |  FREERUN         |	LOCKED          | FREERUN  | 248
-| NA           |  FREERUN         |	FREERUN         | FREERUN  | 248
-| NA           |  LOCKED          |	FREERUN         | FREERUN  | 248
-| NA           |  LOCKED          |	LOCKED          | LOCKED   | 6
-
-*/
-func (e *EventHandler) updateGMState(cfgName string) clockSyncState {
-	dpllState := PTP_NOTSET
-	gnssState := PTP_FREERUN
-	ts2phcState := PTP_FREERUN
-	syncSrcLost := e.isSourceLost(cfgName)
-	leadingInterface := e.getLeadingInterface(cfgName)
-	if leadingInterface == LEADING_INTERFACE_UNKNOWN {
-		glog.Infof("Leading interface is not yet identified, clock state reporting delayed.")
-		return clockSyncState{leadingIFace: leadingInterface}
-	}
-
-	if _, ok := e.clkSyncState[cfgName]; !ok {
-		e.clkSyncState[cfgName] = &clockSyncState{
-			state:         PTP_FREERUN,
-			clockClass:    protocol.ClockClassUninitialized,
-			clockAccuracy: fbprotocol.ClockAccuracyUnknown,
-			sourceLost:    syncSrcLost,
-			leadingIFace:  leadingInterface,
-		}
-	}
-	// right now if GPS offset || mode is bad then consider source lost
-	e.clkSyncState[cfgName].sourceLost = syncSrcLost
-	e.clkSyncState[cfgName].leadingIFace = leadingInterface
-	if data, ok := e.data[cfgName]; ok {
-		for _, d := range data {
-			switch d.ProcessName {
-			case DPLL:
-				dpllState = d.State
-				if e.hasNonLeadingDPLLFault(cfgName, leadingInterface) {
-					dpllState = PTP_FREERUN
-				}
-			case GNSS:
-				gnssState = d.State
-				// expecting to have at least one interface
-			case TS2PHCProcessName:
-				ts2phcState = d.State
-				if parser.NoSourceTSCount == 2 {
-					ts2phcState = PTP_FREERUN
-				}
-			}
-		}
-	} else {
-		e.clkSyncState[cfgName].state = PTP_FREERUN
-		e.clkSyncState[cfgName].clockClass = protocol.ClockClassFreerun
-		e.clkSyncState[cfgName].clockAccuracy = fbprotocol.ClockAccuracyUnknown
-		e.clkSyncState[cfgName].lastLoggedTime = time.Now().Unix()
-		e.clkSyncState[cfgName].leadingIFace = leadingInterface
-		e.clkSyncState[cfgName].clkLog = fmt.Sprintf("%s[%d]:[%s] %s T-GM-STATUS %s\n", GM, e.clkSyncState[cfgName].lastLoggedTime, cfgName, leadingInterface, e.clkSyncState[cfgName].state)
-		return *e.clkSyncState[cfgName]
-	}
-	e.clkSyncState[cfgName].leadingIFace = leadingInterface
-	switch dpllState {
-	case PTP_FREERUN: // This is OVER ALL State with HOLDOVER having the highest priority
-		// add check so that clock class won't change if GM was in HOLDOVER state
-		e.clkSyncState[cfgName].state = dpllState
-		// T-GM or T-BC in free-run mode
-		if e.outOfSpec && e.frequencyTraceable {
-			// T-GM in holdover, out of holdover specification
-			e.clkSyncState[cfgName].clockClass = protocol.ClockClassOutOfSpec
-		} else { // from holdover it goes to out of spec to free run
-			// T-GM or T-BC in free-run mode
-			e.clkSyncState[cfgName].clockClass = protocol.ClockClassFreerun
-		}
-		e.clkSyncState[cfgName].clockAccuracy = fbprotocol.ClockAccuracyUnknown
-	case PTP_HOLDOVER:
-		e.clkSyncState[cfgName].state = dpllState
-		// T-GM in holdover, within holdover specification
-		e.clkSyncState[cfgName].clockClass = fbprotocol.ClockClass7
-	case PTP_LOCKED, PTP_NOTSET: // consider DPLL is locked if DPLL is not available
-		switch gnssState {
-		case PTP_LOCKED:
-			switch ts2phcState {
-			case PTP_FREERUN:
-				e.clkSyncState[cfgName].state = PTP_FREERUN
-				// T-GM or T-BC in free-run mode
-				e.clkSyncState[cfgName].clockClass = protocol.ClockClassFreerun
-				e.clkSyncState[cfgName].clockAccuracy = fbprotocol.ClockAccuracyUnknown
-			case PTP_LOCKED:
-				e.clkSyncState[cfgName].state = PTP_LOCKED
-				// T-GM connected to a PRTC in locked mode (e.g., PRTC traceable to GNSS)
-				e.clkSyncState[cfgName].clockClass = fbprotocol.ClockClass6
-				e.clkSyncState[cfgName].clockAccuracy = fbprotocol.ClockAccuracyNanosecond100
-			case PTP_HOLDOVER:
-				e.clkSyncState[cfgName].state = PTP_HOLDOVER
-				e.clkSyncState[cfgName].clockClass = fbprotocol.ClockClass7
-			}
-		case PTP_FREERUN:
-			if syncSrcLost {
-				switch ts2phcState {
-				case PTP_LOCKED:
-				case PTP_FREERUN:
-					e.clkSyncState[cfgName].state = PTP_FREERUN
-				// stay with last GM state and wait for DPLL to move to HOLDOVER
-				case PTP_HOLDOVER:
-					e.clkSyncState[cfgName].state = PTP_HOLDOVER
-					e.clkSyncState[cfgName].clockClass = fbprotocol.ClockClass7
-				}
-			} else {
-				switch ts2phcState {
-				case PTP_FREERUN, PTP_LOCKED, PTP_UNKNOWN, PTP_NOTSET:
-					e.clkSyncState[cfgName].state = PTP_FREERUN
-					// T-GM or T-BC in free-run mode
-					e.clkSyncState[cfgName].clockClass = protocol.ClockClassFreerun
-					e.clkSyncState[cfgName].clockAccuracy = fbprotocol.ClockAccuracyUnknown
-				}
-			}
-		}
-	default:
-		switch gnssState {
-		case PTP_LOCKED:
-			switch ts2phcState {
-			case PTP_FREERUN, PTP_UNKNOWN, PTP_NOTSET:
-				e.clkSyncState[cfgName].state = PTP_FREERUN
-				// T-GM or T-BC in free-run mode
-				e.clkSyncState[cfgName].clockClass = protocol.ClockClassFreerun
-				e.clkSyncState[cfgName].clockAccuracy = fbprotocol.ClockAccuracyUnknown
-			case PTP_LOCKED:
-				e.clkSyncState[cfgName].state = PTP_LOCKED
-				// T-GM connected to a PRTC in locked mode (e.g., PRTC traceable to GNSS)
-				e.clkSyncState[cfgName].clockClass = fbprotocol.ClockClass6
-				e.clkSyncState[cfgName].clockAccuracy = fbprotocol.ClockAccuracyNanosecond100
-			case PTP_HOLDOVER:
-				e.clkSyncState[cfgName].state = PTP_HOLDOVER
-				e.clkSyncState[cfgName].clockClass = fbprotocol.ClockClass7 //TODO: check if this is correct
-			}
-		case PTP_FREERUN:
-			switch ts2phcState {
-			case PTP_FREERUN, PTP_LOCKED, PTP_UNKNOWN, PTP_NOTSET: // when GNSS is lost ts2phc will stop printing and will wait to move to HOLDOVER
-				e.clkSyncState[cfgName].state = PTP_FREERUN
-				e.clkSyncState[cfgName].clockClass = protocol.ClockClassFreerun
-				e.clkSyncState[cfgName].clockAccuracy = fbprotocol.ClockAccuracyUnknown
-			case PTP_HOLDOVER: // if holdover is detected then wait for ts2phc to move to HOLDOVER
-				e.clkSyncState[cfgName].state = PTP_HOLDOVER
-				e.clkSyncState[cfgName].clockClass = fbprotocol.ClockClass7 //TODO: check if this is correct
-			}
-		default: // bad case
-			e.clkSyncState[cfgName].state = ts2phcState
-			switch ts2phcState {
-			case PTP_FREERUN:
-				e.clkSyncState[cfgName].clockClass = protocol.ClockClassFreerun
-				e.clkSyncState[cfgName].clockAccuracy = fbprotocol.ClockAccuracyUnknown
-			case PTP_LOCKED:
-				e.clkSyncState[cfgName].clockClass = fbprotocol.ClockClass7
-				e.clkSyncState[cfgName].clockAccuracy = fbprotocol.ClockAccuracyNanosecond100
-			}
-		}
-	}
-	gSycState := e.clkSyncState[cfgName]
-	rclockSyncState := clockSyncState{
-		state:         gSycState.state,
-		clockClass:    gSycState.clockClass,
-		clockAccuracy: gSycState.clockAccuracy,
-		sourceLost:    gSycState.sourceLost,
-		leadingIFace:  gSycState.leadingIFace,
-	}
-	// this will reduce log noise and prints 1 per sec
-	logTime := time.Now().Unix()
-	if e.clkSyncState[cfgName].lastLoggedTime != logTime {
-		clkLog := fmt.Sprintf("%s[%d]:[%s] %s T-GM-STATUS %s\n", GM, logTime, cfgName, gSycState.leadingIFace, gSycState.state)
-		e.clkSyncState[cfgName].lastLoggedTime = logTime
-		e.clkSyncState[cfgName].clkLog = clkLog
-		rclockSyncState.clkLog = clkLog
-		glog.Infof("dpll State %s, gnss State %s, tsphc state %s, gm state %s,", dpllState, gnssState, ts2phcState, e.clkSyncState[cfgName].state)
-	}
-	return rclockSyncState
-}
-
-func (e *EventHandler) getGMClockClass(cfgName string) fbprotocol.ClockClass {
-	if g, ok := e.clkSyncState[cfgName]; ok {
-		return g.clockClass
-	}
-	return protocol.ClockClassUninitialized
-}
-
-func (e *EventHandler) isSourceLost(cfgName string) bool {
-	if data, ok := e.data[cfgName]; ok {
-		for _, d := range data {
-			if d.ProcessName == GNSS && len(d.Details) > 0 && d.Details[0] != nil {
-				return d.Details[0].sourceLost
-			}
-		}
-	}
-	return false
-}
-
-// hasNonLeadingDPLLFault returns true when the leading DPLL is locked but at
-// least one non-leading DPLL is not locked, indicating a follower fault that
-// should force the composite clock to FREERUN.
-func (e *EventHandler) hasNonLeadingDPLLFault(cfgName, leadingInterface string) bool {
-	if leadingInterface == LEADING_INTERFACE_UNKNOWN {
-		return false
-	}
-	if data, ok := e.data[cfgName]; ok {
-		for _, d := range data {
-			if d.ProcessName != DPLL {
-				continue
-			}
-			leadingDetail := d.GetDataDetails(leadingInterface)
-			if leadingDetail == nil || leadingDetail.State != PTP_LOCKED {
-				return false
-			}
-			for _, dd := range d.Details {
-				if dd.IFace != leadingInterface && dd.State != PTP_LOCKED {
-					glog.Infof("non-leading DPLL %s is %s while leading %s is locked, composite DPLL forced to FREERUN",
-						dd.IFace, dd.State, leadingInterface)
-					return true
-				}
-			}
-		}
-	}
-	return false
-}
-
-func (e *EventHandler) getLeadingInterface(cfgName string) string {
-	if data, ok := e.data[cfgName]; ok {
-		for _, d := range data {
-			if d.ProcessName == GNSS && len(d.Details) > 0 {
-				return d.Details[0].IFace
-			} else if d.ProcessName == TS2PHCProcessName && len(d.Details) > 0 {
-				for _, dd := range d.Details {
-					if dd.signalSource == GNSS {
-						return dd.IFace
-					}
-				}
-			}
-		}
-	}
-	return LEADING_INTERFACE_UNKNOWN
-}
-
-func (e *EventHandler) updateSpecState(event Event) {
-	if ptp, ok := event.Data.(*PTPData); ok && event.Source == DPLL {
-		e.outOfSpec = ptp.OutOfSpec
-		e.frequencyTraceable = ptp.FrequencyTraceable
-	}
-}
 func (e *EventHandler) toString() string {
 	// update if DPLL holdover is out of spec
 	out := strings.Builder{}
@@ -651,52 +398,27 @@ func (e *EventHandler) hasMetric(name string) (*prometheus.GaugeVec, bool) {
 	return nil, false
 }
 
-// AnnounceClockClass announces clock class changes to the event handler and writes to the connection.
-// It also sends a non-blocking clock class update request to the ProcessEvents goroutine,
-// which calls UpdateClockClass to read the local GRANDMASTER_SETTINGS_NP and determine
-// the correct clock class for the local clock (e.g., 255 for OC slave).
-func (e *EventHandler) AnnounceClockClass(clockClass fbprotocol.ClockClass, clockAcc fbprotocol.ClockAccuracy, cfgName string, clockType ClockType) {
-	e.announceClockClass(clockClass, clockAcc, cfgName)
-	// Non-blocking send to trigger UpdateClockClass in the ProcessEvents goroutine.
-	// For non-GM clock types (OC/BC), UpdateClockClass reads the local GRANDMASTER_SETTINGS_NP
-	// to determine the correct clock class (e.g., 255 for OC slave).
-	select {
-	case clockClassRequestCh <- ClockClassRequest{
-		cfgName:       cfgName,
-		clockClass:    clockClass,
-		clockType:     clockType,
-		clockAccuracy: clockAcc,
-	}:
+// EmitClockClass re-emits the stored clock class for any clock type.
+func (e *EventHandler) EmitClockClass(cfgName string) {
+	clk := e.GetClock(cfgName)
+	if clk == nil {
+		return
+	}
+	var clockClass fbprotocol.ClockClass
+	switch c := clk.(type) {
+	case *GMClock:
+		clockClass = c.announcedClockClass
+	case *TBCClock:
+		clockClass = c.announcedClockClass
+	case *BCClock:
+		clockClass = c.clockClass
 	default:
-		glog.Warning("clock class request busy updating previous request, will try on next event")
+		return
 	}
-}
-
-func (e *EventHandler) announceClockClass(clockClass fbprotocol.ClockClass, clockAcc fbprotocol.ClockAccuracy, cfgName string) {
-	e.Lock()
-	e.setClockClassLocked(clockClass, clockAcc)
-	e.storeClockClassLocked(cfgName, clockClass, clockAcc)
-	e.Unlock()
-
+	if clockClass == 0 {
+		return
+	}
 	e.emitClockClass(clockClass, cfgName)
-}
-
-// setClockClassLocked updates the clock class and accuracy fields.
-// Caller must hold e.Lock().
-func (e *EventHandler) setClockClassLocked(clockClass fbprotocol.ClockClass, clockAcc fbprotocol.ClockAccuracy) {
-	e.clockClass = clockClass
-	e.clockAccuracy = clockAcc
-}
-
-// storeClockClassLocked stores the clock class and accuracy in clkSyncState
-// so that EmitClockClass and the classTicker can re-emit after a reconnect.
-// Caller must hold e.Lock().
-func (e *EventHandler) storeClockClassLocked(cfgName string, clockClass fbprotocol.ClockClass, clockAcc fbprotocol.ClockAccuracy) {
-	if _, ok := e.clkSyncState[cfgName]; !ok {
-		e.clkSyncState[cfgName] = &clockSyncState{}
-	}
-	e.clkSyncState[cfgName].clockClass = clockClass
-	e.clkSyncState[cfgName].clockAccuracy = clockAcc
 }
 
 // emitClockClass writes the clock class to the socket and updates the metric.
@@ -709,6 +431,82 @@ func (e *EventHandler) emitClockClass(clockClass fbprotocol.ClockClass, cfgName 
 	if !e.stdoutToSocket && e.clockClassMetric != nil {
 		e.clockClassMetric.With(prometheus.Labels{
 			"process": PTP4lProcessName, "config": cfgName, "node": e.nodeName}).Set(float64(clockClass))
+	}
+}
+
+func (e *EventHandler) sendIPC(msg ipc.Message) {
+	if e.ipcCache != nil {
+		e.ipcCache.Send(msg)
+	}
+}
+
+func (e *EventHandler) getGMSettings(cfgName string) (protocol.GrandmasterSettings, error) {
+	return pmc.GetGMSettings(cfgName)
+}
+
+func (e *EventHandler) setGMSettings(cfgName string, g protocol.GrandmasterSettings) error {
+	return pmc.SetGMSettings(cfgName, g)
+}
+
+func (e *EventHandler) setExternalGMPropertiesNP(cfgName string, egp protocol.ExternalGrandmasterProperties) error {
+	return pmc.SetExternalGMPropertiesNP(cfgName, egp)
+}
+
+func (e *EventHandler) getParentTimeAndCurrentDS(cfgName string) (pmc.ParentTimeCurrentDS, error) {
+	return pmc.GetParentTimeAndCurrentDS(cfgName)
+}
+
+func (e *EventHandler) getUtcOffset() int {
+	return leap.GetUtcOffset()
+}
+
+// IPCCache returns the IPC cache, or nil if not configured.
+func (e *EventHandler) IPCCache() *ipc.Cache {
+	return e.ipcCache
+}
+
+// handleOSClockEvent fans out a PHC2SYS/CHRONYD event to all TBCClocks,
+// emits os_clock_state IPC once (system-wide), and emits sync_state IPC
+// per-profile when the overall state changes.
+func (e *EventHandler) handleOSClockEvent(event Event) {
+	prevOS := e.osClockState
+	if ptp, ok := event.Data.(*PTPData); ok {
+		e.osClockState = ptp.State
+	}
+
+	var osOffset int64
+	if ptp, ok := event.Data.(*PTPData); ok {
+		if v, exists := ptp.Values[OFFSET]; exists {
+			if i, isInt := v.(int64); isInt {
+				osOffset = i
+			}
+		}
+	}
+
+	osChanged := e.osClockState != prevOS
+	if osChanged {
+		e.sendIPC(ipc.Message{
+			Type:   ipc.TypeOSClockState,
+			IFace:  event.IFace,
+			Values: ipc.StateValue{State: ptpStateToIPCState(e.osClockState), Offset: osOffset},
+		})
+	}
+
+	seen := map[Clock]bool{}
+	e.Lock()
+	clocks := make([]Clock, 0, len(e.clocks))
+	for _, clk := range e.clocks {
+		clocks = append(clocks, clk)
+	}
+	e.Unlock()
+
+	for _, clk := range clocks {
+		if seen[clk] {
+			continue
+		}
+		seen[clk] = true
+
+		clk.SystemClockUpdate(e.osClockState)
 	}
 }
 
@@ -800,15 +598,11 @@ func (e *EventHandler) writeLogToSocket(l string) bool {
 
 // ProcessEvents ... process events to generate new events
 func (e *EventHandler) ProcessEvents() {
-	redialClockClass := true
-
 	defer func() {
 		if e.stdoutToSocket {
 			e.setConn(nil) // closes the connection if present
 		}
 	}()
-	var lastClockState PTPState
-
 	// Establish initial connection to the event socket using exponential backoff.
 	// Retries indefinitely until connected or the handler is shutting down.
 	if e.stdoutToSocket {
@@ -825,90 +619,93 @@ func (e *EventHandler) ProcessEvents() {
 		}
 	}
 
-	if redialClockClass {
-		go func() {
-			defer func() {
-				if err := recover(); err != nil {
-					glog.Errorf("restored from clock class update: %s", err)
+	go func() {
+		defer func() {
+			if err := recover(); err != nil {
+				glog.Errorf("restored from clock class update: %s", err)
+			}
+		}()
+		classTicker := time.NewTicker(60 * time.Second)
+		for {
+			select {
+			case <-e.closeCh:
+				return
+			case <-classTicker.C:
+				type clkEntry struct {
+					cfgName    string
+					clockClass fbprotocol.ClockClass
 				}
-			}()
-			cfgName := ""
-			classTicker := time.NewTicker(60 * time.Second)
-			for {
-				select {
-				case clk := <-clockClassRequestCh:
-					cfgName = clk.cfgName
-					// TODO: UpdateClockClass produces the wrong value for BC, investigate and fix.
-					if clk.clockType != BC {
-						e.UpdateClockClass(clk)
-					} else {
-						e.Lock()
-						e.clockClass = clk.clockClass
-						e.clockAccuracy = clk.clockAccuracy
-						e.storeClockClassLocked(clk.cfgName, clk.clockClass, clk.clockAccuracy)
-						e.Unlock()
+				e.Lock()
+				entries := make([]clkEntry, 0, len(e.clocks))
+				for name, clk := range e.clocks {
+					var cc fbprotocol.ClockClass
+					switch c := clk.(type) {
+					case *GMClock:
+						cc = c.announcedClockClass
+					case *TBCClock:
+						cc = c.announcedClockClass
+					case *BCClock:
+						cc = c.clockClass
+					default:
+						continue
 					}
-
-				case <-e.closeCh:
-					return
-				case <-classTicker.C: // send clock class event 60 secs interval
-					// Snapshot the clock sync state under lock to avoid concurrent map access
-					e.Lock()
-					clkSnapshot := make(map[string]fbprotocol.ClockClass, len(e.clkSyncState))
-					for k, v := range e.clkSyncState {
-						clkSnapshot[k] = v.clockClass
+					if cc == 0 {
+						continue
 					}
-					e.Unlock()
-					for clkCfgName, clockClass := range clkSnapshot {
-						parts := strings.SplitN(clkCfgName, ".", 2)
-						if len(parts) >= 2 {
-							clkCfgName = "ptp4l." + strings.Join(parts[1:], ".")
-						}
-						if clockClass == 0 {
-							continue
-						}
-						if clkCfgName == cfgName {
-							// Stop double emmit
-							cfgName = ""
-						}
-						logMsg := utils.GetClockClassLogMessage(PTP4lProcessName, clkCfgName, clockClass)
-						if !e.writeLogToSocket(logMsg) {
-							break
-						}
+					entries = append(entries, clkEntry{cfgName: name, clockClass: cc})
+				}
+				e.Unlock()
+				for _, entry := range entries {
+					cfgName := entry.cfgName
+					parts := strings.SplitN(cfgName, ".", 2)
+					if len(parts) >= 2 {
+						cfgName = "ptp4l." + strings.Join(parts[1:], ".")
 					}
-
-					if cfgName != "" {
-						parts := strings.SplitN(cfgName, ".", 2)
-						if len(parts) >= 2 {
-							cfgName = "ptp4l." + strings.Join(parts[1:], ".")
-						}
-						e.Lock()
-						currentClockClass := e.clockClass
-						e.Unlock()
-						logMsg := utils.GetClockClassLogMessage(PTP4lProcessName, cfgName, currentClockClass)
-						e.writeLogToSocket(logMsg)
+					logMsg := utils.GetClockClassLogMessage(PTP4lProcessName, cfgName, entry.clockClass)
+					if !e.writeLogToSocket(logMsg) {
+						break
 					}
 				}
 			}
-		}()
-		redialClockClass = false
-	}
+		}
+	}()
 	glog.Info("starting state monitoring...")
 	for {
 		select {
 		case event := <-e.processChannel: // for non GM this thread will be in sleep forever
+			glog.V(2).Infof("ProcessEvents: received event source=%s iface=%s cfg=%s clockType=%s reset=%v",
+				event.Source, event.IFace, event.CfgName, event.ClockType, event.Reset)
 			// ts2phc[123455]:[ts2phc.0.config] 12345 s0 offset/gps
 			// replace ts2phc logs here
 			if event.Reset { // clean up
 				debug.ClearState() // clear any state data used for debug
-				e.LeadingClockData = newLeadingClockParams()
+				// TODO: Can we just create new objects here? I think so. This also needs a test
+				if clk := e.GetClock(event.CfgName); clk != nil {
+					switch c := clk.(type) {
+					case *TBCClock:
+						c.leadingClockData = newLeadingClockParams()
+						c.syncState = clockSyncState{}
+						c.overallSyncState = PTP_FREERUN
+						c.announcedClockClass = 0
+						c.announcedClockAccuracy = 0
+						c.data = nil
+					case *BCClock:
+						c.syncState = PTP_FREERUN
+						c.overallSyncState = PTP_FREERUN
+						c.clockClass = 0
+					case *GMClock:
+						c.syncState = clockSyncState{}
+						c.overallSyncState = PTP_FREERUN
+						c.announcedClockClass = 0
+						c.announcedClockAccuracy = 0
+						c.lastLoggedState = ""
+						c.data = nil
+					}
+				}
 				if event.Source == TS2PHC {
 					e.unregisterMetrics(event.CfgName, "")
-					delete(e.data, event.CfgName) // this will delete all index
-					e.clockClass = protocol.ClockClassUninitialized
-					e.clockAccuracy = fbprotocol.ClockAccuracyUnknown
+					delete(e.data, event.CfgName)
 				} else {
-					// Check if the index is within the slice bounds
 					for indexToRemove, d := range e.data[event.CfgName] {
 						if d.ProcessName == event.Source {
 							e.unregisterMetrics(event.CfgName, string(event.Source))
@@ -917,17 +714,13 @@ func (e *EventHandler) ProcessEvents() {
 							}
 						}
 					}
-					e.Lock()
-					delete(e.clkSyncState, event.CfgName) // delete the clkSyncState
-					e.Unlock()
-					e.outOfSpec = false
-					e.frequencyTraceable = false
 				}
 				continue
 			}
 			var logOut []string
 			logDataValues := ""
-			if event.Source == SYNCE {
+			switch event.Source {
+			case SYNCE:
 				ptp, _ := event.Data.(*PTPData)
 				logDataValues = event.GetLogData()
 				if event.WriteToLog && logDataValues != "" {
@@ -936,39 +729,48 @@ func (e *EventHandler) ProcessEvents() {
 				if !e.stdoutToSocket && ptp != nil {
 					e.UpdateClockStateMetrics(ptp.State, string(event.Source), event.IFace)
 				}
-			} else {
-
-				// Update the in MemData
-
+				ptp4lName := strings.Replace(event.CfgName, "synce4l", "ptp4l", 1)
+				if clk := e.GetClock(ptp4lName); clk != nil {
+					if bc, ok := clk.(*TBCClock); ok {
+						bc.processSyncE(event)
+					}
+				}
+			case PHC2SYS, CHRONYD:
+				e.handleOSClockEvent(event)
+			case PMC:
+				if ds, ok := event.Data.(*ParentDSData); ok {
+					if clk := e.GetClock(event.CfgName); clk != nil {
+						clk.ParentDSUpdate(ds.ParentDataSet)
+					}
+				}
+			default:
 				var clockState clockSyncState
 				var dataDetails *DataDetails
-				if event.ClockType == GM {
-					dataDetails = e.addEvent(event)
-					// Computes GM state
-					e.Lock()
-					clockState = e.updateGMState(event.CfgName)
-					e.Unlock()
-					if clockState.state != PTP_LOCKED {
-						if ptp, isPTP := event.Data.(*PTPData); isPTP {
-							if _, hasNMEA := ptp.Values[NMEA_STATUS]; hasNMEA {
-								ptp.Values[NMEA_STATUS] = 0
+				if clk := e.GetClock(event.CfgName); clk != nil {
+					switch c := clk.(type) {
+					case *GMClock:
+						dataDetails, clockState = c.addEvent(event)
+						if clockState.state != PTP_LOCKED {
+							if ptp, isPTP := event.Data.(*PTPData); isPTP {
+								if _, hasNMEA := ptp.Values[NMEA_STATUS]; hasNMEA {
+									ptp.Values[NMEA_STATUS] = 0
+								}
 							}
 						}
+					case *TBCClock:
+						event, clockState, dataDetails = c.addEvent(event)
+					case *BCClock:
+						dataDetails = e.addEvent(event)
+						result := c.addEvent(event)
+						clockState = clockSyncState{state: result.State, leadingIFace: LEADING_INTERFACE_UNKNOWN}
+						// TODO: no case for *OCClock — OC profile events are
+						// silently dropped. OCClock needs addEvent/state logic
+						// before a case can be added here.
 					}
-				} else { // T-BC or T-TSC
-					e.Lock()
-					event = e.convergeConfig(event)
-					dataDetails = e.addEvent(event)
-					var needsTTSCAnnounce, needsDownstreamUpdate bool
-					clockState, needsTTSCAnnounce, needsDownstreamUpdate = e.updateBCState(event)
-					e.Unlock()
-					// Perform I/O after releasing the lock
-					if needsTTSCAnnounce {
-						e.emitClockClass(clockState.clockClass, event.CfgName)
-					}
-					if needsDownstreamUpdate {
-						go e.updateDownstreamData(event.CfgName)
-					}
+				}
+				if dataDetails == nil {
+					glog.Warningf("ProcessEvents: no clock registered for %s, skipping event", event.CfgName)
+					continue
 				}
 				logDataValues = dataDetails.logData
 				if event.WriteToLog && logDataValues != "" {
@@ -1013,45 +815,6 @@ func (e *EventHandler) ProcessEvents() {
 						e.UpdateClockStateMetrics(clockState.state, string(event.ClockType), alias.GetAlias(clockState.leadingIFace))
 					}
 				}
-				if event.ClockType == GM {
-					clockState.clockAccuracy = e.clockAccuracy
-
-					if ptp, isPTP := event.Data.(*PTPData); isPTP && event.Source == DPLL {
-						if clockState.clockClass == fbprotocol.ClockClass7 || clockState.clockClass == protocol.ClockClassOutOfSpec {
-							if offset, found := ptp.Values[OFFSET]; found {
-								offsetValue, isInt64 := offset.(int64)
-								if isInt64 {
-									clockAccuracy := fbprotocol.ClockAccuracyFromOffset(time.Duration(offsetValue) * time.Nanosecond)
-									clockState.clockAccuracy = clockAccuracy
-								}
-							}
-						}
-					}
-
-					if clockState.clockClass != protocol.ClockClassUninitialized &&
-						(clockState.clockClass != e.clockClass || clockState.clockAccuracy != e.clockAccuracy) {
-						glog.Infof("clock class change request from %d to %d with clock accuracy from %d to %d",
-							uint8(e.clockClass), uint8(clockState.clockClass), uint8(e.clockAccuracy), uint8(clockState.clockAccuracy))
-						debug.UpdateClockClass(uint8(clockState.clockClass))
-						go func() {
-							select {
-							case clockClassRequestCh <- ClockClassRequest{
-								cfgName:       event.CfgName,
-								clockState:    clockState.state,
-								clockType:     event.ClockType,
-								clockClass:    clockState.clockClass,
-								clockAccuracy: clockState.clockAccuracy,
-							}:
-							default:
-								glog.Error("clock class request busy updating previous request, will try next event")
-							}
-						}()
-					}
-					if lastClockState != clockState.state {
-						glog.Infof("PTP State: %v, Clock Class %d Time %s sourceLost %v", clockState.state, clockState.clockClass, time.Now(), clockState.sourceLost)
-						lastClockState = clockState.state
-					}
-				} // T-GM
 			} // Not SYNC-E
 
 			if len(logOut) > 0 {
@@ -1077,70 +840,6 @@ func (e *EventHandler) ProcessEvents() {
 			return
 		}
 	}
-}
-
-func (e *EventHandler) updateClockClass(cfgName string, clkClass fbprotocol.ClockClass, clockType ClockType, clkAccuracy fbprotocol.ClockAccuracy,
-	gmGetterFn func(string) (protocol.GrandmasterSettings, error),
-	gmSetterFn func(string, protocol.GrandmasterSettings) error) (err error, clockClass fbprotocol.ClockClass, clockAccuracy fbprotocol.ClockAccuracy) {
-	g, err := gmGetterFn(cfgName)
-	if err != nil {
-		glog.Errorf("failed to get current GRANDMASTER_SETTINGS_NP: %s", err)
-		return err, clockClass, clockAccuracy
-	}
-	switch clockType {
-	case GM:
-		g.TimePropertiesDS.PtpTimescale = true
-		g.TimePropertiesDS.FrequencyTraceable = true
-		g.TimePropertiesDS.CurrentUtcOffsetValid = true
-		g.TimePropertiesDS.CurrentUtcOffset = int32(leap.GetUtcOffset())
-		switch clkClass {
-		case fbprotocol.ClockClass6: // T-GM connected to a PRTC in locked mode (e.g., PRTC traceable to GNSS)
-			// update only when ClockClass is changed or clockAccuracy changes
-			if g.ClockQuality.ClockClass != fbprotocol.ClockClass6 || g.TimePropertiesDS.TimeTraceable != true {
-				g.ClockQuality.ClockClass = fbprotocol.ClockClass6
-				g.TimePropertiesDS.TimeTraceable = true
-				g.ClockQuality.ClockAccuracy = fbprotocol.ClockAccuracyNanosecond100
-				g.TimePropertiesDS.TimeSource = fbprotocol.TimeSourceGNSS
-				// T-REC-G.8275.1-202211-I section 6.3.5
-				g.ClockQuality.OffsetScaledLogVariance = 0x4e5d
-				err = gmSetterFn(cfgName, g)
-			}
-		case protocol.ClockClassOutOfSpec: // GM out of holdover specification, traceable to Category 3
-			if g.ClockQuality.ClockClass != protocol.ClockClassOutOfSpec {
-				g.ClockQuality.ClockClass = protocol.ClockClassOutOfSpec
-				g.TimePropertiesDS.TimeTraceable = false
-				g.ClockQuality.ClockAccuracy = clkAccuracy
-				g.TimePropertiesDS.TimeSource = fbprotocol.TimeSourceInternalOscillator
-				// T-REC-G.8275.1-202211-I section 6.3.5
-				g.ClockQuality.OffsetScaledLogVariance = 0xffff
-				err = gmSetterFn(cfgName, g)
-			}
-		case fbprotocol.ClockClass7: // T-GM in holdover, within holdover specification
-			if g.ClockQuality.ClockClass != fbprotocol.ClockClass7 {
-				g.ClockQuality.ClockClass = fbprotocol.ClockClass7
-				g.TimePropertiesDS.TimeTraceable = true
-				g.ClockQuality.ClockAccuracy = clkAccuracy
-				g.TimePropertiesDS.TimeSource = fbprotocol.TimeSourceInternalOscillator
-				// T-REC-G.8275.1-202211-I section 6.3.5
-				g.ClockQuality.OffsetScaledLogVariance = 0xffff
-				err = gmSetterFn(cfgName, g)
-			}
-		case protocol.ClockClassFreerun: // T-GM in free-run mode
-			if g.ClockQuality.ClockClass != protocol.ClockClassFreerun {
-				g.ClockQuality.ClockClass = protocol.ClockClassFreerun
-				g.TimePropertiesDS.TimeTraceable = false
-				g.ClockQuality.ClockAccuracy = fbprotocol.ClockAccuracyUnknown
-				g.TimePropertiesDS.TimeSource = fbprotocol.TimeSourceInternalOscillator
-				// T-REC-G.8275.1-202211-I section 6.3.5
-				g.ClockQuality.OffsetScaledLogVariance = 0xffff
-				err = gmSetterFn(cfgName, g)
-			}
-		default:
-			glog.Infof("No clock class identified for %d", clkClass)
-		}
-	default: // other than GM
-	}
-	return err, g.ClockQuality.ClockClass, g.ClockQuality.ClockAccuracy
 }
 
 // GetPTPState ...
@@ -1254,7 +953,7 @@ func registerMetrics(m *prometheus.GaugeVec) {
 
 func (e *EventHandler) unregisterMetrics(configName string, processName string) {
 	if e.stdoutToSocket {
-		return // no need to unregister metrics if events are going to socket
+		return
 	}
 	if data, ok := e.data[configName]; ok {
 		for _, v := range data {
@@ -1295,47 +994,8 @@ func (e *EventHandler) GetData(cfgName string, processName EventSource) *Data {
 func (e *EventHandler) addEvent(event Event) *DataDetails {
 	d := e.GetData(event.CfgName, event.Source)
 	d.AddEvent(event)
-
-	// update if DPLL holdover is out of spec
-	e.updateSpecState(event)
 	d.UpdateState()
 	return d.GetDataDetails(event.IFace)
-}
-
-// UpdateClockClass ... update clock class
-func (e *EventHandler) UpdateClockClass(clk ClockClassRequest) {
-	getter := func(cfgName string) (protocol.GrandmasterSettings, error) {
-		cfgName = strings.Replace(cfgName, TS2PHCProcessName, PTP4lProcessName, 1)
-		return pmc.GetGMSettings(cfgName)
-	}
-	setter := func(cfgName string, g protocol.GrandmasterSettings) error {
-		cfgName = strings.Replace(cfgName, TS2PHCProcessName, PTP4lProcessName, 1)
-		if err := pmc.SetGMSettings(cfgName, g); err != nil {
-			return fmt.Errorf("failed to update GRANDMASTER_SETTINGS_NP: %s", err)
-		}
-		return nil
-	}
-	classErr, clockClass, clockAccuracy := e.updateClockClass(clk.cfgName, clk.clockClass, clk.clockType, clk.clockAccuracy,
-		getter, setter)
-	glog.Infof("received %s,%v,%s,%v", clk.cfgName, clk.clockClass, clk.clockType, clk.clockAccuracy)
-	if classErr != nil {
-		glog.Errorf("error updating clock class %s", classErr)
-	} else {
-		glog.Infof("updated clock class for last clock class %d to %d with clock accuracy %d", clk.clockClass, clockClass, clockAccuracy)
-		e.Lock()
-		e.clockClass = clockClass
-		e.clockAccuracy = clockAccuracy
-		e.storeClockClassLocked(clk.cfgName, clockClass, clockAccuracy)
-		e.Unlock()
-		clockClassOut := utils.GetClockClassLogMessage(PTP4lProcessName, clk.cfgName, clockClass)
-		if e.stdoutToSocket {
-			e.writeLogToSocket(clockClassOut)
-		} else if e.clockClassMetric != nil {
-			e.clockClassMetric.With(prometheus.Labels{
-				"process": PTP4lProcessName, "config": clk.cfgName, "node": e.nodeName}).Set(float64(clockClass))
-		}
-		fmt.Printf("%s", clockClassOut)
-	}
 }
 
 func getMetricName(valueType ValueType) string {
@@ -1369,12 +1029,18 @@ func (e *EventHandler) EmitClockSyncLogs() {
 			return
 		}
 	}
-	// Snapshot clkSyncState logs under lock to avoid concurrent map access
 	e.Lock()
-	logs := make([]string, 0, len(e.clkSyncState))
-	for _, syncState := range e.clkSyncState {
-		if syncState.clkLog != "" {
-			logs = append(logs, syncState.clkLog)
+	logs := make([]string, 0, len(e.clocks))
+	for _, clk := range e.clocks {
+		switch c := clk.(type) {
+		case *GMClock:
+			if c.syncState.clkLog != "" {
+				logs = append(logs, c.syncState.clkLog)
+			}
+		case *TBCClock:
+			if c.syncState.clkLog != "" {
+				logs = append(logs, c.syncState.clkLog)
+			}
 		}
 	}
 	e.Unlock()

--- a/pkg/event/event_bc.go
+++ b/pkg/event/event_bc.go
@@ -1,0 +1,91 @@
+package event
+
+import (
+	fbprotocol "github.com/facebook/time/ptp/protocol"
+	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/ipc"
+	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/protocol"
+)
+
+// BCClock is a simple Boundary Clock instance (no DPLL/ts2phc).
+// State is derived directly from ptp4l clock state codes and offset
+// thresholds, matching CEPv1 behavior.
+type BCClock struct {
+	cfgName          string
+	io               clockIO
+	iface            string
+	syncState        PTPState
+	clockClass       fbprotocol.ClockClass
+	overallSyncState PTPState
+	osClockState     PTPState
+}
+
+// ClockType returns BC.
+func (c *BCClock) ClockType() ClockType { return BC }
+
+func (c *BCClock) ClockClass() fbprotocol.ClockClass {
+	return c.clockClass
+}
+
+// ConfigName returns the config profile name.
+func (c *BCClock) ConfigName() string { return c.cfgName }
+
+// BCProcessResult holds the outcome of BCClock.addEvent.
+type BCProcessResult struct {
+	State            PTPState
+	SyncStateChanged bool
+}
+
+func (c *BCClock) addEvent(event Event) BCProcessResult {
+	ptp, ok := event.Data.(*PTPData)
+	if !ok || ptp == nil {
+		return BCProcessResult{State: c.syncState}
+	}
+
+	if c.iface == "" && event.IFace != "" {
+		c.iface = event.IFace
+	}
+
+	prev := c.syncState
+	c.syncState = ptp.State
+	changed := c.syncState != prev
+
+	if changed {
+		c.io.sendIPC(ipc.Message{
+			Type:    ipc.TypePTPState,
+			Profile: c.cfgName,
+			IFace:   event.IFace,
+			Values:  ipc.StateValue{State: ptpStateToIPCState(c.syncState)},
+		})
+	}
+
+	emitOverallSyncStateIfChanged(c.io, &c.overallSyncState, c.syncState, c.osClockState, c.cfgName)
+
+	return BCProcessResult{
+		State:            c.syncState,
+		SyncStateChanged: changed,
+	}
+}
+
+func (c *BCClock) SystemClockUpdate(osClockState PTPState) {
+	c.osClockState = osClockState
+	emitOverallSyncStateIfChanged(c.io, &c.overallSyncState, c.syncState, c.osClockState, c.cfgName)
+}
+
+func (c *BCClock) ParentDSUpdate(parentDS protocol.ParentDataSet) {
+	clockClass := fbprotocol.ClockClass(parentDS.GrandmasterClockClass)
+	c.updateClockClass(clockClass)
+	c.io.emitClockClass(clockClass, c.cfgName)
+}
+
+func (c *BCClock) updateClockClass(clockClass fbprotocol.ClockClass) {
+	if clockClass == c.clockClass {
+		return
+	}
+	c.clockClass = clockClass
+	c.io.sendIPC(ipc.Message{
+		Type:    ipc.TypeClockClass,
+		Profile: c.cfgName,
+		IFace:   c.iface,
+		Values:  ipc.ClockClassValue{ClockClass: uint8(clockClass)},
+	})
+}

--- a/pkg/event/event_bc_test.go
+++ b/pkg/event/event_bc_test.go
@@ -1,0 +1,149 @@
+package event
+
+import (
+	"testing"
+
+	fbprotocol "github.com/facebook/time/ptp/protocol"
+	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/ipc"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestBCClock() (*BCClock, *recordingClockIO) {
+	rio := &recordingClockIO{}
+	return &BCClock{
+		cfgName:          testPTP4lCfg,
+		io:               rio,
+		syncState:        PTP_NOTSET,
+		overallSyncState: PTP_NOTSET,
+		osClockState:     PTP_NOTSET,
+	}, rio
+}
+
+func TestBCClock_AddEvent_StateTransitions(t *testing.T) {
+	t.Run("NOTSET to LOCKED emits ptp_state IPC", func(t *testing.T) {
+		bc, rio := newTestBCClock()
+		result := bc.addEvent(Event{
+			IFace: testEns7f0,
+			Data:  &PTPData{State: PTP_LOCKED},
+		})
+		assert.Equal(t, PTP_LOCKED, result.State)
+		assert.True(t, result.SyncStateChanged)
+		require.Len(t, rio.ipcMessages, 1)
+		assert.Equal(t, ipc.TypePTPState, rio.ipcMessages[0].Type)
+		assert.Equal(t, testPTP4lCfg, rio.ipcMessages[0].Profile)
+		assert.Equal(t, testEns7f0, rio.ipcMessages[0].IFace)
+		assert.Equal(t, ipc.StateValue{State: ipc.StateLocked}, rio.ipcMessages[0].Values)
+	})
+
+	t.Run("LOCKED to FREERUN emits ptp_state IPC", func(t *testing.T) {
+		bc, rio := newTestBCClock()
+		bc.syncState = PTP_LOCKED
+		result := bc.addEvent(Event{
+			IFace: testEns7f0,
+			Data:  &PTPData{State: PTP_FREERUN},
+		})
+		assert.Equal(t, PTP_FREERUN, result.State)
+		assert.True(t, result.SyncStateChanged)
+		require.Len(t, rio.ipcMessages, 1)
+		assert.Equal(t, ipc.StateFreerun, rio.ipcMessages[0].Values.(ipc.StateValue).State)
+	})
+
+	t.Run("duplicate state does not emit ptp_state IPC", func(t *testing.T) {
+		bc, rio := newTestBCClock()
+		bc.syncState = PTP_LOCKED
+		result := bc.addEvent(Event{
+			IFace: testEns7f0,
+			Data:  &PTPData{State: PTP_LOCKED},
+		})
+		assert.Equal(t, PTP_LOCKED, result.State)
+		assert.False(t, result.SyncStateChanged)
+		assert.Empty(t, rio.ipcMessages)
+	})
+
+	t.Run("nil PTPData returns current state unchanged", func(t *testing.T) {
+		bc, rio := newTestBCClock()
+		bc.syncState = PTP_FREERUN
+		result := bc.addEvent(Event{Data: nil})
+		assert.Equal(t, PTP_FREERUN, result.State)
+		assert.False(t, result.SyncStateChanged)
+		assert.Empty(t, rio.ipcMessages)
+	})
+}
+
+func TestBCClock_UpdateOSClockState(t *testing.T) {
+	t.Run("worst of LOCKED and FREERUN is FREERUN", func(t *testing.T) {
+		bc, rio := newTestBCClock()
+		bc.syncState = PTP_LOCKED
+		bc.overallSyncState = PTP_LOCKED
+		bc.SystemClockUpdate(PTP_FREERUN)
+		assert.Equal(t, PTP_FREERUN, bc.overallSyncState)
+		assert.Equal(t, PTP_FREERUN, bc.osClockState)
+		require.Len(t, rio.ipcMessages, 1)
+		assert.Equal(t, ipc.TypeSyncState, rio.ipcMessages[0].Type)
+		assert.Equal(t, ipc.SyncStateValue{State: ipc.StateFreerun}, rio.ipcMessages[0].Values)
+	})
+
+	t.Run("worst of LOCKED and LOCKED is LOCKED", func(t *testing.T) {
+		bc, rio := newTestBCClock()
+		bc.syncState = PTP_LOCKED
+		bc.overallSyncState = PTP_LOCKED
+		bc.SystemClockUpdate(PTP_LOCKED)
+		assert.Equal(t, PTP_LOCKED, bc.overallSyncState)
+		assert.Empty(t, rio.ipcMessages)
+	})
+
+	t.Run("worst of HOLDOVER and LOCKED is HOLDOVER", func(t *testing.T) {
+		bc, rio := newTestBCClock()
+		bc.syncState = PTP_HOLDOVER
+		bc.overallSyncState = PTP_NOTSET
+		bc.SystemClockUpdate(PTP_LOCKED)
+		assert.Equal(t, PTP_HOLDOVER, bc.overallSyncState)
+		require.Len(t, rio.ipcMessages, 1)
+		assert.Equal(t, ipc.TypeSyncState, rio.ipcMessages[0].Type)
+	})
+
+	t.Run("no change does not emit IPC", func(t *testing.T) {
+		bc, rio := newTestBCClock()
+		bc.syncState = PTP_FREERUN
+		bc.overallSyncState = PTP_FREERUN
+		bc.SystemClockUpdate(PTP_LOCKED)
+		assert.Equal(t, PTP_FREERUN, bc.overallSyncState)
+		assert.Empty(t, rio.ipcMessages)
+	})
+}
+
+func TestBCClock_UpdateClockClass(t *testing.T) {
+	t.Run("change emits clock_class IPC with iface", func(t *testing.T) {
+		bc, rio := newTestBCClock()
+		bc.addEvent(Event{IFace: testEns7f0, Data: &PTPData{State: PTP_LOCKED}})
+		rio.ipcMessages = nil // clear ptp_state IPC from addEvent
+		bc.updateClockClass(fbprotocol.ClockClass6)
+		require.Len(t, rio.ipcMessages, 1)
+		assert.Equal(t, ipc.TypeClockClass, rio.ipcMessages[0].Type)
+		assert.Equal(t, testPTP4lCfg, rio.ipcMessages[0].Profile)
+		assert.Equal(t, testEns7f0, rio.ipcMessages[0].IFace)
+		assert.Equal(t, ipc.ClockClassValue{ClockClass: 6}, rio.ipcMessages[0].Values)
+	})
+
+	t.Run("same class does not emit IPC", func(t *testing.T) {
+		bc, rio := newTestBCClock()
+		bc.clockClass = fbprotocol.ClockClass6
+		bc.updateClockClass(fbprotocol.ClockClass6)
+		assert.Empty(t, rio.ipcMessages)
+	})
+
+	t.Run("class change updates stored value", func(t *testing.T) {
+		bc, _ := newTestBCClock()
+		bc.updateClockClass(fbprotocol.ClockClass7)
+		assert.Equal(t, fbprotocol.ClockClass7, bc.clockClass)
+		bc.updateClockClass(fbprotocol.ClockClass6)
+		assert.Equal(t, fbprotocol.ClockClass6, bc.clockClass)
+	})
+}
+
+func TestBCClock_Interface(t *testing.T) {
+	bc, _ := newTestBCClock()
+	assert.Equal(t, BC, bc.ClockType())
+	assert.Equal(t, testPTP4lCfg, bc.ConfigName())
+}

--- a/pkg/event/event_gm.go
+++ b/pkg/event/event_gm.go
@@ -1,0 +1,454 @@
+package event
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	fbprotocol "github.com/facebook/time/ptp/protocol"
+	"github.com/golang/glog"
+	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/debug"
+	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/ipc"
+	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/parser"
+	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/protocol"
+	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/utils"
+)
+
+func (c *GMClock) ParentDSUpdate(_ protocol.ParentDataSet) {}
+
+func (c *GMClock) getData(processName EventSource) *Data {
+	for _, d := range c.data {
+		if d.ProcessName == processName {
+			return d
+		}
+	}
+	d := &Data{ProcessName: processName, State: PTP_UNKNOWN, window: *utils.NewWindow(WindowSize)}
+	c.data = append(c.data, d)
+	return d
+}
+
+func (c *GMClock) addEvent(event Event) (*DataDetails, clockSyncState) {
+	d := c.getData(event.Source)
+	d.AddEvent(event)
+	d.UpdateState()
+	clockState := c.updateState()
+	emitOverallSyncStateIfChanged(c.io, &c.overallSyncState, c.syncState.state, c.osClockState, c.cfgName)
+	c.announceClockClassIfChanged(event, clockState)
+	return d.GetDataDetails(event.IFace), clockState
+}
+
+func (c *GMClock) announceClockClassIfChanged(event Event, clockState clockSyncState) {
+	if clockState.clockClass == protocol.ClockClassUninitialized {
+		return
+	}
+
+	clockAccuracy := c.announcedClockAccuracy
+	if ptp, isPTP := event.Data.(*PTPData); isPTP && event.Source == DPLL {
+		if clockState.clockClass == fbprotocol.ClockClass7 || clockState.clockClass == protocol.ClockClassOutOfSpec {
+			if offset, found := ptp.Values[OFFSET]; found {
+				if offsetValue, isInt64 := offset.(int64); isInt64 {
+					clockAccuracy = fbprotocol.ClockAccuracyFromOffset(time.Duration(offsetValue) * time.Nanosecond)
+				}
+			}
+		}
+	}
+
+	if clockState.clockClass != c.announcedClockClass || clockAccuracy != c.announcedClockAccuracy {
+		glog.Infof("clock class change request from %d to %d with clock accuracy from %d to %d",
+			uint8(c.announcedClockClass), uint8(clockState.clockClass),
+			uint8(c.announcedClockAccuracy), uint8(clockAccuracy))
+		c.syncState.clockAccuracy = clockAccuracy
+		err, clockClass, _ := c.announceClockClass()
+		debug.UpdateClockClass(uint8(clockState.clockClass))
+		if err != nil {
+			glog.Errorf("error updating clock class %s", err)
+		} else {
+			glog.Infof("updated clock class to %d", clockClass)
+			c.io.emitClockClass(clockClass, c.cfgName)
+			clockClassOut := utils.GetClockClassLogMessage(PTP4lProcessName, c.cfgName, clockClass)
+			fmt.Printf("%s", clockClassOut)
+		}
+	}
+
+	if c.lastLoggedState != clockState.state {
+		glog.Infof("PTP State: %v, Clock Class %d Time %s sourceLost %v",
+			clockState.state, clockState.clockClass, time.Now(), clockState.sourceLost)
+		c.lastLoggedState = clockState.state
+	}
+}
+
+func (c *GMClock) isSourceLost() bool {
+	for _, d := range c.data {
+		if d.ProcessName == GNSS && len(d.Details) > 0 && d.Details[0] != nil {
+			return d.Details[0].sourceLost
+		}
+	}
+	return false
+}
+
+func (c *GMClock) getLeadingInterface() string {
+	for _, d := range c.data {
+		if d.ProcessName == GNSS && len(d.Details) > 0 {
+			return d.Details[0].IFace
+		} else if d.ProcessName == TS2PHCProcessName && len(d.Details) > 0 {
+			for _, dd := range d.Details {
+				if dd.signalSource == GNSS {
+					return dd.IFace
+				}
+			}
+		}
+	}
+	return LEADING_INTERFACE_UNKNOWN
+}
+
+func (c *GMClock) hasNonLeadingDPLLFault(leadingInterface string) bool {
+	if leadingInterface == LEADING_INTERFACE_UNKNOWN {
+		return false
+	}
+	for _, d := range c.data {
+		if d.ProcessName != DPLL {
+			continue
+		}
+		leadingDetail := d.GetDataDetails(leadingInterface)
+		if leadingDetail == nil || leadingDetail.State != PTP_LOCKED {
+			return false
+		}
+		for _, dd := range d.Details {
+			if dd.IFace != leadingInterface && dd.State != PTP_LOCKED {
+				glog.Infof("non-leading DPLL %s is %s while leading %s is locked, composite DPLL forced to FREERUN",
+					dd.IFace, dd.State, leadingInterface)
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func (c *GMClock) SystemClockUpdate(osClockState PTPState) {
+	c.osClockState = osClockState
+	emitOverallSyncStateIfChanged(c.io, &c.overallSyncState, c.syncState.state, c.osClockState, c.cfgName)
+}
+
+func (c *GMClock) updateClockClass(clockClass fbprotocol.ClockClass) {
+	if clockClass == c.syncState.clockClass {
+		return
+	}
+	c.syncState.clockClass = clockClass
+	c.io.sendIPC(ipc.Message{
+		Type:    ipc.TypeClockClass,
+		Profile: c.cfgName,
+		IFace:   c.syncState.leadingIFace,
+		Values:  ipc.ClockClassValue{ClockClass: uint8(clockClass)},
+	})
+}
+
+func (c *GMClock) announceClockClass() (err error, clockClass fbprotocol.ClockClass, clockAccuracy fbprotocol.ClockAccuracy) {
+	pmcCfgName := strings.Replace(c.cfgName, TS2PHCProcessName, PTP4lProcessName, 1)
+	g, err := c.io.getGMSettings(pmcCfgName)
+	if err != nil {
+		glog.Errorf("failed to get current GRANDMASTER_SETTINGS_NP: %s", err)
+		return err, clockClass, clockAccuracy
+	}
+	g.TimePropertiesDS.PtpTimescale = true
+	g.TimePropertiesDS.FrequencyTraceable = true
+	g.TimePropertiesDS.CurrentUtcOffsetValid = true
+	g.TimePropertiesDS.CurrentUtcOffset = int32(c.io.getUtcOffset())
+	switch c.syncState.clockClass {
+	case fbprotocol.ClockClass6:
+		if g.ClockQuality.ClockClass != fbprotocol.ClockClass6 || g.TimePropertiesDS.TimeTraceable != true {
+			g.ClockQuality.ClockClass = fbprotocol.ClockClass6
+			g.TimePropertiesDS.TimeTraceable = true
+			g.ClockQuality.ClockAccuracy = fbprotocol.ClockAccuracyNanosecond100
+			g.TimePropertiesDS.TimeSource = fbprotocol.TimeSourceGNSS
+			g.ClockQuality.OffsetScaledLogVariance = 0x4e5d
+			err = c.io.setGMSettings(pmcCfgName, g)
+		}
+	case protocol.ClockClassOutOfSpec:
+		if g.ClockQuality.ClockClass != protocol.ClockClassOutOfSpec {
+			g.ClockQuality.ClockClass = protocol.ClockClassOutOfSpec
+			g.TimePropertiesDS.TimeTraceable = false
+			g.ClockQuality.ClockAccuracy = c.syncState.clockAccuracy
+			g.TimePropertiesDS.TimeSource = fbprotocol.TimeSourceInternalOscillator
+			g.ClockQuality.OffsetScaledLogVariance = 0xffff
+			err = c.io.setGMSettings(pmcCfgName, g)
+		}
+	case fbprotocol.ClockClass7:
+		if g.ClockQuality.ClockClass != fbprotocol.ClockClass7 {
+			g.ClockQuality.ClockClass = fbprotocol.ClockClass7
+			g.TimePropertiesDS.TimeTraceable = true
+			g.ClockQuality.ClockAccuracy = c.syncState.clockAccuracy
+			g.TimePropertiesDS.TimeSource = fbprotocol.TimeSourceInternalOscillator
+			g.ClockQuality.OffsetScaledLogVariance = 0xffff
+			err = c.io.setGMSettings(pmcCfgName, g)
+		}
+	case protocol.ClockClassFreerun:
+		if g.ClockQuality.ClockClass != protocol.ClockClassFreerun {
+			g.ClockQuality.ClockClass = protocol.ClockClassFreerun
+			g.TimePropertiesDS.TimeTraceable = false
+			g.ClockQuality.ClockAccuracy = fbprotocol.ClockAccuracyUnknown
+			g.TimePropertiesDS.TimeSource = fbprotocol.TimeSourceInternalOscillator
+			g.ClockQuality.OffsetScaledLogVariance = 0xffff
+			err = c.io.setGMSettings(pmcCfgName, g)
+		}
+	default:
+		glog.Infof("No clock class identified for %d", c.syncState.clockClass)
+		err = fmt.Errorf("no clock class identified for %d", c.syncState.clockClass)
+	}
+	if err == nil {
+		c.announcedClockClass = g.ClockQuality.ClockClass
+		c.announcedClockAccuracy = g.ClockQuality.ClockAccuracy
+	}
+	return err, g.ClockQuality.ClockClass, g.ClockQuality.ClockAccuracy
+}
+
+// getGMState ... get lowest state of all the interfaces
+/*
+GNSS State + DPLL State= DPLL State
+DPLL STate + Ts2phc State =GM State
+----------------------------------------------------------------
+GNSS| Mode              | Offset   | State
+1.  | 0-2(Source LOST)  | in Range | FREERUN
+2.  | 0-2(Source LOST ) | out Range| FREERUN
+3.  | 3                 | in Range | LOCKED
+4.  | 3                 | out Range| FREERUN
+----------------------------------------------------------------
+DPLL | Frequency/Phase  	|  Offset  | GNSS STATE |  DPLL PTP STATE
+------------------------------------------------------------------
+1.  | -1/1/0           	| in Range |  LOCKED    | FREERUN
+2.  | -1/1/0           	| out Range|  FREERUN   | FREERUN
+-----------------------------------------------------------------
+3.  |  2 (LOCKED)       	| in Range |  LOCKED      | LOCKED
+4.  |  2 (LOCKED)       	| in Range |  FREERUN     | LOCKED
+-----------------------------------------------------------------
+SL :-> Source Lost
+------------------------------------------------------------------------------------------
+DPLL| Frequency/Phase      | Offset      | GNSS STATE               | DPLL PTP State
+------------------------------------------------------------------------------------------
+5   | 2 (LOCKED)           | Out Range   | All State                | FREERUN
+6.  | 3 (LOCK_ACQ_HOLDOVER)| In Range    | LOCKED                   | LOCKED
+7.  | 3 (LOCK_ACQ_HOLDOVER)| In/Out Range| FREERUN (SL)             | FREERUN
+8.  | 3 (LOCK_ACQ_HOLDOVER)| Out Range   | LOCKED                   | FREERUN
+*9. | 3 (LOCK_ACQ_HOLDOVER)| In/Out Range| FREERUN (SL)             | HOLDOVER
+------------------------------------------------------------------------------------------
+*10.| 4 (HOLDOVER)		| IN/Out Range   | FREERUN (SL)	            | HOLDOVER
+*11.| 4 (HOLDOVER)		| in/Out Range   | FREERUN (SL)             | AFTER TIME OUT
+                                                                    FREERUN OUT OF SPEC
+
+12. | 4 (HOLDOVER)		| in Range	     | LOCKED                   | LOCKED
+13. | 4 (HOLDOVER)		| Out Range	     | LOCKED                   | FREERUN
+14. | 4 (HOLDOVER)		| in Range       | FREERUN (SL)             | LOCKED
+15. | 4 (HOLDOVER)		| Out Range      | FREERUN (SL)             | FREERUN
+------------------------------------------------------------------------------------------
+FINAL GM STATE  *SL = Source Lost
+---------------------------------------------------------------------------------------------
+| DPLL PTP State        | GNSS PTP STATE    | TS2PHC PTP STATE | GM STATE  | Clock Class
+---------------------------------------------------------------------------------------------
+| FREERUN               | NA                | NA                | FREERUN  | 248
+| HOLDOVER IN SPEC      | NA                | NA                | HOLDOVER | 7
+| FREERUN OUT OF SPEC   | NA                | NA                | FREERUN  | 140
+| LOCKED                | LOCKED            | LOCKED            | LOCKED   | 6
+| LOCKED                | LOCKED            | FREERUN           | FREERUN  | 248
+| LOCKED                | *FREERUN (SL)     | LOCKED            | NA       | Wait for DPLL
+                                                                           | to move to HOLDOVER
+
+| LOCKED                | *FREERUN (SL)     | FREERUN           | NA       | Wait for DPLL
+                                                                           |to move to HOLDOVER
+
+| LOCKED                | *FREERUN(offset)  | LOCKED            | FREERUN  | 248
+| LOCKED                | *FREERUN(offset)  | FREERUN           | FREERUN  | 248
+ Final GM State When DPLL not available
+---------------------------------------------------------------------------------------------
+DPLL PTP State |  GNSS PTP STATE  |	TS2PHC PTP STATE| GM STATE | Clock Class
+---------------------------------------------------------------------------------------------
+| NA           |  FREERUN         |	LOCKED          | FREERUN  | 248
+| NA           |  FREERUN         |	FREERUN         | FREERUN  | 248
+| NA           |  LOCKED          |	FREERUN         | FREERUN  | 248
+| NA           |  LOCKED          |	LOCKED          | LOCKED   | 6
+
+*/
+// updateState computes the composite GM state from DPLL, GNSS, and ts2phc
+// data sources. It emits TypePTPState and TypeClockClass IPC on state/class change.
+func (c *GMClock) updateState() clockSyncState {
+	dpllState := PTP_NOTSET
+	gnssState := PTP_FREERUN
+	ts2phcState := PTP_FREERUN
+	syncSrcLost := c.isSourceLost()
+	leadingInterface := c.getLeadingInterface()
+	if leadingInterface == LEADING_INTERFACE_UNKNOWN {
+		glog.Infof("Leading interface is not yet identified, clock state reporting delayed.")
+		return clockSyncState{leadingIFace: leadingInterface}
+	}
+
+	c.syncState.sourceLost = syncSrcLost
+	c.syncState.leadingIFace = leadingInterface
+
+	var outOfSpec, frequencyTraceable bool
+	if c.data != nil {
+		for _, d := range c.data {
+			switch d.ProcessName {
+			case DPLL:
+				dpllState = d.State
+				if c.hasNonLeadingDPLLFault(leadingInterface) {
+					dpllState = PTP_FREERUN
+				}
+				if dd := d.GetDataDetails(leadingInterface); dd != nil {
+					outOfSpec = dd.outOfSpec
+					frequencyTraceable = dd.frequencyTraceable
+				}
+			case GNSS:
+				gnssState = d.State
+			case TS2PHCProcessName:
+				ts2phcState = d.State
+				if parser.NoSourceTSCount == 2 {
+					ts2phcState = PTP_FREERUN
+				}
+			}
+		}
+	} else {
+		c.syncState.state = PTP_FREERUN
+		c.syncState.clockClass = protocol.ClockClassFreerun
+		c.syncState.clockAccuracy = fbprotocol.ClockAccuracyUnknown
+		c.syncState.lastLoggedTime = time.Now().Unix()
+		c.syncState.clkLog = fmt.Sprintf("%s[%d]:[%s] %s T-GM-STATUS %s\n", GM, c.syncState.lastLoggedTime, c.cfgName, leadingInterface, c.syncState.state)
+		return c.syncState
+	}
+
+	prevState := c.syncState.state
+	prevClass := c.syncState.clockClass
+
+	switch dpllState {
+	case PTP_FREERUN:
+		c.syncState.state = dpllState
+		if outOfSpec && frequencyTraceable {
+			c.syncState.clockClass = protocol.ClockClassOutOfSpec
+		} else {
+			c.syncState.clockClass = protocol.ClockClassFreerun
+		}
+		c.syncState.clockAccuracy = fbprotocol.ClockAccuracyUnknown
+	case PTP_HOLDOVER:
+		c.syncState.state = dpllState
+		c.syncState.clockClass = fbprotocol.ClockClass7
+	case PTP_LOCKED, PTP_NOTSET:
+		switch gnssState {
+		case PTP_LOCKED:
+			switch ts2phcState {
+			case PTP_FREERUN:
+				c.syncState.state = PTP_FREERUN
+				c.syncState.clockClass = protocol.ClockClassFreerun
+				c.syncState.clockAccuracy = fbprotocol.ClockAccuracyUnknown
+			case PTP_LOCKED:
+				c.syncState.state = PTP_LOCKED
+				c.syncState.clockClass = fbprotocol.ClockClass6
+				c.syncState.clockAccuracy = fbprotocol.ClockAccuracyNanosecond100
+			case PTP_HOLDOVER:
+				c.syncState.state = PTP_HOLDOVER
+				c.syncState.clockClass = fbprotocol.ClockClass7
+			}
+		case PTP_FREERUN:
+			if syncSrcLost {
+				switch ts2phcState {
+				case PTP_LOCKED:
+				case PTP_FREERUN:
+					c.syncState.state = PTP_FREERUN
+				case PTP_HOLDOVER:
+					c.syncState.state = PTP_HOLDOVER
+					c.syncState.clockClass = fbprotocol.ClockClass7
+				}
+			} else {
+				switch ts2phcState {
+				case PTP_FREERUN, PTP_LOCKED, PTP_UNKNOWN, PTP_NOTSET:
+					c.syncState.state = PTP_FREERUN
+					c.syncState.clockClass = protocol.ClockClassFreerun
+					c.syncState.clockAccuracy = fbprotocol.ClockAccuracyUnknown
+				}
+			}
+		}
+	default:
+		switch gnssState {
+		case PTP_LOCKED:
+			switch ts2phcState {
+			case PTP_FREERUN, PTP_UNKNOWN, PTP_NOTSET:
+				c.syncState.state = PTP_FREERUN
+				c.syncState.clockClass = protocol.ClockClassFreerun
+				c.syncState.clockAccuracy = fbprotocol.ClockAccuracyUnknown
+			case PTP_LOCKED:
+				c.syncState.state = PTP_LOCKED
+				c.syncState.clockClass = fbprotocol.ClockClass6
+				c.syncState.clockAccuracy = fbprotocol.ClockAccuracyNanosecond100
+			case PTP_HOLDOVER:
+				c.syncState.state = PTP_HOLDOVER
+				c.syncState.clockClass = fbprotocol.ClockClass7
+			}
+		case PTP_FREERUN:
+			switch ts2phcState {
+			case PTP_FREERUN, PTP_LOCKED, PTP_UNKNOWN, PTP_NOTSET:
+				c.syncState.state = PTP_FREERUN
+				c.syncState.clockClass = protocol.ClockClassFreerun
+				c.syncState.clockAccuracy = fbprotocol.ClockAccuracyUnknown
+			case PTP_HOLDOVER:
+				c.syncState.state = PTP_HOLDOVER
+				c.syncState.clockClass = fbprotocol.ClockClass7
+			}
+		default:
+			c.syncState.state = ts2phcState
+			switch ts2phcState {
+			case PTP_FREERUN:
+				c.syncState.clockClass = protocol.ClockClassFreerun
+				c.syncState.clockAccuracy = fbprotocol.ClockAccuracyUnknown
+			case PTP_LOCKED:
+				c.syncState.clockClass = fbprotocol.ClockClass7
+				c.syncState.clockAccuracy = fbprotocol.ClockAccuracyNanosecond100
+			}
+		}
+	}
+
+	if gnssState != c.gnssState {
+		c.gnssState = gnssState
+		c.io.sendIPC(ipc.Message{
+			Type:    ipc.TypeGNSSState,
+			Profile: c.cfgName,
+			IFace:   leadingInterface,
+			Values:  ipc.GNSSStateValue{State: ptpStateToIPCState(gnssState)},
+		})
+	}
+
+	// TODO: the prevState != PTP_NOTSET guard suppresses the initial FREERUN
+	// IPC announcement. TBCClock and BCClock do NOT have this guard, so they
+	// report from PTP_NOTSET. Verify whether GM should also emit the first
+	// transition or if suppressing it is correct for multi-source init.
+	if c.syncState.state != prevState && prevState != PTP_NOTSET {
+		c.io.sendIPC(ipc.Message{
+			Type:    ipc.TypePTPState,
+			Profile: c.cfgName,
+			IFace:   leadingInterface,
+			Values:  ipc.StateValue{State: ptpStateToIPCState(c.syncState.state)},
+		})
+	}
+
+	if c.syncState.clockClass != prevClass && prevClass != protocol.ClockClassUninitialized {
+		c.io.sendIPC(ipc.Message{
+			Type:    ipc.TypeClockClass,
+			Profile: c.cfgName,
+			IFace:   leadingInterface,
+			Values:  ipc.ClockClassValue{ClockClass: uint8(c.syncState.clockClass)},
+		})
+	}
+
+	result := clockSyncState{
+		state:         c.syncState.state,
+		clockClass:    c.syncState.clockClass,
+		clockAccuracy: c.syncState.clockAccuracy,
+		sourceLost:    c.syncState.sourceLost,
+		leadingIFace:  c.syncState.leadingIFace,
+	}
+
+	logTime := time.Now().Unix()
+	if c.syncState.lastLoggedTime != logTime {
+		clkLog := fmt.Sprintf("%s[%d]:[%s] %s T-GM-STATUS %s\n", GM, logTime, c.cfgName, leadingInterface, c.syncState.state)
+		c.syncState.lastLoggedTime = logTime
+		c.syncState.clkLog = clkLog
+		result.clkLog = clkLog
+		glog.Infof("dpll State %s, gnss State %s, tsphc state %s, gm state %s,", dpllState, gnssState, ts2phcState, c.syncState.state)
+	}
+	return result
+}

--- a/pkg/event/event_gm_test.go
+++ b/pkg/event/event_gm_test.go
@@ -1,0 +1,343 @@
+package event
+
+import (
+	"fmt"
+	"testing"
+
+	fbprotocol "github.com/facebook/time/ptp/protocol"
+	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/ipc"
+	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/protocol"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestGMClock() (*GMClock, *recordingClockIO) {
+	rio := &recordingClockIO{}
+	gm := &GMClock{
+		cfgName: "ts2phc.0.config",
+		io:      rio,
+		syncState: clockSyncState{
+			state:         PTP_NOTSET,
+			clockClass:    protocol.ClockClassUninitialized,
+			clockAccuracy: fbprotocol.ClockAccuracyUnknown,
+		},
+		overallSyncState: PTP_NOTSET,
+		osClockState:     PTP_NOTSET,
+		gnssState:        PTP_NOTSET,
+	}
+	return gm, rio
+}
+
+func gmData(process EventSource, state PTPState) *Data {
+	d := &Data{
+		ProcessName: process,
+		State:       state,
+		Details: []*DataDetails{{
+			IFace: "ens1f0",
+			State: state,
+		}},
+	}
+	if process == TS2PHCProcessName {
+		d.Details[0].signalSource = GNSS
+	}
+	return d
+}
+
+func TestGMClock_UpdateState_IPCEmission(t *testing.T) {
+	const cfg = "ts2phc.0.config"
+	const iface = "ens1f0"
+
+	t.Run("FREERUN to LOCKED emits TypePTPState", func(t *testing.T) {
+		gm, rio := newTestGMClock()
+
+		// First call: establish FREERUN (from PTP_NOTSET, no IPC emitted)
+		gm.data = []*Data{
+			gmData(GNSS, PTP_LOCKED),
+			gmData(DPLL, PTP_LOCKED),
+			gmData(TS2PHCProcessName, PTP_FREERUN),
+		}
+		result := gm.updateState()
+		assert.Equal(t, PTP_FREERUN, result.state)
+
+		var gotGNSS bool
+		for _, msg := range rio.ipcMessages {
+			assert.NotEqual(t, ipc.TypePTPState, msg.Type, "no TypePTPState IPC from PTP_NOTSET→FREERUN")
+			if msg.Type == ipc.TypeGNSSState {
+				gv := msg.Values.(ipc.GNSSStateValue)
+				assert.Equal(t, ipc.StateLocked, gv.State)
+				assert.Equal(t, cfg, msg.Profile)
+				assert.Equal(t, iface, msg.IFace)
+				gotGNSS = true
+			}
+		}
+		assert.True(t, gotGNSS, "expected TypeGNSSState LOCKED on initial GNSS transition")
+		rio.ipcMessages = nil
+
+		// Second call: transition to LOCKED
+		gm.data[2] = gmData(TS2PHCProcessName, PTP_LOCKED)
+		result = gm.updateState()
+		assert.Equal(t, PTP_LOCKED, result.state)
+		assert.Equal(t, fbprotocol.ClockClass6, result.clockClass)
+
+		var gotState, gotClass6 bool
+		for _, msg := range rio.ipcMessages {
+			if msg.Type == ipc.TypePTPState {
+				sv := msg.Values.(ipc.StateValue)
+				assert.Equal(t, ipc.StateLocked, sv.State)
+				assert.Equal(t, cfg, msg.Profile)
+				gotState = true
+			}
+			if msg.Type == ipc.TypeClockClass {
+				cv := msg.Values.(ipc.ClockClassValue)
+				assert.Equal(t, uint8(6), cv.ClockClass)
+				gotClass6 = true
+			}
+			assert.NotEqual(t, ipc.TypeGNSSState, msg.Type, "no GNSS IPC when GNSS state unchanged")
+		}
+		assert.True(t, gotState, "expected TypePTPState LOCKED")
+		assert.True(t, gotClass6, "expected TypeClockClass 6 on FREERUN→LOCKED")
+	})
+
+	t.Run("LOCKED to HOLDOVER emits TypePTPState and TypeClockClass", func(t *testing.T) {
+		gm, rio := newTestGMClock()
+
+		// Establish FREERUN then LOCKED
+		gm.data = []*Data{
+			gmData(GNSS, PTP_LOCKED),
+			gmData(DPLL, PTP_LOCKED),
+			gmData(TS2PHCProcessName, PTP_FREERUN),
+		}
+		gm.updateState()
+		gm.data[2] = gmData(TS2PHCProcessName, PTP_LOCKED)
+		gm.updateState()
+		rio.ipcMessages = nil // clear
+
+		// DPLL holdover
+		gm.data[1] = gmData(DPLL, PTP_HOLDOVER)
+		result := gm.updateState()
+		assert.Equal(t, PTP_HOLDOVER, result.state)
+		assert.Equal(t, fbprotocol.ClockClass7, result.clockClass)
+
+		var gotState, gotClass bool
+		for _, msg := range rio.ipcMessages {
+			if msg.Type == ipc.TypePTPState {
+				sv := msg.Values.(ipc.StateValue)
+				assert.Equal(t, ipc.StateHoldover, sv.State)
+				gotState = true
+			}
+			if msg.Type == ipc.TypeClockClass {
+				cv := msg.Values.(ipc.ClockClassValue)
+				assert.Equal(t, uint8(7), cv.ClockClass)
+				gotClass = true
+			}
+			assert.NotEqual(t, ipc.TypeGNSSState, msg.Type, "no GNSS IPC when GNSS state unchanged")
+		}
+		assert.True(t, gotState, "expected TypePTPState HOLDOVER")
+		assert.True(t, gotClass, "expected TypeClockClass 7")
+	})
+
+	t.Run("duplicate state produces no IPC", func(t *testing.T) {
+		gm, rio := newTestGMClock()
+
+		gm.data = []*Data{
+			gmData(GNSS, PTP_LOCKED),
+			gmData(DPLL, PTP_LOCKED),
+			gmData(TS2PHCProcessName, PTP_FREERUN),
+		}
+		gm.updateState()
+		gm.updateState()
+		rio.ipcMessages = nil
+
+		// Same state again
+		gm.updateState()
+		assert.Empty(t, rio.ipcMessages, "duplicate events should not emit IPC")
+	})
+
+	t.Run("GNSS LOCKED to FREERUN emits TypeGNSSState", func(t *testing.T) {
+		gm, rio := newTestGMClock()
+
+		// Establish GNSS LOCKED
+		gm.data = []*Data{
+			gmData(GNSS, PTP_LOCKED),
+			gmData(DPLL, PTP_LOCKED),
+			gmData(TS2PHCProcessName, PTP_FREERUN),
+		}
+		gm.updateState()
+		rio.ipcMessages = nil
+
+		// GNSS drops to FREERUN
+		gm.data[0] = gmData(GNSS, PTP_FREERUN)
+		gm.updateState()
+
+		var gotGNSS bool
+		for _, msg := range rio.ipcMessages {
+			if msg.Type == ipc.TypeGNSSState {
+				gv := msg.Values.(ipc.GNSSStateValue)
+				assert.Equal(t, ipc.StateFreerun, gv.State)
+				assert.Equal(t, cfg, msg.Profile)
+				assert.Equal(t, iface, msg.IFace)
+				gotGNSS = true
+			}
+		}
+		assert.True(t, gotGNSS, "expected TypeGNSSState FREERUN when GNSS drops")
+	})
+
+	t.Run("LOCKED to FREERUN emits TypeClockClass 248", func(t *testing.T) {
+		gm, rio := newTestGMClock()
+
+		// Establish LOCKED
+		gm.data = []*Data{
+			gmData(GNSS, PTP_LOCKED),
+			gmData(DPLL, PTP_LOCKED),
+			gmData(TS2PHCProcessName, PTP_FREERUN),
+		}
+		gm.updateState()
+		gm.data[2] = gmData(TS2PHCProcessName, PTP_LOCKED)
+		gm.updateState()
+		rio.ipcMessages = nil
+
+		// ts2phc FREERUN → GM FREERUN
+		gm.data[2] = gmData(TS2PHCProcessName, PTP_FREERUN)
+		result := gm.updateState()
+		assert.Equal(t, PTP_FREERUN, result.state)
+		assert.Equal(t, protocol.ClockClassFreerun, result.clockClass)
+
+		var gotClass bool
+		for _, msg := range rio.ipcMessages {
+			if msg.Type == ipc.TypeClockClass {
+				cv := msg.Values.(ipc.ClockClassValue)
+				assert.Equal(t, uint8(protocol.ClockClassFreerun), cv.ClockClass)
+				gotClass = true
+			}
+		}
+		assert.True(t, gotClass, "expected TypeClockClass 248")
+	})
+}
+
+func TestGMClock_UpdateOSClockState(t *testing.T) {
+	gm, rio := newTestGMClock()
+	gm.syncState.state = PTP_LOCKED
+
+	gm.SystemClockUpdate(PTP_LOCKED)
+	assert.Equal(t, PTP_LOCKED, gm.overallSyncState, "first call from PTP_NOTSET should change")
+	assert.Equal(t, PTP_LOCKED, gm.osClockState)
+	require.Len(t, rio.ipcMessages, 1)
+	assert.Equal(t, ipc.TypeSyncState, rio.ipcMessages[0].Type)
+
+	rio.ipcMessages = nil
+	gm.SystemClockUpdate(PTP_LOCKED)
+	assert.Empty(t, rio.ipcMessages, "same state should not emit IPC")
+
+	gm.SystemClockUpdate(PTP_FREERUN)
+	assert.Equal(t, PTP_FREERUN, gm.overallSyncState, "OS clock FREERUN should degrade overall")
+	require.Len(t, rio.ipcMessages, 1)
+	assert.Equal(t, ipc.TypeSyncState, rio.ipcMessages[0].Type)
+	assert.Equal(t, ipc.SyncStateValue{State: ipc.StateFreerun}, rio.ipcMessages[0].Values)
+}
+
+func TestGMClock_UpdateClockClass(t *testing.T) {
+	gm, rio := newTestGMClock()
+	gm.syncState.clockClass = fbprotocol.ClockClass6
+	gm.syncState.leadingIFace = "ens1f0"
+
+	// Same class → no IPC
+	gm.updateClockClass(fbprotocol.ClockClass6)
+	assert.Empty(t, rio.ipcMessages)
+
+	// Different class → IPC emitted
+	gm.updateClockClass(fbprotocol.ClockClass7)
+	assert.Len(t, rio.ipcMessages, 1)
+	assert.Equal(t, ipc.TypeClockClass, rio.ipcMessages[0].Type)
+	cv := rio.ipcMessages[0].Values.(ipc.ClockClassValue)
+	assert.Equal(t, uint8(7), cv.ClockClass)
+}
+
+func TestGMClock_AnnounceClockClassIfChanged(t *testing.T) {
+	t.Run("skips when clockClass is uninitialized", func(t *testing.T) {
+		gm, rio := newTestGMClock()
+		gm.announceClockClassIfChanged(
+			Event{Source: DPLL, Data: &PTPData{Values: map[ValueType]interface{}{OFFSET: int64(50)}}},
+			clockSyncState{state: PTP_LOCKED, clockClass: protocol.ClockClassUninitialized},
+		)
+		assert.Empty(t, rio.setGMCalls)
+	})
+
+	t.Run("sets GM settings on class change", func(t *testing.T) {
+		gm, rio := newTestGMClock()
+		gm.announcedClockClass = fbprotocol.ClockClass6
+		gm.announcedClockAccuracy = fbprotocol.ClockAccuracyNanosecond100
+		gm.syncState.clockClass = protocol.ClockClassFreerun
+		gm.announceClockClassIfChanged(
+			Event{Source: GNSS, Data: &GNSSData{}},
+			clockSyncState{state: PTP_FREERUN, clockClass: protocol.ClockClassFreerun},
+		)
+		require.Len(t, rio.setGMCalls, 1)
+		assert.Equal(t, protocol.ClockClassFreerun, rio.setGMCalls[0].ClockQuality.ClockClass)
+		assert.Equal(t, fbprotocol.ClockAccuracyUnknown, rio.setGMCalls[0].ClockQuality.ClockAccuracy)
+	})
+
+	t.Run("no PMC call when class and accuracy unchanged", func(t *testing.T) {
+		gm, rio := newTestGMClock()
+		gm.announcedClockClass = fbprotocol.ClockClass6
+		gm.announcedClockAccuracy = fbprotocol.ClockAccuracyNanosecond100
+		gm.syncState.clockClass = fbprotocol.ClockClass6
+		gm.announceClockClassIfChanged(
+			Event{Source: GNSS, Data: &GNSSData{}},
+			clockSyncState{state: PTP_LOCKED, clockClass: fbprotocol.ClockClass6},
+		)
+		assert.Empty(t, rio.setGMCalls)
+	})
+
+	t.Run("DPLL holdover computes accuracy from offset", func(t *testing.T) {
+		gm, rio := newTestGMClock()
+		gm.announcedClockClass = fbprotocol.ClockClass6
+		gm.announcedClockAccuracy = fbprotocol.ClockAccuracyNanosecond100
+		gm.syncState.clockClass = fbprotocol.ClockClass7
+		gm.announceClockClassIfChanged(
+			Event{Source: DPLL, Data: &PTPData{Values: map[ValueType]interface{}{OFFSET: int64(500)}}},
+			clockSyncState{state: PTP_HOLDOVER, clockClass: fbprotocol.ClockClass7},
+		)
+		require.Len(t, rio.setGMCalls, 1)
+		assert.Equal(t, fbprotocol.ClockClass7, rio.setGMCalls[0].ClockQuality.ClockClass)
+		assert.NotEqual(t, fbprotocol.ClockAccuracyUnknown, rio.setGMCalls[0].ClockQuality.ClockAccuracy)
+	})
+
+	t.Run("updates announcedClockClass on success", func(t *testing.T) {
+		gm, _ := newTestGMClock()
+		gm.announcedClockClass = fbprotocol.ClockClass6
+		gm.announcedClockAccuracy = fbprotocol.ClockAccuracyNanosecond100
+		gm.syncState.clockClass = protocol.ClockClassFreerun
+		gm.announceClockClassIfChanged(
+			Event{Source: GNSS, Data: &GNSSData{}},
+			clockSyncState{state: PTP_FREERUN, clockClass: protocol.ClockClassFreerun},
+		)
+		assert.Equal(t, protocol.ClockClassFreerun, gm.announcedClockClass)
+	})
+
+	t.Run("does not update announcedClockClass on setGMSettings error", func(t *testing.T) {
+		gm, rio := newTestGMClock()
+		rio.setGMErr = fmt.Errorf("pmc error")
+		gm.announcedClockClass = fbprotocol.ClockClass6
+		gm.announcedClockAccuracy = fbprotocol.ClockAccuracyNanosecond100
+		gm.syncState.clockClass = protocol.ClockClassFreerun
+		gm.announceClockClassIfChanged(
+			Event{Source: GNSS, Data: &GNSSData{}},
+			clockSyncState{state: PTP_FREERUN, clockClass: protocol.ClockClassFreerun},
+		)
+		assert.Equal(t, fbprotocol.ClockClass6, gm.announcedClockClass,
+			"announcedClockClass must not change when PMC write fails")
+	})
+
+	t.Run("emits clock class on success", func(t *testing.T) {
+		gm, rio := newTestGMClock()
+		gm.announcedClockClass = fbprotocol.ClockClass6
+		gm.announcedClockAccuracy = fbprotocol.ClockAccuracyNanosecond100
+		gm.syncState.clockClass = protocol.ClockClassFreerun
+		gm.announceClockClassIfChanged(
+			Event{Source: GNSS, Data: &GNSSData{}},
+			clockSyncState{state: PTP_FREERUN, clockClass: protocol.ClockClassFreerun},
+		)
+		require.Len(t, rio.emittedClasses, 1)
+		assert.Equal(t, protocol.ClockClassFreerun, rio.emittedClasses[0])
+	})
+}

--- a/pkg/event/event_internal_test.go
+++ b/pkg/event/event_internal_test.go
@@ -2,99 +2,99 @@
 package event
 
 import (
+	"sync"
 	"testing"
 	"time"
 
 	fbprotocol "github.com/facebook/time/ptp/protocol"
+	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/ipc"
+	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/pmc"
 	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/protocol"
 	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/utils"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type MockData struct {
 	Data map[string][]*Data
 }
 
-type MockEventHandler struct {
-	Event Event
-	e     EventHandler
+type noopClockIO struct{ sync.Mutex }
+
+func (n *noopClockIO) emitClockClass(fbprotocol.ClockClass, string) {}
+func (n *noopClockIO) sendIPC(ipc.Message)                          {}
+func (n *noopClockIO) getGMSettings(string) (protocol.GrandmasterSettings, error) {
+	return protocol.GrandmasterSettings{}, nil
+}
+func (n *noopClockIO) setGMSettings(string, protocol.GrandmasterSettings) error { return nil }
+func (n *noopClockIO) setExternalGMPropertiesNP(string, protocol.ExternalGrandmasterProperties) error {
+	return nil
+}
+func (n *noopClockIO) getParentTimeAndCurrentDS(string) (pmc.ParentTimeCurrentDS, error) {
+	return pmc.ParentTimeCurrentDS{}, nil
+}
+func (n *noopClockIO) getUtcOffset() int { return 37 }
+
+func newTestTBCClock(lcp *LeadingClockParams) *TBCClock {
+	if lcp == nil {
+		lcp = newLeadingClockParams()
+	}
+	return &TBCClock{
+		io:               &noopClockIO{},
+		leadingClockData: lcp,
+		syncState: clockSyncState{
+			state:         PTP_FREERUN,
+			clockClass:    protocol.ClockClassUninitialized,
+			clockAccuracy: fbprotocol.ClockAccuracyUnknown,
+		},
+		overallSyncState: PTP_FREERUN,
+		osClockState:     PTP_NOTSET,
+	}
 }
 
-func TestConvergeConfig(t *testing.T) {
-	t.Run("PTP4lProcessName with matching IFace", func(t *testing.T) {
-		mockData := &MockData{
-			Data: map[string][]*Data{
-				"config1": {
-					{ProcessName: DPLL, Details: DDetails{{IFace: "eth0"}}},
-				},
-			},
+func TestAddEvent_NormalizesCfgName(t *testing.T) {
+	t.Run("PTP4l event gets cfgName from TBCClock", func(t *testing.T) {
+		bc := newTestTBCClock(nil)
+		bc.cfgName = testTS2PHCCfg
+		ev := Event{
+			Source:  PTP4lProcessName,
+			CfgName: testPTP4lCfg,
+			IFace:   testEth0,
 		}
-		mockEventHandler := &MockEventHandler{
-			e: EventHandler{
-				data: mockData.Data,
-			},
-
-			Event: Event{
-				Source: PTP4lProcessName,
-				IFace:  "eth0",
-			},
-		}
-		mockEventHandler.Event = mockEventHandler.e.convergeConfig(mockEventHandler.Event)
-		assert.Equal(t, "config1", mockEventHandler.Event.CfgName)
+		ev, _, _ = bc.addEvent(ev)
+		assert.Equal(t, testTS2PHCCfg, ev.CfgName)
 	})
 
-	t.Run("PTP4lProcessName without matching IFace", func(t *testing.T) {
-		mockData := &MockData{
-			Data: map[string][]*Data{
-				"config1": {
-					{ProcessName: DPLL, Details: DDetails{{IFace: "ens4f1"}}},
-				},
-			},
+	t.Run("Non-PTP4l event keeps original cfgName", func(t *testing.T) {
+		bc := newTestTBCClock(nil)
+		bc.cfgName = testTS2PHCCfg
+		ev := Event{
+			Source:  DPLL,
+			CfgName: testTS2PHCCfg,
+			IFace:   testEth0,
 		}
-		mockEventHandler := &MockEventHandler{
-			e: EventHandler{
-				data: mockData.Data,
-			},
-			Event: Event{
-				Source: PTP4lProcessName,
-				IFace:  "ens5f0",
-			},
-		}
-
-		mockEventHandler.Event = mockEventHandler.e.convergeConfig(mockEventHandler.Event)
-		assert.Equal(t, "", mockEventHandler.Event.CfgName)
-	})
-
-	t.Run("Non-PTP4lProcessName", func(t *testing.T) {
-		mockData := &MockData{
-			Data: map[string][]*Data{
-				"config1": {
-					{ProcessName: DPLL, Details: DDetails{{IFace: "eth0"}}},
-				},
-			},
-		}
-		mockEventHandler := &MockEventHandler{
-			e: EventHandler{
-				data: mockData.Data,
-			},
-			Event: Event{
-				Source: "otherProcess",
-				IFace:  "eth0",
-			},
-		}
-
-		mockEventHandler.Event = mockEventHandler.e.convergeConfig(mockEventHandler.Event)
-		assert.Equal(t, "", mockEventHandler.Event.CfgName)
+		ev, _, _ = bc.addEvent(ev)
+		assert.Equal(t, testTS2PHCCfg, ev.CfgName)
 	})
 }
 
 const (
-	testConfig = "config"
-	testIface  = "iface"
+	testConfig      = "config"
+	testIface       = "iface"
+	testEth0        = "eth0"
+	testEth1        = "eth1"
+	testEth2        = "eth2"
+	testEth99       = "eth99"
+	testIFace1      = "IFace1"
+	testIface1Lower = "iface1"
+	testEno8703     = "eno8703"
+	testEns7f0      = "ens7f0"
+	testPTP4lCfg    = "ptp4l.0.config"
+	testTS2PHCCfg   = "ts2phc.0.config"
 )
 
 func TestUpdateLeadingClockData_PTP4lProcessName(t *testing.T) {
-	event := Event{
+	ev := Event{
 		Source: PTP4lProcessName,
 		Data: &PTPData{
 			Values: map[ValueType]interface{}{
@@ -104,22 +104,15 @@ func TestUpdateLeadingClockData_PTP4lProcessName(t *testing.T) {
 		},
 	}
 
-	expectedLeadingClockData := LeadingClockParams{
-		controlledPortsConfig: testConfig,
-		clockID:               "clockID",
-	}
+	bc := newTestTBCClock(&LeadingClockParams{})
+	bc.updateLeadingClockData(ev)
 
-	e := EventHandler{
-		LeadingClockData: &LeadingClockParams{},
-	}
-	e.updateLeadingClockData(event)
-
-	assert.Equal(t, expectedLeadingClockData.controlledPortsConfig, e.LeadingClockData.controlledPortsConfig)
-	assert.Equal(t, expectedLeadingClockData.clockID, e.LeadingClockData.clockID)
+	assert.Equal(t, testConfig, bc.leadingClockData.controlledPortsConfig)
+	assert.Equal(t, "clockID", bc.leadingClockData.clockID)
 }
 
 func TestUpdateLeadingClockData_DPLL(t *testing.T) {
-	event := Event{
+	ev := Event{
 		Source: DPLL,
 		IFace:  testIface,
 		Data: &PTPData{
@@ -133,53 +126,38 @@ func TestUpdateLeadingClockData_DPLL(t *testing.T) {
 		},
 	}
 
-	expectedLeadingClockData := LeadingClockParams{
-		leadingInterface:         testIface,
-		inSyncConditionThreshold: 100,
-		inSyncConditionTimes:     200,
-		toFreeRunThreshold:       300,
-		MaxInSpecOffset:          400,
-	}
+	bc := newTestTBCClock(&LeadingClockParams{})
+	bc.updateLeadingClockData(ev)
 
-	e := EventHandler{
-		LeadingClockData: &LeadingClockParams{},
-	}
-	e.updateLeadingClockData(event)
-
-	assert.Equal(t, expectedLeadingClockData.leadingInterface, e.LeadingClockData.leadingInterface)
-	assert.Equal(t, expectedLeadingClockData.inSyncConditionThreshold, e.LeadingClockData.inSyncConditionThreshold)
-	assert.Equal(t, expectedLeadingClockData.inSyncConditionTimes, e.LeadingClockData.inSyncConditionTimes)
-	assert.Equal(t, expectedLeadingClockData.toFreeRunThreshold, e.LeadingClockData.toFreeRunThreshold)
-	assert.Equal(t, expectedLeadingClockData.MaxInSpecOffset, e.LeadingClockData.MaxInSpecOffset)
+	assert.Equal(t, testIface, bc.leadingClockData.leadingInterface)
+	assert.Equal(t, 100, bc.leadingClockData.inSyncConditionThreshold)
+	assert.Equal(t, 200, bc.leadingClockData.inSyncConditionTimes)
+	assert.Equal(t, 300, bc.leadingClockData.toFreeRunThreshold)
+	assert.Equal(t, uint64(400), bc.leadingClockData.MaxInSpecOffset)
 }
 
 func TestGetLeadingInterfaceBC(t *testing.T) {
 	tests := []struct {
 		name     string
-		input    *EventHandler
+		lcp      *LeadingClockParams
 		expected string
 	}{
 		{
-			name: "LeadingInterface is not empty",
-			input: &EventHandler{
-				LeadingClockData: &LeadingClockParams{
-					leadingInterface: "eth0",
-				},
-			},
-			expected: "eth0",
+			name:     "LeadingInterface is not empty",
+			lcp:      &LeadingClockParams{leadingInterface: testEth0},
+			expected: testEth0,
 		},
 		{
-			name: "LeadingInterface is empty",
-			input: &EventHandler{
-				LeadingClockData: &LeadingClockParams{},
-			},
+			name:     "LeadingInterface is empty",
+			lcp:      &LeadingClockParams{},
 			expected: LEADING_INTERFACE_UNKNOWN,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := tt.input.getLeadingInterfaceBC()
+			bc := newTestTBCClock(tt.lcp)
+			result := bc.getLeadingInterfaceBC()
 			assert.Equal(t, tt.expected, result)
 		})
 	}
@@ -187,155 +165,128 @@ func TestGetLeadingInterfaceBC(t *testing.T) {
 
 func TestInSpecCondition(t *testing.T) {
 	t.Run("returns false when MaxInSpecOffset is 0", func(t *testing.T) {
-		e := EventHandler{
-			LeadingClockData: &LeadingClockParams{MaxInSpecOffset: 0},
-		}
-		result := e.inSpecCondition("testConfig")
+		bc := newTestTBCClock(&LeadingClockParams{MaxInSpecOffset: 0})
+		result := bc.inSpecCondition()
 		assert.False(t, result)
 	})
 
 	t.Run("returns false when offset is out of spec", func(t *testing.T) {
-		e := EventHandler{
-			data: map[string][]*Data{
-				"testConfig": {
-					{ProcessName: DPLL, Details: []*DataDetails{{IFace: "iface1", Offset: 10}}},
-				},
-			},
-			clkSyncState: map[string]*clockSyncState{
-				"testConfig": {leadingIFace: "iface1"},
-			},
-			LeadingClockData: &LeadingClockParams{MaxInSpecOffset: 5},
+		bc := newTestTBCClock(&LeadingClockParams{MaxInSpecOffset: 5})
+		bc.data = []*Data{
+			{ProcessName: DPLL, Details: []*DataDetails{{IFace: testIface1Lower, Offset: 10}}},
 		}
-		result := e.inSpecCondition("testConfig")
+		bc.syncState.leadingIFace = testIface1Lower
+		result := bc.inSpecCondition()
 		assert.False(t, result)
 	})
 
 	t.Run("returns true when offset is in spec", func(t *testing.T) {
-		e := EventHandler{
-			data: map[string][]*Data{
-				"testConfig": {
-					{ProcessName: DPLL, Details: []*DataDetails{{IFace: "iface1", Offset: 3}}},
-				},
-			},
-			clkSyncState: map[string]*clockSyncState{
-				"testConfig": {leadingIFace: "iface1"},
-			},
-			LeadingClockData: &LeadingClockParams{MaxInSpecOffset: 5},
+		bc := newTestTBCClock(&LeadingClockParams{MaxInSpecOffset: 5})
+		bc.data = []*Data{
+			{ProcessName: DPLL, Details: []*DataDetails{{IFace: testIface1Lower, Offset: 3}}},
 		}
-		result := e.inSpecCondition("testConfig")
+		bc.syncState.leadingIFace = testIface1Lower
+		result := bc.inSpecCondition()
 		assert.True(t, result)
 	})
 }
 
 func TestFreeRunCondition(t *testing.T) {
 	tests := []struct {
-		name       string
-		cfgName    string
-		data       map[string][]*Data
-		syncState  map[string]*clockSyncState
-		threshold  int
-		fillWindow bool
-		expected   bool
+		name         string
+		data         []*Data
+		leadingIFace string
+		threshold    int
+		fillWindow   bool
+		expected     bool
 	}{
 		{
-			name:      "Free run condition not met",
-			cfgName:   "test",
-			data:      map[string][]*Data{"test": {{ProcessName: DPLL, Details: []*DataDetails{{IFace: "IFace1", Offset: 5}}}}},
-			syncState: map[string]*clockSyncState{"test": {leadingIFace: "IFace1"}},
-			threshold: 10,
-			expected:  false,
+			name:         "Free run condition not met",
+			data:         []*Data{{ProcessName: DPLL, Details: []*DataDetails{{IFace: testIFace1, Offset: 5}}}},
+			leadingIFace: testIFace1,
+			threshold:    10,
+			expected:     false,
 		},
 		{
-			name:      "Free run condition met",
-			cfgName:   "test",
-			data:      map[string][]*Data{"test": {{ProcessName: DPLL, Details: []*DataDetails{{IFace: "IFace1", Offset: 15}}}}},
-			syncState: map[string]*clockSyncState{"test": {leadingIFace: "IFace1"}},
-			threshold: 10,
-			expected:  true,
+			name:         "Free run condition met",
+			data:         []*Data{{ProcessName: DPLL, Details: []*DataDetails{{IFace: testIFace1, Offset: 15}}}},
+			leadingIFace: testIFace1,
+			threshold:    10,
+			expected:     true,
 		},
 		{
-			name:      "Free run condition pending initialization",
-			cfgName:   "test",
-			data:      map[string][]*Data{},
-			syncState: map[string]*clockSyncState{"test": {leadingIFace: "IFace1"}},
-			threshold: 0,
-			expected:  true,
+			name:         "Free run condition pending initialization",
+			data:         nil,
+			leadingIFace: testIFace1,
+			threshold:    0,
+			expected:     true,
 		},
 		{
-			name:    "Free run condition met via PTP4l window mean",
-			cfgName: "test",
-			data: map[string][]*Data{"test": {
-				{ProcessName: DPLL, Details: []*DataDetails{{IFace: "IFace1", Offset: 5}}},
-				{ProcessName: PTP4l, Details: []*DataDetails{{IFace: "IFace1", Offset: 9798319463}}},
-			}},
-			syncState:  map[string]*clockSyncState{"test": {leadingIFace: "IFace1"}},
-			threshold:  1500,
-			fillWindow: true,
-			expected:   true,
+			name: "Free run condition met via PTP4l window mean",
+			data: []*Data{
+				{ProcessName: DPLL, Details: []*DataDetails{{IFace: testIFace1, Offset: 5}}},
+				{ProcessName: PTP4l, Details: []*DataDetails{{IFace: testIFace1, Offset: 9798319463}}},
+			},
+			leadingIFace: testIFace1,
+			threshold:    1500,
+			fillWindow:   true,
+			expected:     true,
 		},
 		{
-			name:    "PTP4l window mean below threshold does not trigger free run",
-			cfgName: "test",
-			data: map[string][]*Data{"test": {
-				{ProcessName: DPLL, Details: []*DataDetails{{IFace: "IFace1", Offset: 5}}},
-				{ProcessName: PTP4l, Details: []*DataDetails{{IFace: "IFace1", Offset: 100}}},
-			}},
-			syncState:  map[string]*clockSyncState{"test": {leadingIFace: "IFace1"}},
-			threshold:  1500,
-			fillWindow: true,
-			expected:   false,
+			name: "PTP4l window mean below threshold does not trigger free run",
+			data: []*Data{
+				{ProcessName: DPLL, Details: []*DataDetails{{IFace: testIFace1, Offset: 5}}},
+				{ProcessName: PTP4l, Details: []*DataDetails{{IFace: testIFace1, Offset: 100}}},
+			},
+			leadingIFace: testIFace1,
+			threshold:    1500,
+			fillWindow:   true,
+			expected:     false,
 		},
 		{
-			name:    "PTP4l with empty window is skipped",
-			cfgName: "test",
-			data: map[string][]*Data{"test": {
-				{ProcessName: DPLL, Details: []*DataDetails{{IFace: "IFace1", Offset: 5}}},
-				{ProcessName: PTP4l, Details: []*DataDetails{{IFace: "IFace1", Offset: 9798319463}}},
-			}},
-			syncState: map[string]*clockSyncState{"test": {leadingIFace: "IFace1"}},
-			threshold: 1500,
-			expected:  false,
+			name: "PTP4l with empty window is skipped",
+			data: []*Data{
+				{ProcessName: DPLL, Details: []*DataDetails{{IFace: testIFace1, Offset: 5}}},
+				{ProcessName: PTP4l, Details: []*DataDetails{{IFace: testIFace1, Offset: 9798319463}}},
+			},
+			leadingIFace: testIFace1,
+			threshold:    1500,
+			expected:     false,
 		},
 		{
-			name:    "PTP4l stale detail on leading iface does not trigger free run when window has good data",
-			cfgName: "test",
-			data: map[string][]*Data{"test": {
-				{ProcessName: DPLL, Details: []*DataDetails{{IFace: "eno8703", Offset: 0}}},
+			name: "PTP4l stale detail on leading iface does not trigger free run when window has good data",
+			data: []*Data{
+				{ProcessName: DPLL, Details: []*DataDetails{{IFace: testEno8703, Offset: 0}}},
 				{ProcessName: PTP4l, Details: []*DataDetails{
-					{IFace: "eno8703", Offset: -93},
+					{IFace: testEno8703, Offset: -93},
 					{IFace: "eno8903", Offset: 2},
 				}},
-			}},
-			syncState:  map[string]*clockSyncState{"test": {leadingIFace: "eno8703"}},
-			threshold:  30,
-			fillWindow: true,
-			expected:   false,
+			},
+			leadingIFace: testEno8703,
+			threshold:    30,
+			fillWindow:   true,
+			expected:     false,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.fillWindow {
-				for _, processData := range tt.data {
-					for _, d := range processData {
-						if d.ProcessName == PTP4l && len(d.Details) > 0 {
-							d.window = *utils.NewWindow(WindowSize)
-							// Fill with the last detail's offset to simulate the active port feeding the window
-							lastOffset := d.Details[len(d.Details)-1].Offset
-							for i := 0; i < WindowSize; i++ {
-								d.window.Insert(float64(lastOffset))
-							}
+				for _, d := range tt.data {
+					if d.ProcessName == PTP4l && len(d.Details) > 0 {
+						d.window = *utils.NewWindow(WindowSize)
+						lastOffset := d.Details[len(d.Details)-1].Offset
+						for i := 0; i < WindowSize; i++ {
+							d.window.Insert(float64(lastOffset))
 						}
 					}
 				}
 			}
-			e := &EventHandler{
-				data:             tt.data,
-				clkSyncState:     tt.syncState,
-				LeadingClockData: &LeadingClockParams{toFreeRunThreshold: tt.threshold},
-			}
+			bc := newTestTBCClock(&LeadingClockParams{toFreeRunThreshold: tt.threshold})
+			bc.data = tt.data
+			bc.syncState.leadingIFace = tt.leadingIFace
 
-			result := e.freeRunCondition(tt.cfgName)
+			result := bc.freeRunCondition()
 			assert.Equal(t, tt.expected, result)
 		})
 	}
@@ -348,260 +299,178 @@ func TestGetLargestOffset(t *testing.T) {
 
 	tests := []struct {
 		name         string
-		cfgName      string
-		data         map[string][]*Data
-		clkSyncState map[string]*clockSyncState
+		data         []*Data
+		leadingIFace string
 		fillWindow   bool
 		expected     int64
 	}{
 		{
 			name:     "No data for config",
-			cfgName:  "nonexistent",
-			data:     map[string][]*Data{},
+			data:     nil,
 			expected: FaultyPhaseOffset,
 		},
 		{
-			name:    "No process data",
-			cfgName: "test",
-			data: map[string][]*Data{
-				"test": {},
-			},
+			name:     "No process data",
+			data:     []*Data{},
 			expected: FaultyPhaseOffset,
 		},
 		{
-			name:    "No details in data",
-			cfgName: "test",
-			data: map[string][]*Data{
-				"test": {
-					{ProcessName: DPLL, Details: []*DataDetails{}},
-					{ProcessName: "other", Details: []*DataDetails{}},
-				},
+			name: "No details in data",
+			data: []*Data{
+				{ProcessName: DPLL, Details: []*DataDetails{}},
+				{ProcessName: "other", Details: []*DataDetails{}},
 			},
-			clkSyncState: map[string]*clockSyncState{
-				"test": {
-					leadingIFace: "eth99",
-				},
-			},
-			expected: FaultyPhaseOffset,
+			leadingIFace: testEth99,
+			expected:     FaultyPhaseOffset,
 		},
 		{
-			name:    "Window not full - should return FaultyPhaseOffset",
-			cfgName: "test",
-			data: map[string][]*Data{
-				"test": {
-					{ProcessName: DPLL, Details: []*DataDetails{
-						{IFace: "eth0", Offset: 15, time: recentTime},
-						{IFace: "eth1", Offset: 5, time: recentTime},
-					}},
-				},
+			name: "Window not full - should return FaultyPhaseOffset",
+			data: []*Data{
+				{ProcessName: DPLL, Details: []*DataDetails{
+					{IFace: testEth0, Offset: 15, time: recentTime},
+					{IFace: testEth1, Offset: 5, time: recentTime},
+				}},
 			},
-			clkSyncState: map[string]*clockSyncState{
-				"test": {
-					leadingIFace: "eth99",
-				},
-			},
-			expected: FaultyPhaseOffset,
+			leadingIFace: testEth99,
+			expected:     FaultyPhaseOffset,
 		},
 		{
-			name:    "Single offset value",
-			cfgName: "test",
-			data: map[string][]*Data{
-				"test": {
-					{ProcessName: DPLL, Details: []*DataDetails{
-						{IFace: "eth0", Offset: 100, time: recentTime},
-					}},
-				},
+			name: "Single offset value",
+			data: []*Data{
+				{ProcessName: DPLL, Details: []*DataDetails{
+					{IFace: testEth0, Offset: 100, time: recentTime},
+				}},
 			},
-			clkSyncState: map[string]*clockSyncState{
-				"test": {
-					leadingIFace: "eth99",
-				},
-			},
-			fillWindow: true,
-			expected:   100,
+			leadingIFace: testEth99,
+			fillWindow:   true,
+			expected:     100,
 		},
 		{
-			name:    "Multiple offsets - largest positive",
-			cfgName: "test",
-			data: map[string][]*Data{
-				"test": {
-					{ProcessName: DPLL, Details: []*DataDetails{
-						{IFace: "eth0", Offset: 15, time: recentTime},
-						{IFace: "eth1", Offset: 5, time: recentTime},
-						{IFace: "eth2", Offset: 25, time: recentTime},
-					}},
-				},
+			name: "Multiple offsets - largest positive",
+			data: []*Data{
+				{ProcessName: DPLL, Details: []*DataDetails{
+					{IFace: testEth0, Offset: 15, time: recentTime},
+					{IFace: testEth1, Offset: 5, time: recentTime},
+					{IFace: testEth2, Offset: 25, time: recentTime},
+				}},
 			},
-			clkSyncState: map[string]*clockSyncState{
-				"test": {
-					leadingIFace: "eth99",
-				},
-			},
-			fillWindow: true,
-			expected:   25,
+			leadingIFace: testEth99,
+			fillWindow:   true,
+			expected:     25,
 		},
 		{
-			name:    "Multiple offsets - largest negative",
-			cfgName: "test",
-			data: map[string][]*Data{
-				"test": {
-					{ProcessName: DPLL, Details: []*DataDetails{
-						{IFace: "eth0", Offset: -30, time: recentTime},
-						{IFace: "eth1", Offset: 5, time: recentTime},
-						{IFace: "eth2", Offset: -10, time: recentTime},
-					}},
-				},
+			name: "Multiple offsets - largest negative",
+			data: []*Data{
+				{ProcessName: DPLL, Details: []*DataDetails{
+					{IFace: testEth0, Offset: -30, time: recentTime},
+					{IFace: testEth1, Offset: 5, time: recentTime},
+					{IFace: testEth2, Offset: -10, time: recentTime},
+				}},
 			},
-			clkSyncState: map[string]*clockSyncState{
-				"test": {
-					leadingIFace: "eth99",
-				},
-			},
-			fillWindow: true,
-			expected:   -30,
+			leadingIFace: testEth99,
+			fillWindow:   true,
+			expected:     -30,
 		},
 		{
-			name:    "Mixed positive and negative - largest absolute value",
-			cfgName: "test",
-			data: map[string][]*Data{
-				"test": {
-					{ProcessName: DPLL, Details: []*DataDetails{
-						{IFace: "eth0", Offset: 20, time: recentTime},
-						{IFace: "eth1", Offset: -25, time: recentTime},
-						{IFace: "eth2", Offset: 15, time: recentTime},
-					}},
-				},
+			name: "Mixed positive and negative - largest absolute value",
+			data: []*Data{
+				{ProcessName: DPLL, Details: []*DataDetails{
+					{IFace: testEth0, Offset: 20, time: recentTime},
+					{IFace: testEth1, Offset: -25, time: recentTime},
+					{IFace: testEth2, Offset: 15, time: recentTime},
+				}},
 			},
-			clkSyncState: map[string]*clockSyncState{
-				"test": {
-					leadingIFace: "eth99",
-				},
-			},
-			fillWindow: true,
-			expected:   -25,
+			leadingIFace: testEth99,
+			fillWindow:   true,
+			expected:     -25,
 		},
 		{
-			name:    "Stale data filtered out",
-			cfgName: "test",
-			data: map[string][]*Data{
-				"test": {
-					{ProcessName: DPLL, Details: []*DataDetails{
-						{IFace: "eth0", Offset: 100, time: staleTime - 1000}, // stale
-						{IFace: "eth1", Offset: 20, time: recentTime},        // recent
-						{IFace: "eth2", Offset: 50, time: staleTime - 500},   // stale
-					}},
-				},
+			name: "Stale data filtered out",
+			data: []*Data{
+				{ProcessName: DPLL, Details: []*DataDetails{
+					{IFace: testEth0, Offset: 100, time: staleTime - 1000},
+					{IFace: testEth1, Offset: 20, time: recentTime},
+					{IFace: testEth2, Offset: 50, time: staleTime - 500},
+				}},
 			},
-			clkSyncState: map[string]*clockSyncState{
-				"test": {
-					leadingIFace: "eth99",
-				},
-			},
-			fillWindow: true,
-			expected:   20,
+			leadingIFace: testEth99,
+			fillWindow:   true,
+			expected:     20,
 		},
 		{
-			name:    "All data stale - should return FaultyPhaseOffset",
-			cfgName: "test",
-			data: map[string][]*Data{
-				"test": {
-					{ProcessName: DPLL, Details: []*DataDetails{
-						{IFace: "eth0", Offset: 15, time: staleTime - 1000}, // stale, ignored
-						{IFace: "eth1", Offset: 50, time: staleTime - 500},  // stale, ignored
-						{IFace: "eth2", Offset: 30, time: staleTime - 200},  // stale, ignored
-					}},
-				},
+			name: "All data stale - should return FaultyPhaseOffset",
+			data: []*Data{
+				{ProcessName: DPLL, Details: []*DataDetails{
+					{IFace: testEth0, Offset: 15, time: staleTime - 1000},
+					{IFace: testEth1, Offset: 50, time: staleTime - 500},
+					{IFace: testEth2, Offset: 30, time: staleTime - 200},
+				}},
 			},
-			clkSyncState: map[string]*clockSyncState{
-				"test": {
-					leadingIFace: "eth99",
-				},
-			},
-			expected: FaultyPhaseOffset,
+			leadingIFace: testEth99,
+			expected:     FaultyPhaseOffset,
 		},
 		{
-			name:    "Multiple processes with different offsets",
-			cfgName: "test",
-			data: map[string][]*Data{
-				"test": {
-					{ProcessName: DPLL, Details: []*DataDetails{
-						{IFace: "eth0", Offset: 20, time: recentTime},
-					}},
-					{ProcessName: "ptp4l", Details: []*DataDetails{
-						{IFace: "eth1", Offset: 35, time: recentTime},
-					}},
-					{ProcessName: "ts2phc", Details: []*DataDetails{
-						{IFace: "eth2", Offset: -40, time: recentTime},
-					}},
-				},
+			name: "Multiple processes with different offsets",
+			data: []*Data{
+				{ProcessName: DPLL, Details: []*DataDetails{
+					{IFace: testEth0, Offset: 20, time: recentTime},
+				}},
+				{ProcessName: "ptp4l", Details: []*DataDetails{
+					{IFace: testEth1, Offset: 35, time: recentTime},
+				}},
+				{ProcessName: "ts2phc", Details: []*DataDetails{
+					{IFace: testEth2, Offset: -40, time: recentTime},
+				}},
 			},
-			clkSyncState: map[string]*clockSyncState{
-				"test": {
-					leadingIFace: "eth99",
-				},
-			},
-			fillWindow: true,
-			expected:   -40,
+			leadingIFace: testEth99,
+			fillWindow:   true,
+			expected:     -40,
 		},
 		{
-			name:    "Zero offset values",
-			cfgName: "test",
-			data: map[string][]*Data{
-				"test": {
-					{ProcessName: DPLL, Details: []*DataDetails{
-						{IFace: "eth0", Offset: 0, time: recentTime},
-						{IFace: "eth1", Offset: 0, time: recentTime},
-					}},
-				},
+			name: "Zero offset values",
+			data: []*Data{
+				{ProcessName: DPLL, Details: []*DataDetails{
+					{IFace: testEth0, Offset: 0, time: recentTime},
+					{IFace: testEth1, Offset: 0, time: recentTime},
+				}},
 			},
-			clkSyncState: map[string]*clockSyncState{
-				"test": {
-					leadingIFace: "eth99",
-				},
-			},
-			fillWindow: true,
-			expected:   0,
+			leadingIFace: testEth99,
+			fillWindow:   true,
+			expected:     0,
 		},
 		{
-			name:    "Mix of zero and non-zero offsets",
-			cfgName: "test",
-			data: map[string][]*Data{
-				"test": {
-					{ProcessName: DPLL, Details: []*DataDetails{
-						{IFace: "eth0", Offset: 0, time: recentTime},
-						{IFace: "eth1", Offset: 10, time: recentTime},
-						{IFace: "eth2", Offset: 0, time: recentTime},
-					}},
-				},
+			name: "Mix of zero and non-zero offsets",
+			data: []*Data{
+				{ProcessName: DPLL, Details: []*DataDetails{
+					{IFace: testEth0, Offset: 0, time: recentTime},
+					{IFace: testEth1, Offset: 10, time: recentTime},
+					{IFace: testEth2, Offset: 0, time: recentTime},
+				}},
 			},
-			clkSyncState: map[string]*clockSyncState{
-				"test": {
-					leadingIFace: "eth99",
-				},
-			},
-			fillWindow: true,
-			expected:   10,
+			leadingIFace: testEth99,
+			fillWindow:   true,
+			expected:     10,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.fillWindow {
-				for _, processData := range tt.data {
-					for _, d := range processData {
-						if len(d.Details) == 0 {
-							continue
-						}
-						d.window = *utils.NewWindow(WindowSize)
-						for i := 0; i < WindowSize; i++ {
-							offset := d.Details[i%len(d.Details)].Offset
-							d.window.Insert(float64(offset))
-						}
+				for _, d := range tt.data {
+					if len(d.Details) == 0 {
+						continue
+					}
+					d.window = *utils.NewWindow(WindowSize)
+					for i := 0; i < WindowSize; i++ {
+						offset := d.Details[i%len(d.Details)].Offset
+						d.window.Insert(float64(offset))
 					}
 				}
 			}
-			e := EventHandler{data: tt.data, clkSyncState: tt.clkSyncState}
-			result := e.getLargestOffset(tt.cfgName)
+			bc := newTestTBCClock(nil)
+			bc.data = tt.data
+			bc.syncState.leadingIFace = tt.leadingIFace
+			result := bc.getLargestOffset()
 			assert.Equal(t, tt.expected, result)
 		})
 	}
@@ -612,7 +481,7 @@ func TestGetLargestOffset_EmptyPTP4lWindowSkipped(t *testing.T) {
 
 	dpllData := &Data{
 		ProcessName: DPLL,
-		Details:     []*DataDetails{{IFace: "eth0", Offset: 20, time: recentTime}},
+		Details:     []*DataDetails{{IFace: testEth0, Offset: 20, time: recentTime}},
 		window:      *utils.NewWindow(WindowSize),
 	}
 	for i := 0; i < WindowSize; i++ {
@@ -621,21 +490,15 @@ func TestGetLargestOffset_EmptyPTP4lWindowSkipped(t *testing.T) {
 
 	ptp4lData := &Data{
 		ProcessName: PTP4l,
-		Details:     []*DataDetails{{IFace: "eth0", Offset: 9798319463, time: recentTime}},
+		Details:     []*DataDetails{{IFace: testEth0, Offset: 9798319463, time: recentTime}},
 		window:      *utils.NewWindow(WindowSize),
 	}
-	// PTP4l window left empty — simulates state-change-only events (no OFFSET)
 
-	e := EventHandler{
-		data: map[string][]*Data{
-			"test": {dpllData, ptp4lData},
-		},
-		clkSyncState: map[string]*clockSyncState{
-			"test": {leadingIFace: "eth99"},
-		},
-	}
+	bc := newTestTBCClock(nil)
+	bc.data = []*Data{dpllData, ptp4lData}
+	bc.syncState.leadingIFace = testEth99
 
-	result := e.getLargestOffset("test")
+	result := bc.getLargestOffset()
 	assert.Equal(t, int64(20), result, "should use DPLL data, skipping PTP4l with empty window")
 }
 
@@ -644,21 +507,16 @@ func TestGetLargestOffset_PartiallyFilledWindowBlocksResult(t *testing.T) {
 
 	dpllData := &Data{
 		ProcessName: DPLL,
-		Details:     []*DataDetails{{IFace: "eth0", Offset: 20, time: recentTime}},
+		Details:     []*DataDetails{{IFace: testEth0, Offset: 20, time: recentTime}},
 		window:      *utils.NewWindow(WindowSize),
 	}
-	dpllData.window.Insert(20) // partially filled (1 of WindowSize)
+	dpllData.window.Insert(20)
 
-	e := EventHandler{
-		data: map[string][]*Data{
-			"test": {dpllData},
-		},
-		clkSyncState: map[string]*clockSyncState{
-			"test": {leadingIFace: "eth99"},
-		},
-	}
+	bc := newTestTBCClock(nil)
+	bc.data = []*Data{dpllData}
+	bc.syncState.leadingIFace = testEth99
 
-	result := e.getLargestOffset("test")
+	result := bc.getLargestOffset()
 	assert.Equal(t, FaultyPhaseOffset, result, "partially filled window should return FaultyPhaseOffset")
 }
 
@@ -676,63 +534,63 @@ func TestAddEvent_SourceLostPropagation(t *testing.T) {
 			name: "source-lost does not propagate to other iface (no cross-hardware bleeding)",
 			initialDetails: []*DataDetails{
 				{IFace: "eno8903", State: PTP_LOCKED, sourceLost: false, time: now - 5000},
-				{IFace: "eno8703", State: PTP_LOCKED, sourceLost: false, time: now - 3000},
+				{IFace: testEno8703, State: PTP_LOCKED, sourceLost: false, time: now - 3000},
 			},
 			event: Event{
 				Source: PTP4l,
-				IFace:  "eno8703",
+				IFace:  testEno8703,
 				Time:   now,
 				Data:   &PTPData{State: PTP_FREERUN, SourceLost: true},
 			},
 			expectedStates: map[string]PTPState{
-				"eno8903": PTP_LOCKED,
-				"eno8703": PTP_FREERUN,
+				"eno8903":   PTP_LOCKED,
+				testEno8703: PTP_FREERUN,
 			},
 			expectedSrcLost: map[string]bool{
-				"eno8903": false,
-				"eno8703": true,
+				"eno8903":   false,
+				testEno8703: true,
 			},
 		},
 		{
 			name: "source-lost does not overwrite already-FREERUN detail",
 			initialDetails: []*DataDetails{
 				{IFace: "eno8903", State: PTP_FREERUN, sourceLost: true, time: now - 2000},
-				{IFace: "eno8703", State: PTP_LOCKED, sourceLost: false, time: now - 1000},
+				{IFace: testEno8703, State: PTP_LOCKED, sourceLost: false, time: now - 1000},
 			},
 			event: Event{
 				Source: PTP4l,
-				IFace:  "eno8703",
+				IFace:  testEno8703,
 				Time:   now,
 				Data:   &PTPData{State: PTP_FREERUN, SourceLost: true},
 			},
 			expectedStates: map[string]PTPState{
-				"eno8903": PTP_FREERUN,
-				"eno8703": PTP_FREERUN,
+				"eno8903":   PTP_FREERUN,
+				testEno8703: PTP_FREERUN,
 			},
 			expectedSrcLost: map[string]bool{
-				"eno8903": true,
-				"eno8703": true,
+				"eno8903":   true,
+				testEno8703: true,
 			},
 		},
 		{
 			name: "non-source-lost event does not propagate",
 			initialDetails: []*DataDetails{
 				{IFace: "eno8903", State: PTP_LOCKED, sourceLost: false, time: now - 5000},
-				{IFace: "eno8703", State: PTP_FREERUN, sourceLost: false, time: now - 3000},
+				{IFace: testEno8703, State: PTP_FREERUN, sourceLost: false, time: now - 3000},
 			},
 			event: Event{
 				Source: PTP4l,
-				IFace:  "eno8703",
+				IFace:  testEno8703,
 				Time:   now,
 				Data:   &PTPData{State: PTP_LOCKED, SourceLost: false},
 			},
 			expectedStates: map[string]PTPState{
-				"eno8903": PTP_LOCKED,
-				"eno8703": PTP_LOCKED,
+				"eno8903":   PTP_LOCKED,
+				testEno8703: PTP_LOCKED,
 			},
 			expectedSrcLost: map[string]bool{
-				"eno8903": false,
-				"eno8703": false,
+				"eno8903":   false,
+				testEno8703: false,
 			},
 		},
 	}
@@ -760,35 +618,29 @@ func TestIsSourceLostBC_StaleDetailFixed(t *testing.T) {
 			ProcessName: PTP4l,
 			Details: []*DataDetails{
 				{IFace: "eno8903", State: PTP_LOCKED, sourceLost: false, time: now - 5000},
-				{IFace: "eno8703", State: PTP_LOCKED, sourceLost: false, time: now - 3000},
+				{IFace: testEno8703, State: PTP_LOCKED, sourceLost: false, time: now - 3000},
 			},
 		}
 		dpllData := &Data{
 			ProcessName: DPLL,
 			Details: []*DataDetails{
-				{IFace: "eno8703", State: PTP_LOCKED, time: now},
+				{IFace: testEno8703, State: PTP_LOCKED, time: now},
 			},
 		}
 
-		e := &EventHandler{
-			data: map[string][]*Data{
-				"cfg": {ptp4lData, dpllData},
-			},
-		}
+		bc := newTestTBCClock(nil)
+		bc.data = []*Data{ptp4lData, dpllData}
 
-		assert.False(t, e.isSourceLostBC("cfg"), "before source-lost event, ptpLost should be false")
+		assert.False(t, bc.isSourceLostBC(), "before source-lost event, ptpLost should be false")
 
 		ptp4lData.AddEvent(Event{
 			Source: PTP4l,
-			IFace:  "eno8703",
+			IFace:  testEno8703,
 			Time:   now,
 			Data:   &PTPData{State: PTP_FREERUN, SourceLost: true},
 		})
 
-		// Without cross-hardware propagation, the stale LOCKED detail on
-		// eno8903 is not overwritten, so isSourceLostBC still sees a LOCKED
-		// port and returns false.
-		assert.False(t, e.isSourceLostBC("cfg"), "stale LOCKED detail on other iface prevents ptpLost")
+		assert.False(t, bc.isSourceLostBC(), "stale LOCKED detail on other iface prevents ptpLost")
 	})
 
 	t.Run("single LOCKED detail keeps source as not lost", func(t *testing.T) {
@@ -796,29 +648,23 @@ func TestIsSourceLostBC_StaleDetailFixed(t *testing.T) {
 			ProcessName: PTP4l,
 			Details: []*DataDetails{
 				{IFace: "eno8903", State: PTP_FREERUN, sourceLost: true, time: now},
-				{IFace: "eno8703", State: PTP_LOCKED, sourceLost: false, time: now},
+				{IFace: testEno8703, State: PTP_LOCKED, sourceLost: false, time: now},
 			},
 		}
 		dpllData := &Data{
 			ProcessName: DPLL,
 			Details: []*DataDetails{
-				{IFace: "eno8703", State: PTP_LOCKED, time: now},
+				{IFace: testEno8703, State: PTP_LOCKED, time: now},
 			},
 		}
-		e := &EventHandler{
-			data: map[string][]*Data{
-				"cfg": {ptp4lData, dpllData},
-			},
-		}
-		assert.False(t, e.isSourceLostBC("cfg"))
+		bc := newTestTBCClock(nil)
+		bc.data = []*Data{ptp4lData, dpllData}
+		assert.False(t, bc.isSourceLostBC())
 	})
 }
 
-// fillDataWindows fills all Data windows in the given config with their
-// first detail's offset value. This satisfies getLargestOffset's requirement
-// that the window be full before it returns a real value.
-func fillDataWindows(e *EventHandler, cfgName string, offset int64) { //nolint:unparam // cfgName kept for clarity
-	for _, d := range e.data[cfgName] {
+func fillBCDataWindows(bc *TBCClock, offset int64) {
+	for _, d := range bc.data {
 		d.window = *utils.NewWindow(WindowSize)
 		for i := 0; i < WindowSize; i++ {
 			d.window.Insert(float64(offset))
@@ -826,8 +672,63 @@ func fillDataWindows(e *EventHandler, cfgName string, offset int64) { //nolint:u
 	}
 }
 
+const testTBCIface = "ens1f0"
+
+func makeTBCEvent(process EventSource, state PTPState, offset int64, sourceLost bool) Event {
+	return Event{
+		Source:     process,
+		IFace:      testTBCIface,
+		CfgName:    testPTP4lCfg,
+		ClockType:  BC,
+		Time:       time.Now().UnixMilli(),
+		WriteToLog: true,
+		Data: &PTPData{
+			State:      state,
+			Values:     map[ValueType]interface{}{OFFSET: offset},
+			SourceLost: sourceLost,
+		},
+	}
+}
+
+func tbcLeadingClockParams() *LeadingClockParams {
+	return &LeadingClockParams{
+		leadingInterface:         testTBCIface,
+		inSyncConditionThreshold: 100,
+		inSyncConditionTimes:     1,
+		toFreeRunThreshold:       1500,
+		MaxInSpecOffset:          500,
+		upstreamParentDataSet:    &protocol.ParentDataSet{},
+		upstreamTimeProperties:   &protocol.TimePropertiesDS{},
+		downstreamParentDataSet:  &protocol.ParentDataSet{},
+		downstreamTimeProperties: &protocol.TimePropertiesDS{},
+	}
+}
+
+func newLockedTBCClock(io clockIO) *TBCClock {
+	if io == nil {
+		io = &noopClockIO{}
+	}
+	bc := &TBCClock{
+		io:               io,
+		cfgName:          testTS2PHCCfg,
+		leadingClockData: tbcLeadingClockParams(),
+		syncState: clockSyncState{
+			state:         PTP_FREERUN,
+			clockClass:    protocol.ClockClassUninitialized,
+			clockAccuracy: fbprotocol.ClockAccuracyUnknown,
+		},
+		overallSyncState: PTP_FREERUN,
+		osClockState:     PTP_NOTSET,
+	}
+	bc.addEvent(makeTBCEvent(DPLL, PTP_LOCKED, 10, false))
+	bc.addEvent(makeTBCEvent(PTP4lProcessName, PTP_LOCKED, 10, false))
+	fillBCDataWindows(bc, 10)
+	bc.addEvent(makeTBCEvent(DPLL, PTP_LOCKED, 10, false))
+	return bc
+}
+
 func TestUpdateGMState(t *testing.T) {
-	const cfg = "ts2phc.0.config"
+	const cfg = testTS2PHCCfg
 	const iface = "ens1f0"
 
 	makeEvent := func(process EventSource, state PTPState, sourceLost bool) Event {
@@ -855,10 +756,16 @@ func TestUpdateGMState(t *testing.T) {
 		return e
 	}
 
+	makeDPLLEvent := func(state PTPState, sourceLost, outOfSpec, frequencyTraceable bool) Event {
+		e := makeEvent(DPLL, state, sourceLost)
+		d := e.Data.(*PTPData)
+		d.OutOfSpec = outOfSpec
+		d.FrequencyTraceable = frequencyTraceable
+		return e
+	}
+
 	type step struct {
 		events         []Event
-		outOfSpec      bool
-		frequencyTrace bool
 		wantState      PTPState
 		wantClockClass fbprotocol.ClockClass
 	}
@@ -929,10 +836,8 @@ func TestUpdateGMState(t *testing.T) {
 				{
 					events: []Event{
 						makeEvent(GNSS, PTP_LOCKED, false),
-						makeEvent(DPLL, PTP_FREERUN, false),
+						makeDPLLEvent(PTP_FREERUN, false, true, true),
 					},
-					outOfSpec:      true,
-					frequencyTrace: true,
 					wantState:      PTP_FREERUN,
 					wantClockClass: protocol.ClockClassOutOfSpec,
 				},
@@ -1079,234 +984,601 @@ func TestUpdateGMState(t *testing.T) {
 				},
 			},
 		},
+		// --- "Wait for DPLL" rows from state table ---
+		{
+			desc: "GNSS sourceLost DPLL locked ts2phc freerun - wait for DPLL holdover",
+			steps: []step{
+				{
+					events: []Event{
+						makeEvent(GNSS, PTP_LOCKED, false),
+						makeEvent(DPLL, PTP_LOCKED, false),
+						makeEvent(TS2PHCProcessName, PTP_LOCKED, false),
+					},
+					wantState:      PTP_LOCKED,
+					wantClockClass: fbprotocol.ClockClass6,
+				},
+				{
+					events: []Event{
+						makeEvent(GNSS, PTP_FREERUN, true),
+						makeEvent(TS2PHCProcessName, PTP_FREERUN, false),
+					},
+					wantState:      PTP_FREERUN,
+					wantClockClass: fbprotocol.ClockClass6, // clockClass NOT updated in wait path
+				},
+			},
+		},
+		// --- GNSS FREERUN (not sourceLost) rows ---
+		{
+			desc: "GNSS FREERUN (not SL) DPLL locked ts2phc locked → FREERUN 248",
+			steps: []step{
+				{
+					events: []Event{
+						makeEvent(GNSS, PTP_FREERUN, false),
+						makeEvent(DPLL, PTP_LOCKED, false),
+						makeEvent(TS2PHCProcessName, PTP_LOCKED, false),
+					},
+					wantState:      PTP_FREERUN,
+					wantClockClass: protocol.ClockClassFreerun,
+				},
+			},
+		},
+		{
+			desc: "GNSS FREERUN (not SL) DPLL locked ts2phc freerun → FREERUN 248",
+			steps: []step{
+				{
+					events: []Event{
+						makeEvent(GNSS, PTP_FREERUN, false),
+						makeEvent(DPLL, PTP_LOCKED, false),
+						makeEvent(TS2PHCProcessName, PTP_FREERUN, false),
+					},
+					wantState:      PTP_FREERUN,
+					wantClockClass: protocol.ClockClassFreerun,
+				},
+			},
+		},
+		// --- No DPLL available rows (dpllState stays PTP_NOTSET) ---
+		{
+			desc: "no DPLL, GNSS locked, ts2phc freerun → FREERUN 248",
+			steps: []step{
+				{
+					events: []Event{
+						makeEvent(GNSS, PTP_LOCKED, false),
+						makeEvent(TS2PHCProcessName, PTP_FREERUN, false),
+					},
+					wantState:      PTP_FREERUN,
+					wantClockClass: protocol.ClockClassFreerun,
+				},
+			},
+		},
+		{
+			desc: "no DPLL, GNSS locked, ts2phc holdover → HOLDOVER 7",
+			steps: []step{
+				{
+					events: []Event{
+						makeEvent(GNSS, PTP_LOCKED, false),
+						makeEvent(TS2PHCProcessName, PTP_HOLDOVER, false),
+					},
+					wantState:      PTP_HOLDOVER,
+					wantClockClass: fbprotocol.ClockClass7,
+				},
+			},
+		},
+		{
+			desc: "no DPLL, GNSS freerun (not SL), ts2phc locked → FREERUN 248",
+			steps: []step{
+				{
+					events: []Event{
+						makeEvent(GNSS, PTP_FREERUN, false),
+						makeEvent(TS2PHCProcessName, PTP_LOCKED, false),
+					},
+					wantState:      PTP_FREERUN,
+					wantClockClass: protocol.ClockClassFreerun,
+				},
+			},
+		},
+		{
+			desc: "no DPLL, GNSS freerun (not SL), ts2phc freerun → FREERUN 248",
+			steps: []step{
+				{
+					events: []Event{
+						makeEvent(GNSS, PTP_FREERUN, false),
+						makeEvent(TS2PHCProcessName, PTP_FREERUN, false),
+					},
+					wantState:      PTP_FREERUN,
+					wantClockClass: protocol.ClockClassFreerun,
+				},
+			},
+		},
+		// --- Out-of-spec edge cases: both flags required for class 140 ---
+		{
+			desc: "DPLL freerun outOfSpec only (no frequencyTrace) → class 248 not 140",
+			steps: []step{
+				{
+					events: []Event{
+						makeEvent(GNSS, PTP_LOCKED, false),
+						makeDPLLEvent(PTP_FREERUN, false, true, false),
+					},
+					wantState:      PTP_FREERUN,
+					wantClockClass: protocol.ClockClassFreerun,
+				},
+			},
+		},
+		{
+			desc: "DPLL freerun frequencyTrace only (no outOfSpec) → class 248 not 140",
+			steps: []step{
+				{
+					events: []Event{
+						makeEvent(GNSS, PTP_LOCKED, false),
+						makeDPLLEvent(PTP_FREERUN, false, false, true),
+					},
+					wantState:      PTP_FREERUN,
+					wantClockClass: protocol.ClockClassFreerun,
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
-			e := &EventHandler{
-				data:             map[string][]*Data{},
-				clkSyncState:     map[string]*clockSyncState{},
-				LeadingClockData: newLeadingClockParams(),
+			gm := &GMClock{
+				cfgName: cfg,
+				io:      &recordingClockIO{},
+				syncState: clockSyncState{
+					state:         PTP_NOTSET,
+					clockClass:    protocol.ClockClassUninitialized,
+					clockAccuracy: fbprotocol.ClockAccuracyUnknown,
+				},
+				overallSyncState: PTP_NOTSET,
 			}
 
+			var result clockSyncState
 			for i, s := range tt.steps {
 				for _, ev := range s.events {
-					e.addEvent(ev)
+					_, result = gm.addEvent(ev)
 				}
-				e.outOfSpec = s.outOfSpec
-				e.frequencyTraceable = s.frequencyTrace
 
-				result := e.updateGMState(cfg)
+				result = gm.updateState()
 				assert.Equal(t, s.wantState, result.state, "step %d: state", i)
 				assert.Equal(t, s.wantClockClass, result.clockClass, "step %d: clockClass", i)
 			}
 		})
 	}
-}
 
-func TestUpdateBCState(t *testing.T) {
-	const cfg = "ptp4l.0.config"
-	const iface = "ens1f0"
+	t.Run("nil data → leading interface unknown, state reporting delayed", func(t *testing.T) {
+		gm := &GMClock{
+			cfgName: cfg,
+			io:      &recordingClockIO{},
+			syncState: clockSyncState{
+				state:         PTP_NOTSET,
+				clockClass:    protocol.ClockClassUninitialized,
+				clockAccuracy: fbprotocol.ClockAccuracyUnknown,
+			},
+			overallSyncState: PTP_NOTSET,
+		}
+		result := gm.updateState()
+		assert.Equal(t, LEADING_INTERFACE_UNKNOWN, result.leadingIFace)
+		assert.Equal(t, PTPState(""), result.state, "no state set when leading interface unknown")
+	})
 
-	makeBCEvent := func(process EventSource, state PTPState, offset int64, sourceLost bool) Event {
-		return Event{
-			Source:     process,
-			IFace:      iface,
+	t.Run("non-leading DPLL fault forces FREERUN", func(t *testing.T) {
+		gm := &GMClock{
+			cfgName: cfg,
+			io:      &recordingClockIO{},
+			syncState: clockSyncState{
+				state:         PTP_NOTSET,
+				clockClass:    protocol.ClockClassUninitialized,
+				clockAccuracy: fbprotocol.ClockAccuracyUnknown,
+			},
+			overallSyncState: PTP_NOTSET,
+		}
+
+		// Leading interface locked
+		gm.addEvent(makeEvent(GNSS, PTP_LOCKED, false))
+		gm.addEvent(makeEvent(DPLL, PTP_LOCKED, false))
+		gm.addEvent(makeEvent(TS2PHCProcessName, PTP_LOCKED, false))
+
+		// Add a second DPLL interface that is NOT locked
+		secondDPLL := Event{
+			Source:     DPLL,
+			IFace:      "ens1f1",
 			CfgName:    cfg,
-			ClockType:  BC,
+			ClockType:  GM,
 			Time:       time.Now().UnixMilli(),
 			WriteToLog: true,
 			Data: &PTPData{
-				State:      state,
-				Values:     map[ValueType]interface{}{OFFSET: offset},
-				SourceLost: sourceLost,
+				State:  PTP_FREERUN,
+				Values: map[ValueType]interface{}{OFFSET: int64(0)},
 			},
 		}
-	}
+		gm.addEvent(secondDPLL)
 
-	newBCHandler := func() *EventHandler {
-		return &EventHandler{
-			data:         map[string][]*Data{},
-			clkSyncState: map[string]*clockSyncState{},
-			LeadingClockData: &LeadingClockParams{
-				leadingInterface:         iface,
-				inSyncConditionThreshold: 100,
-				inSyncConditionTimes:     1,
-				toFreeRunThreshold:       1500,
-				MaxInSpecOffset:          500,
-				upstreamParentDataSet:    &protocol.ParentDataSet{},
-				upstreamTimeProperties:   &protocol.TimePropertiesDS{},
-				downstreamParentDataSet:  &protocol.ParentDataSet{},
-				downstreamTimeProperties: &protocol.TimePropertiesDS{},
-			},
-		}
-	}
-
-	t.Run("FREERUN to LOCKED", func(t *testing.T) {
-		e := newBCHandler()
-
-		e.addEvent(makeBCEvent(DPLL, PTP_LOCKED, 10, false))
-		e.addEvent(makeBCEvent(PTP4lProcessName, PTP_LOCKED, 10, false))
-		fillDataWindows(e, cfg, 10)
-
-		result, needsTTSCAnnounce, needsDownstreamUpdate := e.updateBCState(makeBCEvent(DPLL, PTP_LOCKED, 10, false))
-		assert.Equal(t, PTP_LOCKED, result.state, "should transition to LOCKED")
-		assert.False(t, needsTTSCAnnounce, "not a TTSC")
-		assert.False(t, needsDownstreamUpdate, "clockClass still uninitialized, no downstream update")
-	})
-
-	t.Run("LOCKED to FREERUN via offset", func(t *testing.T) {
-		e := newBCHandler()
-
-		// First establish LOCKED state
-		e.addEvent(makeBCEvent(DPLL, PTP_LOCKED, 10, false))
-		e.addEvent(makeBCEvent(PTP4lProcessName, PTP_LOCKED, 10, false))
-		fillDataWindows(e, cfg, 10)
-		result, _, _ := e.updateBCState(makeBCEvent(DPLL, PTP_LOCKED, 10, false))
-		assert.Equal(t, PTP_LOCKED, result.state, "setup: should be LOCKED")
-
-		// Now send offset exceeding toFreeRunThreshold (1500)
-		e.addEvent(makeBCEvent(DPLL, PTP_LOCKED, 2000, false))
-		result, needsTTSCAnnounce, needsDownstreamUpdate := e.updateBCState(makeBCEvent(DPLL, PTP_LOCKED, 2000, false))
-		assert.Equal(t, PTP_FREERUN, result.state, "should transition to FREERUN")
-		assert.Equal(t, protocol.ClockClassFreerun, result.clockClass, "clockClass should be 248")
-		assert.False(t, needsTTSCAnnounce, "not a TTSC")
-		assert.True(t, needsDownstreamUpdate, "FREERUN clockClass set, downstream needs update")
-	})
-
-	t.Run("LOCKED to HOLDOVER via source lost", func(t *testing.T) {
-		e := newBCHandler()
-
-		// Establish LOCKED state
-		e.addEvent(makeBCEvent(DPLL, PTP_LOCKED, 10, false))
-		e.addEvent(makeBCEvent(PTP4lProcessName, PTP_LOCKED, 10, false))
-		fillDataWindows(e, cfg, 10)
-		result, _, _ := e.updateBCState(makeBCEvent(DPLL, PTP_LOCKED, 10, false))
-		assert.Equal(t, PTP_LOCKED, result.state, "setup: should be LOCKED")
-
-		// Source lost: PTP4l goes FREERUN, DPLL goes HOLDOVER
-		e.addEvent(makeBCEvent(PTP4lProcessName, PTP_FREERUN, 10, true))
-		e.addEvent(makeBCEvent(DPLL, PTP_HOLDOVER, 10, false))
-		result, needsTTSCAnnounce, needsDownstreamUpdate := e.updateBCState(makeBCEvent(DPLL, PTP_HOLDOVER, 10, false))
-		assert.Equal(t, PTP_HOLDOVER, result.state, "should transition to HOLDOVER")
-		assert.Equal(t, fbprotocol.ClockClass(135), result.clockClass, "clockClass should be 135 (holdover in-spec)")
-		assert.False(t, needsTTSCAnnounce, "not a TTSC")
-		assert.True(t, needsDownstreamUpdate, "holdover clockClass set, downstream needs update")
-	})
-
-	t.Run("HOLDOVER to LOCKED", func(t *testing.T) {
-		e := newBCHandler()
-
-		// Establish LOCKED then HOLDOVER
-		e.addEvent(makeBCEvent(DPLL, PTP_LOCKED, 10, false))
-		e.addEvent(makeBCEvent(PTP4lProcessName, PTP_LOCKED, 10, false))
-		fillDataWindows(e, cfg, 10)
-		e.updateBCState(makeBCEvent(DPLL, PTP_LOCKED, 10, false))
-
-		e.addEvent(makeBCEvent(PTP4lProcessName, PTP_FREERUN, 10, true))
-		e.addEvent(makeBCEvent(DPLL, PTP_HOLDOVER, 10, false))
-		result, _, _ := e.updateBCState(makeBCEvent(DPLL, PTP_HOLDOVER, 10, false))
-		assert.Equal(t, PTP_HOLDOVER, result.state, "setup: should be HOLDOVER")
-
-		// Restore: PTP4l and DPLL back to LOCKED
-		e.addEvent(makeBCEvent(PTP4lProcessName, PTP_LOCKED, 5, false))
-		e.addEvent(makeBCEvent(DPLL, PTP_LOCKED, 5, false))
-		fillDataWindows(e, cfg, 5)
-		e.LeadingClockData.inSyncThresholdCounter = 0
-		result, needsTTSCAnnounce, needsDownstreamUpdate := e.updateBCState(makeBCEvent(DPLL, PTP_LOCKED, 5, false))
-		assert.Equal(t, PTP_LOCKED, result.state, "should transition back to LOCKED")
-		assert.False(t, needsTTSCAnnounce, "not a TTSC")
-		assert.True(t, needsDownstreamUpdate, "re-locked with non-uninitialized clockClass, downstream needs update")
-	})
-
-	t.Run("HOLDOVER to FREERUN via offset", func(t *testing.T) {
-		e := newBCHandler()
-
-		// Establish LOCKED then HOLDOVER
-		e.addEvent(makeBCEvent(DPLL, PTP_LOCKED, 10, false))
-		e.addEvent(makeBCEvent(PTP4lProcessName, PTP_LOCKED, 10, false))
-		fillDataWindows(e, cfg, 10)
-		e.updateBCState(makeBCEvent(DPLL, PTP_LOCKED, 10, false))
-
-		e.addEvent(makeBCEvent(PTP4lProcessName, PTP_FREERUN, 10, true))
-		e.addEvent(makeBCEvent(DPLL, PTP_HOLDOVER, 10, false))
-		result, _, _ := e.updateBCState(makeBCEvent(DPLL, PTP_HOLDOVER, 10, false))
-		assert.Equal(t, PTP_HOLDOVER, result.state, "setup: should be HOLDOVER")
-
-		// Offset exceeds toFreeRunThreshold
-		e.addEvent(makeBCEvent(DPLL, PTP_HOLDOVER, 2000, false))
-		result, needsTTSCAnnounce, needsDownstreamUpdate := e.updateBCState(makeBCEvent(DPLL, PTP_HOLDOVER, 2000, false))
-		assert.Equal(t, PTP_FREERUN, result.state, "should transition to FREERUN")
-		assert.Equal(t, protocol.ClockClassFreerun, result.clockClass, "clockClass should be 248")
-		assert.False(t, needsTTSCAnnounce, "not a TTSC")
-		assert.True(t, needsDownstreamUpdate, "FREERUN clockClass set, downstream needs update")
-	})
-
-	t.Run("HOLDOVER in-spec to out-of-spec", func(t *testing.T) {
-		e := newBCHandler()
-
-		// Establish LOCKED then HOLDOVER
-		e.addEvent(makeBCEvent(DPLL, PTP_LOCKED, 10, false))
-		e.addEvent(makeBCEvent(PTP4lProcessName, PTP_LOCKED, 10, false))
-		fillDataWindows(e, cfg, 10)
-		e.updateBCState(makeBCEvent(DPLL, PTP_LOCKED, 10, false))
-
-		e.addEvent(makeBCEvent(PTP4lProcessName, PTP_FREERUN, 10, true))
-		e.addEvent(makeBCEvent(DPLL, PTP_HOLDOVER, 10, false))
-		result, _, _ := e.updateBCState(makeBCEvent(DPLL, PTP_HOLDOVER, 10, false))
-		assert.Equal(t, PTP_HOLDOVER, result.state, "setup: should be HOLDOVER")
-		assert.Equal(t, fbprotocol.ClockClass(135), result.clockClass, "setup: should be in-spec (135)")
-
-		// Offset exceeds MaxInSpecOffset (500) but stays below toFreeRunThreshold (1500)
-		e.addEvent(makeBCEvent(DPLL, PTP_HOLDOVER, 600, false))
-		fillDataWindows(e, cfg, 600)
-		result, needsTTSCAnnounce, needsDownstreamUpdate := e.updateBCState(makeBCEvent(DPLL, PTP_HOLDOVER, 600, false))
-		assert.Equal(t, PTP_HOLDOVER, result.state, "should stay in HOLDOVER")
-		assert.Equal(t, fbprotocol.ClockClass(165), result.clockClass, "clockClass should change to 165 (out-of-spec)")
-		assert.False(t, needsTTSCAnnounce, "not a TTSC")
-		assert.True(t, needsDownstreamUpdate, "clockClass changed, downstream needs update")
+		result := gm.updateState()
+		assert.Equal(t, PTP_FREERUN, result.state, "non-leading DPLL fault should force FREERUN")
+		assert.Equal(t, protocol.ClockClassFreerun, result.clockClass)
 	})
 }
 
-func TestUpdateSpecState(t *testing.T) {
-	newHandler := func() *EventHandler {
-		return &EventHandler{
-			data:         map[string][]*Data{},
-			clkSyncState: map[string]*clockSyncState{},
+func TestUpdateBCState(t *testing.T) {
+	t.Run("FREERUN to LOCKED", func(t *testing.T) {
+		bc := newLockedTBCClock(nil)
+		assert.Equal(t, PTP_LOCKED, bc.syncState.state, "should be LOCKED")
+	})
+
+	t.Run("LOCKED to FREERUN via offset", func(t *testing.T) {
+		bc := newLockedTBCClock(nil)
+
+		_, result, _ := bc.addEvent(makeTBCEvent(DPLL, PTP_LOCKED, 2000, false))
+		assert.Equal(t, PTP_FREERUN, result.state, "should transition to FREERUN")
+		assert.Equal(t, protocol.ClockClassFreerun, result.clockClass, "clockClass should be 248")
+	})
+
+	t.Run("LOCKED to HOLDOVER via source lost", func(t *testing.T) {
+		bc := newLockedTBCClock(nil)
+
+		_, result, _ := bc.addEvent(makeTBCEvent(PTP4lProcessName, PTP_FREERUN, 10, true))
+		assert.Equal(t, PTP_HOLDOVER, result.state, "should transition to HOLDOVER")
+		assert.Equal(t, fbprotocol.ClockClass(135), result.clockClass, "clockClass should be 135 (holdover in-spec)")
+	})
+
+	t.Run("HOLDOVER to LOCKED", func(t *testing.T) {
+		bc := newLockedTBCClock(nil)
+
+		_, result, _ := bc.addEvent(makeTBCEvent(PTP4lProcessName, PTP_FREERUN, 10, true))
+		assert.Equal(t, PTP_HOLDOVER, result.state, "setup: should be HOLDOVER")
+
+		bc.leadingClockData.inSyncThresholdCounter = 0
+		bc.addEvent(makeTBCEvent(DPLL, PTP_LOCKED, 5, false))
+		fillBCDataWindows(bc, 5)
+		_, result, _ = bc.addEvent(makeTBCEvent(PTP4lProcessName, PTP_LOCKED, 5, false))
+		assert.Equal(t, PTP_LOCKED, result.state, "should transition back to LOCKED")
+	})
+
+	t.Run("HOLDOVER to FREERUN via offset", func(t *testing.T) {
+		bc := newLockedTBCClock(nil)
+
+		_, result, _ := bc.addEvent(makeTBCEvent(PTP4lProcessName, PTP_FREERUN, 10, true))
+		assert.Equal(t, PTP_HOLDOVER, result.state, "setup: should be HOLDOVER")
+
+		_, result, _ = bc.addEvent(makeTBCEvent(DPLL, PTP_HOLDOVER, 2000, false))
+		assert.Equal(t, PTP_FREERUN, result.state, "should transition to FREERUN")
+		assert.Equal(t, protocol.ClockClassFreerun, result.clockClass, "clockClass should be 248")
+	})
+
+	t.Run("HOLDOVER in-spec to out-of-spec", func(t *testing.T) {
+		bc := newLockedTBCClock(nil)
+
+		_, result, _ := bc.addEvent(makeTBCEvent(PTP4lProcessName, PTP_FREERUN, 10, true))
+		assert.Equal(t, PTP_HOLDOVER, result.state, "setup: should be HOLDOVER")
+		assert.Equal(t, fbprotocol.ClockClass(135), result.clockClass, "setup: should be in-spec (135)")
+
+		fillBCDataWindows(bc, 600)
+		_, result, _ = bc.addEvent(makeTBCEvent(DPLL, PTP_HOLDOVER, 600, false))
+		assert.Equal(t, PTP_HOLDOVER, result.state, "should stay in HOLDOVER")
+		assert.Equal(t, fbprotocol.ClockClass(165), result.clockClass, "clockClass should change to 165 (out-of-spec)")
+	})
+}
+
+func TestAddEvent_StoresSpecFlags(t *testing.T) {
+	t.Run("DPLL event stores outOfSpec and frequencyTraceable in DataDetails", func(t *testing.T) {
+		d := &Data{ProcessName: DPLL, State: PTP_UNKNOWN, window: *utils.NewWindow(WindowSize)}
+		ev := Event{
+			Source:    DPLL,
+			IFace:     "ens1f0",
+			ClockType: GM,
+			Time:      time.Now().UnixMilli(),
+			Data:      &PTPData{State: PTP_FREERUN, OutOfSpec: true, FrequencyTraceable: true, Values: map[ValueType]interface{}{OFFSET: int64(0)}},
 		}
+		d.AddEvent(ev)
+
+		dd := d.GetDataDetails("ens1f0")
+		require.NotNil(t, dd)
+		assert.True(t, dd.outOfSpec)
+		assert.True(t, dd.frequencyTraceable)
+	})
+
+	t.Run("non-DPLL PTPData stores its own flags independently", func(t *testing.T) {
+		dpll := &Data{ProcessName: DPLL, State: PTP_UNKNOWN, window: *utils.NewWindow(WindowSize)}
+		dpll.AddEvent(Event{
+			Source: DPLL, IFace: "ens1f0", ClockType: GM, Time: time.Now().UnixMilli(),
+			Data: &PTPData{State: PTP_FREERUN, OutOfSpec: true, FrequencyTraceable: true, Values: map[ValueType]interface{}{OFFSET: int64(0)}},
+		})
+
+		ts := &Data{ProcessName: TS2PHCProcessName, State: PTP_UNKNOWN, window: *utils.NewWindow(WindowSize)}
+		ts.AddEvent(Event{
+			Source: TS2PHC, IFace: "ens1f0", ClockType: GM, Time: time.Now().UnixMilli(),
+			Data: &PTPData{State: PTP_LOCKED, OutOfSpec: false, FrequencyTraceable: false, Values: map[ValueType]interface{}{OFFSET: int64(0)}},
+		})
+
+		dpllDD := dpll.GetDataDetails("ens1f0")
+		require.NotNil(t, dpllDD)
+		assert.True(t, dpllDD.outOfSpec, "DPLL details should retain its flags")
+		assert.True(t, dpllDD.frequencyTraceable)
+
+		tsDD := ts.GetDataDetails("ens1f0")
+		require.NotNil(t, tsDD)
+		assert.False(t, tsDD.outOfSpec, "ts2phc details should have its own flags")
+		assert.False(t, tsDD.frequencyTraceable)
+	})
+}
+
+func TestWorstOfState(t *testing.T) {
+	tests := []struct {
+		a, b     PTPState
+		expected PTPState
+	}{
+		{PTP_LOCKED, PTP_LOCKED, PTP_LOCKED},
+		{PTP_LOCKED, PTP_FREERUN, PTP_FREERUN},
+		{PTP_FREERUN, PTP_LOCKED, PTP_FREERUN},
+		{PTP_HOLDOVER, PTP_LOCKED, PTP_HOLDOVER},
+		{PTP_LOCKED, PTP_HOLDOVER, PTP_HOLDOVER},
+		{PTP_FREERUN, PTP_HOLDOVER, PTP_FREERUN},
+		{PTP_HOLDOVER, PTP_FREERUN, PTP_FREERUN},
+		{PTP_HOLDOVER, PTP_HOLDOVER, PTP_HOLDOVER},
+		{PTP_FREERUN, PTP_FREERUN, PTP_FREERUN},
 	}
+	for _, tt := range tests {
+		t.Run(string(tt.a)+"_"+string(tt.b), func(t *testing.T) {
+			assert.Equal(t, tt.expected, worstOfState(tt.a, tt.b))
+		})
+	}
+}
 
-	t.Run("DPLL event sets outOfSpec", func(t *testing.T) {
-		e := newHandler()
-		assert.False(t, e.outOfSpec, "initial outOfSpec should be false")
+type recordingClockIO struct {
+	sync.Mutex
+	ipcMessages    []ipc.Message
+	emittedClasses []fbprotocol.ClockClass
+	gmSettings     protocol.GrandmasterSettings
+	gmSettingsErr  error
+	setGMCalls     []protocol.GrandmasterSettings
+	setGMErr       error
+}
 
-		e.updateSpecState(Event{Source: DPLL, Data: &PTPData{OutOfSpec: true}})
-		assert.True(t, e.outOfSpec, "DPLL event with OutOfSpec=true should set outOfSpec")
+func (r *recordingClockIO) emitClockClass(cc fbprotocol.ClockClass, _ string) {
+	r.emittedClasses = append(r.emittedClasses, cc)
+}
+func (r *recordingClockIO) sendIPC(msg ipc.Message) {
+	r.ipcMessages = append(r.ipcMessages, msg)
+}
+func (r *recordingClockIO) getGMSettings(_ string) (protocol.GrandmasterSettings, error) {
+	return r.gmSettings, r.gmSettingsErr
+}
+func (r *recordingClockIO) setGMSettings(_ string, g protocol.GrandmasterSettings) error {
+	r.setGMCalls = append(r.setGMCalls, g)
+	return r.setGMErr
+}
+func (r *recordingClockIO) setExternalGMPropertiesNP(string, protocol.ExternalGrandmasterProperties) error {
+	return nil
+}
+func (r *recordingClockIO) getParentTimeAndCurrentDS(string) (pmc.ParentTimeCurrentDS, error) {
+	return pmc.ParentTimeCurrentDS{}, nil
+}
+func (r *recordingClockIO) getUtcOffset() int { return 37 }
 
-		e.updateSpecState(Event{Source: DPLL, Data: &PTPData{OutOfSpec: false}})
-		assert.False(t, e.outOfSpec, "DPLL event with OutOfSpec=false should clear outOfSpec")
+func TestProcessSyncE(t *testing.T) {
+	t.Run("state event emits synce_state IPC", func(t *testing.T) {
+		rio := &recordingClockIO{}
+		bc := &TBCClock{cfgName: testPTP4lCfg, io: rio}
+		ev := Event{
+			Source: SYNCE,
+			IFace:  testEns7f0,
+			Data: &PTPData{
+				Values: map[ValueType]interface{}{
+					EEC_STATE: "EEC_LOCKED",
+				},
+			},
+		}
+		bc.processSyncE(ev)
+		assert.Len(t, rio.ipcMessages, 1)
+		assert.Equal(t, ipc.TypeSyncEState, rio.ipcMessages[0].Type)
+		assert.Equal(t, testPTP4lCfg, rio.ipcMessages[0].Profile)
+		assert.Equal(t, testEns7f0, rio.ipcMessages[0].IFace)
+		assert.Equal(t, ipc.SyncEStateValue{State: "EEC_LOCKED"}, rio.ipcMessages[0].Values)
 	})
 
-	t.Run("DPLL event sets frequencyTraceable", func(t *testing.T) {
-		e := newHandler()
-		assert.False(t, e.frequencyTraceable, "initial frequencyTraceable should be false")
-
-		e.updateSpecState(Event{Source: DPLL, Data: &PTPData{FrequencyTraceable: true}})
-		assert.True(t, e.frequencyTraceable, "DPLL event should set frequencyTraceable")
-
-		e.updateSpecState(Event{Source: DPLL, Data: &PTPData{FrequencyTraceable: false}})
-		assert.False(t, e.frequencyTraceable, "DPLL event should clear frequencyTraceable")
+	t.Run("quality event emits synce_clock_quality IPC", func(t *testing.T) {
+		rio := &recordingClockIO{}
+		bc := &TBCClock{cfgName: testPTP4lCfg, io: rio}
+		ev := Event{
+			Source: SYNCE,
+			IFace:  testEns7f0,
+			Data: &PTPData{
+				Values: map[ValueType]interface{}{
+					QL:     byte(4),
+					EXT_QL: byte(0xFF),
+				},
+			},
+		}
+		bc.processSyncE(ev)
+		assert.Len(t, rio.ipcMessages, 1)
+		assert.Equal(t, ipc.TypeSyncEClockQuality, rio.ipcMessages[0].Type)
+		assert.Equal(t, testPTP4lCfg, rio.ipcMessages[0].Profile)
+		assert.Equal(t, ipc.SyncEClockQualityValue{QL: 4, ExtendedQL: 0xFF}, rio.ipcMessages[0].Values)
 	})
 
-	t.Run("non-DPLL event does not change spec state", func(t *testing.T) {
-		e := newHandler()
+	t.Run("event with both state and quality emits two IPC messages", func(t *testing.T) {
+		rio := &recordingClockIO{}
+		bc := &TBCClock{cfgName: testPTP4lCfg, io: rio}
+		ev := Event{
+			Source: SYNCE,
+			IFace:  testEns7f0,
+			Data: &PTPData{
+				Values: map[ValueType]interface{}{
+					EEC_STATE: "EEC_LOCKED",
+					QL:        byte(4),
+					EXT_QL:    byte(21),
+				},
+			},
+		}
+		bc.processSyncE(ev)
+		assert.Len(t, rio.ipcMessages, 2)
+		types := []string{rio.ipcMessages[0].Type, rio.ipcMessages[1].Type}
+		assert.Contains(t, types, ipc.TypeSyncEState)
+		assert.Contains(t, types, ipc.TypeSyncEClockQuality)
+	})
 
-		e.updateSpecState(Event{Source: DPLL, Data: &PTPData{OutOfSpec: true, FrequencyTraceable: true}})
-		assert.True(t, e.outOfSpec)
-		assert.True(t, e.frequencyTraceable)
+	t.Run("nil PTPData does not panic", func(t *testing.T) {
+		rio := &recordingClockIO{}
+		bc := &TBCClock{cfgName: testPTP4lCfg, io: rio}
+		bc.processSyncE(Event{Source: SYNCE, Data: nil})
+		assert.Empty(t, rio.ipcMessages)
+	})
 
-		e.updateSpecState(Event{Source: TS2PHC, Data: &PTPData{OutOfSpec: false, FrequencyTraceable: false}})
-		assert.True(t, e.outOfSpec, "non-DPLL event should not change outOfSpec")
-		assert.True(t, e.frequencyTraceable, "non-DPLL event should not change frequencyTraceable")
+	t.Run("ts2phc cfgName normalizes to ptp4l profile", func(t *testing.T) {
+		rio := &recordingClockIO{}
+		bc := &TBCClock{cfgName: testTS2PHCCfg, io: rio}
+		ev := Event{
+			Source: SYNCE,
+			IFace:  testEns7f0,
+			Data: &PTPData{
+				Values: map[ValueType]interface{}{
+					EEC_STATE: "EEC_HOLDOVER",
+				},
+			},
+		}
+		bc.processSyncE(ev)
+		assert.Len(t, rio.ipcMessages, 1)
+		assert.Equal(t, testPTP4lCfg, rio.ipcMessages[0].Profile)
+	})
+}
+
+func TestUpdateOSClockState(t *testing.T) {
+	t.Run("changes when PTP and OS clock differ", func(t *testing.T) {
+		rio := &recordingClockIO{}
+		bc := newTestTBCClock(nil)
+		bc.io = rio
+		bc.syncState.state = PTP_LOCKED
+		bc.overallSyncState = PTP_LOCKED
+
+		bc.SystemClockUpdate(PTP_FREERUN)
+		assert.Equal(t, PTP_FREERUN, bc.overallSyncState)
+		assert.Equal(t, PTP_FREERUN, bc.osClockState)
+		require.Len(t, rio.ipcMessages, 1)
+		assert.Equal(t, ipc.TypeSyncState, rio.ipcMessages[0].Type)
+		assert.Equal(t, ipc.SyncStateValue{State: ipc.StateFreerun}, rio.ipcMessages[0].Values)
+	})
+
+	t.Run("no change when already correct", func(t *testing.T) {
+		rio := &recordingClockIO{}
+		bc := newTestTBCClock(nil)
+		bc.io = rio
+		bc.syncState.state = PTP_LOCKED
+		bc.overallSyncState = PTP_LOCKED
+
+		bc.SystemClockUpdate(PTP_LOCKED)
+		assert.Equal(t, PTP_LOCKED, bc.overallSyncState)
+		assert.Empty(t, rio.ipcMessages)
+	})
+}
+
+func TestTBCClock_ParentDSUpdate(t *testing.T) {
+	t.Run("stores upstream parent dataset", func(t *testing.T) {
+		bc := newTestTBCClock(nil)
+		parentDS := protocol.ParentDataSet{
+			GrandmasterIdentity:   "001122.fffe.334455",
+			GrandmasterClockClass: 6,
+		}
+
+		bc.ParentDSUpdate(parentDS)
+
+		assert.True(t, parentDS.Equal(bc.leadingClockData.upstreamParentDataSet))
+	})
+
+	t.Run("unchanged dataset is a no-op", func(t *testing.T) {
+		bc := newTestTBCClock(nil)
+		parentDS := protocol.ParentDataSet{
+			GrandmasterIdentity:   "001122.fffe.334455",
+			GrandmasterClockClass: 6,
+		}
+
+		bc.ParentDSUpdate(parentDS)
+		bc.ParentDSUpdate(parentDS)
+
+		assert.True(t, parentDS.Equal(bc.leadingClockData.upstreamParentDataSet))
+	})
+
+	t.Run("LOCKED clock propagates upstream clock class immediately", func(t *testing.T) {
+		rio := &recordingClockIO{}
+		bc := newLockedTBCClock(rio)
+		assert.Equal(t, PTP_LOCKED, bc.syncState.state, "precondition: clock must be LOCKED")
+		rio.ipcMessages = nil
+
+		bc.ParentDSUpdate(protocol.ParentDataSet{
+			GrandmasterClockClass: 6,
+		})
+
+		assert.Equal(t, fbprotocol.ClockClass(6), bc.syncState.clockClass,
+			"clock class should update to upstream value")
+		assert.True(t, bc.leadingClockData.upstreamParentDataSet.Equal(
+			bc.leadingClockData.downstreamParentDataSet),
+			"downstream ParentDataSet should match upstream after propagation")
+	})
+
+	t.Run("LOCKED clock sends IPC on clock class change", func(t *testing.T) {
+		rio := &recordingClockIO{}
+		bc := newLockedTBCClock(rio)
+		rio.ipcMessages = nil
+
+		bc.ParentDSUpdate(protocol.ParentDataSet{
+			GrandmasterClockClass: 7,
+		})
+
+		var foundClockClassIPC bool
+		for _, msg := range rio.ipcMessages {
+			if msg.Type == ipc.TypeClockClass {
+				foundClockClassIPC = true
+				assert.Equal(t, ipc.ClockClassValue{ClockClass: 7}, msg.Values)
+			}
+		}
+		assert.True(t, foundClockClassIPC, "should send clock class IPC message")
+	})
+
+	t.Run("LOCKED clock unchanged upstream class produces no IPC", func(t *testing.T) {
+		rio := &recordingClockIO{}
+		bc := newLockedTBCClock(rio)
+
+		bc.ParentDSUpdate(protocol.ParentDataSet{GrandmasterClockClass: 6})
+		rio.ipcMessages = nil
+
+		bc.ParentDSUpdate(protocol.ParentDataSet{GrandmasterClockClass: 6})
+
+		var clockClassIPCs int
+		for _, msg := range rio.ipcMessages {
+			if msg.Type == ipc.TypeClockClass {
+				clockClassIPCs++
+			}
+		}
+		assert.Equal(t, 0, clockClassIPCs, "no clock class IPC when upstream class unchanged")
+	})
+}
+
+func TestBCClock_ParentDSUpdate(t *testing.T) {
+	t.Run("updates clock class and emits", func(t *testing.T) {
+		rio := &recordingClockIO{}
+		bc := &BCClock{cfgName: testPTP4lCfg, io: rio}
+
+		parentDS := protocol.ParentDataSet{
+			GrandmasterClockClass: 6,
+		}
+		bc.ParentDSUpdate(parentDS)
+
+		assert.Equal(t, fbprotocol.ClockClass(6), bc.clockClass)
+		require.Len(t, rio.ipcMessages, 1)
+		assert.Equal(t, ipc.TypeClockClass, rio.ipcMessages[0].Type)
+		assert.Equal(t, ipc.ClockClassValue{ClockClass: 6}, rio.ipcMessages[0].Values)
+		require.Len(t, rio.emittedClasses, 1)
+		assert.Equal(t, fbprotocol.ClockClass(6), rio.emittedClasses[0])
+	})
+
+	t.Run("unchanged class still emits but does not send IPC", func(t *testing.T) {
+		rio := &recordingClockIO{}
+		bc := &BCClock{cfgName: testPTP4lCfg, io: rio, clockClass: fbprotocol.ClockClass(6)}
+
+		parentDS := protocol.ParentDataSet{
+			GrandmasterClockClass: 6,
+		}
+		bc.ParentDSUpdate(parentDS)
+
+		assert.Empty(t, rio.ipcMessages, "updateClockClass should no-op on unchanged class")
+		require.Len(t, rio.emittedClasses, 1, "emitClockClass is always called")
 	})
 }

--- a/pkg/event/event_socket_test.go
+++ b/pkg/event/event_socket_test.go
@@ -22,7 +22,7 @@ func newTestEventHandler(socketPath string) *EventHandler {
 		stdoutSocket:   socketPath,
 		stdoutToSocket: true,
 		closeCh:        make(chan bool, 1),
-		clkSyncState:   map[string]*clockSyncState{},
+		clocks:         map[string]Clock{},
 	}
 }
 
@@ -540,13 +540,21 @@ func TestEmitClockSyncLogs_WritesWithNewline(t *testing.T) {
 	e := newTestEventHandler(socketPath)
 	assert.True(t, e.reconnectEventSocket())
 
-	// Set clock sync state with logs that already have trailing newlines (as GetLogData produces)
+	// Register clock objects with syncState.clkLog populated
 	e.Lock()
-	e.clkSyncState["ptp4l.0.config"] = &clockSyncState{
-		clkLog: "GM[1710000000]:[ptp4l.0.config] ens3f2 T-GM-STATUS s2\n",
+	e.clocks["ptp4l.0.config"] = &GMClock{
+		cfgName: "ptp4l.0.config",
+		io:      &noopClockIO{},
+		syncState: clockSyncState{
+			clkLog: "GM[1710000000]:[ptp4l.0.config] ens3f2 T-GM-STATUS s2\n",
+		},
 	}
-	e.clkSyncState["ptp4l.1.config"] = &clockSyncState{
-		clkLog: "GM[1710000001]:[ptp4l.1.config] ens2f0 T-GM-STATUS s2\n",
+	e.clocks["ptp4l.1.config"] = &GMClock{
+		cfgName: "ptp4l.1.config",
+		io:      &noopClockIO{},
+		syncState: clockSyncState{
+			clkLog: "GM[1710000001]:[ptp4l.1.config] ens2f0 T-GM-STATUS s2\n",
+		},
 	}
 	e.Unlock()
 
@@ -648,9 +656,9 @@ func TestEmitClockClass_ReconnectsOnBrokenPipe(t *testing.T) {
 	e.setConn(nil) // cleanup
 }
 
-// --- EmitClockClass (exported, via clkSyncState) ---
+// --- EmitClockClass (exported, via clock objects) ---
 
-func TestEmitClockClassExported_SkipsWhenNoClkSyncState(t *testing.T) {
+func TestEmitClockClassExported_EmitsDefaultState(t *testing.T) {
 	socketPath := shortSocketPath(t)
 	listener, err := net.Listen("unix", socketPath)
 	assert.NoError(t, err)
@@ -662,15 +670,13 @@ func TestEmitClockClassExported_SkipsWhenNoClkSyncState(t *testing.T) {
 	e := NewEventHandlerForTests(socketPath)
 	assert.True(t, e.reconnectEventSocket())
 
-	// No clkSyncState entry for this config; EmitClockClass should return early
+	// No stored clock class — EmitClockClass should be a no-op
 	e.EmitClockClass("ptp4l.99.config")
 
-	// Verify nothing was sent
 	select {
-	case got := <-received:
-		t.Fatalf("expected no message but got: %q", got)
+	case <-received:
+		t.Fatal("expected no message when no clock class is stored")
 	case <-time.After(200 * time.Millisecond):
-		// expected: no data sent
 	}
 
 	e.setConn(nil) // cleanup
@@ -688,11 +694,8 @@ func TestEmitClockClassExported_EmitsStoredClockClass(t *testing.T) {
 	e := NewEventHandlerForTests(socketPath)
 	assert.True(t, e.reconnectEventSocket())
 
-	// Populate clkSyncState via test helper
+	// Set and emit for config 0
 	e.SetClockClass("ptp4l.0.config", 6)
-	e.SetClockClass("ptp4l.1.config", 255)
-
-	// Emit for config 0
 	e.EmitClockClass("ptp4l.0.config")
 
 	select {
@@ -703,7 +706,8 @@ func TestEmitClockClassExported_EmitsStoredClockClass(t *testing.T) {
 		t.Fatal("timed out waiting for clock class message")
 	}
 
-	// Emit for config 1
+	// Set and emit for config 1
+	e.SetClockClass("ptp4l.1.config", 255)
 	e.EmitClockClass("ptp4l.1.config")
 
 	select {
@@ -712,125 +716,6 @@ func TestEmitClockClassExported_EmitsStoredClockClass(t *testing.T) {
 		assert.Contains(t, got, "ptp4l.1.config")
 	case <-time.After(2 * time.Second):
 		t.Fatal("timed out waiting for clock class message for config 1")
-	}
-
-	e.setConn(nil) // cleanup
-}
-
-// --- storeClockClassLocked ---
-
-func TestStoreClockClassLocked_CreatesNewEntry(t *testing.T) {
-	e := newTestEventHandler("")
-	e.Lock()
-	e.storeClockClassLocked("ptp4l.0.config", fbprotocol.ClockClass(6), fbprotocol.ClockAccuracy(0x21))
-	state, ok := e.clkSyncState["ptp4l.0.config"]
-	e.Unlock()
-
-	assert.True(t, ok)
-	assert.Equal(t, fbprotocol.ClockClass(6), state.clockClass)
-	assert.Equal(t, fbprotocol.ClockAccuracy(0x21), state.clockAccuracy)
-}
-
-func TestStoreClockClassLocked_UpdatesExistingEntry(t *testing.T) {
-	e := newTestEventHandler("")
-
-	// Pre-populate with other fields
-	e.clkSyncState["ptp4l.0.config"] = &clockSyncState{
-		state:      PTP_LOCKED,
-		clockClass: fbprotocol.ClockClass(248),
-	}
-
-	e.Lock()
-	e.storeClockClassLocked("ptp4l.0.config", fbprotocol.ClockClass(6), fbprotocol.ClockAccuracy(0x21))
-	state := e.clkSyncState["ptp4l.0.config"]
-	e.Unlock()
-
-	assert.Equal(t, fbprotocol.ClockClass(6), state.clockClass)
-	assert.Equal(t, fbprotocol.ClockAccuracy(0x21), state.clockAccuracy)
-	// Existing field preserved
-	assert.Equal(t, PTP_LOCKED, state.state)
-}
-
-func TestStoreClockClassLocked_MakesEmitClockClassWork(t *testing.T) {
-	socketPath := shortSocketPath(t)
-	listener, err := net.Listen("unix", socketPath)
-	assert.NoError(t, err)
-	defer listener.Close()
-
-	received := make(chan string, 10)
-	go acceptAndRead(listener, received)
-
-	e := newTestEventHandler(socketPath)
-	assert.True(t, e.reconnectEventSocket())
-
-	// Simulate what clockClassRequestCh handler does
-	e.Lock()
-	e.storeClockClassLocked("ptp4l.0.config", fbprotocol.ClockClass(6), fbprotocol.ClockAccuracy(0x21))
-	e.storeClockClassLocked("ptp4l.1.config", fbprotocol.ClockClass(255), fbprotocol.ClockAccuracy(0xFE))
-	e.Unlock()
-
-	// EmitClockClass should now find and emit the stored values
-	e.EmitClockClass("ptp4l.0.config")
-
-	select {
-	case got := <-received:
-		assert.Contains(t, got, "CLOCK_CLASS_CHANGE 6")
-		assert.Contains(t, got, "ptp4l.0.config")
-	case <-time.After(2 * time.Second):
-		t.Fatal("timed out waiting for clock class message")
-	}
-
-	e.EmitClockClass("ptp4l.1.config")
-
-	select {
-	case got := <-received:
-		assert.Contains(t, got, "CLOCK_CLASS_CHANGE 255")
-		assert.Contains(t, got, "ptp4l.1.config")
-	case <-time.After(2 * time.Second):
-		t.Fatal("timed out waiting for clock class message")
-	}
-
-	e.setConn(nil) // cleanup
-}
-
-// --- announceClockClass stores in clkSyncState ---
-
-func TestAnnounceClockClass_PopulatesClkSyncState(t *testing.T) {
-	socketPath := shortSocketPath(t)
-	listener, err := net.Listen("unix", socketPath)
-	assert.NoError(t, err)
-	defer listener.Close()
-
-	received := make(chan string, 10)
-	go acceptAndRead(listener, received)
-
-	e := newTestEventHandler(socketPath)
-	assert.True(t, e.reconnectEventSocket())
-
-	// clkSyncState should be empty initially
-	e.Lock()
-	_, ok := e.clkSyncState["ptp4l.1.config"]
-	e.Unlock()
-	assert.False(t, ok, "clkSyncState should be empty before announceClockClass")
-
-	// announceClockClass should populate clkSyncState AND emit to socket
-	e.announceClockClass(fbprotocol.ClockClass(6), fbprotocol.ClockAccuracy(0x21), "ptp4l.1.config")
-
-	// Verify clkSyncState was populated
-	e.Lock()
-	state, ok := e.clkSyncState["ptp4l.1.config"]
-	e.Unlock()
-	assert.True(t, ok, "clkSyncState should have ptp4l.1.config after announceClockClass")
-	assert.Equal(t, fbprotocol.ClockClass(6), state.clockClass)
-	assert.Equal(t, fbprotocol.ClockAccuracy(0x21), state.clockAccuracy)
-
-	// Verify it was written to socket
-	select {
-	case got := <-received:
-		assert.Contains(t, got, "CLOCK_CLASS_CHANGE 6")
-		assert.Contains(t, got, "ptp4l.1.config")
-	case <-time.After(2 * time.Second):
-		t.Fatal("timed out waiting for clock class message on socket")
 	}
 
 	e.setConn(nil) // cleanup

--- a/pkg/event/event_tbc.go
+++ b/pkg/event/event_tbc.go
@@ -8,12 +8,12 @@ import (
 	"time"
 
 	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/alias"
-	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/pmc"
+	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/ipc"
 	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/protocol"
+	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/utils"
 
 	fbprotocol "github.com/facebook/time/ptp/protocol"
 	"github.com/golang/glog"
-	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/leap"
 )
 
 const (
@@ -77,43 +77,83 @@ func newLeadingClockParams() *LeadingClockParams {
 	}
 }
 
-// updateBCState updates the BC/TSC state machine.
-// Called with e.Lock() held. Returns the clock sync state, whether a TTSC clock class
-// announcement is needed, and whether downstream data needs updating.
-// The caller must perform all I/O after releasing the lock.
-func (e *EventHandler) updateBCState(event Event) (clockSyncState, bool, bool) {
-	cfgName := event.CfgName
-	dpllState := PTP_NOTSET
-	ts2phcState := PTP_FREERUN
-
-	// For internal data announces, only update the downstream data on class change
-	// For External GM data announces in the locked state, update whenever any of the
-	// information elements change
-	updateDownstreamData := false
-	if event.Source == PTP4lProcessName {
-		glog.Infof("PTP4l event: %+v", event)
-	}
-	leadingInterface := e.getLeadingInterfaceBC()
-	if leadingInterface == LEADING_INTERFACE_UNKNOWN {
-		glog.Infof("Leading interface is not yet identified, clock state reporting delayed.")
-		return clockSyncState{leadingIFace: leadingInterface}, false, false
-	}
-
-	if _, ok := e.clkSyncState[cfgName]; !ok {
-		glog.Info("initializing e.clkSyncState for ", cfgName)
-		e.clkSyncState[cfgName] = &clockSyncState{
-			state:         PTP_FREERUN,
-			clockClass:    protocol.ClockClassUninitialized,
-			clockAccuracy: fbprotocol.ClockAccuracyUnknown,
-			sourceLost:    false,
-			leadingIFace:  leadingInterface,
+// GetData returns the Data entry for the given process, creating one if needed.
+func (c *TBCClock) GetData(processName EventSource) *Data {
+	for _, d := range c.data {
+		if d.ProcessName == processName {
+			return d
 		}
 	}
+	d := &Data{ProcessName: processName, State: PTP_UNKNOWN, window: *utils.NewWindow(WindowSize)}
+	c.data = append(c.data, d)
+	return d
+}
 
-	e.clkSyncState[cfgName].sourceLost = false
-	e.clkSyncState[cfgName].leadingIFace = leadingInterface
-	if data, ok := e.data[cfgName]; ok {
-		for _, d := range data {
+func (c *TBCClock) addEvent(event Event) (Event, clockSyncState, *DataDetails) {
+	if event.Source == PTP4lProcessName {
+		event.CfgName = c.cfgName
+	}
+	d := c.GetData(event.Source)
+	d.AddEvent(event)
+	d.UpdateState()
+	c.updateLeadingClockData(event)
+	c.evaluateState()
+	return event, c.syncState, d.GetDataDetails(event.IFace)
+}
+
+func (c *TBCClock) evaluateState() {
+	prevState := c.syncState.state
+	prevClockClass := c.syncState.clockClass
+
+	needsTTSCAnnounce, needsDownstreamUpdate := c.updateState()
+
+	profile := strings.Replace(c.cfgName, "ts2phc", "ptp4l", 1)
+	if c.syncState.state != prevState {
+		c.io.sendIPC(ipc.Message{
+			Type:    ipc.TypePTPState,
+			Profile: profile,
+			IFace:   c.syncState.leadingIFace,
+			Values:  ipc.StateValue{State: ptpStateToIPCState(c.syncState.state)},
+		})
+	}
+	if c.syncState.clockClass != prevClockClass {
+		c.io.sendIPC(ipc.Message{
+			Type:    ipc.TypeClockClass,
+			Profile: profile,
+			Values:  ipc.ClockClassValue{ClockClass: uint8(c.syncState.clockClass)},
+		})
+	}
+
+	emitOverallSyncStateIfChanged(c.io, &c.overallSyncState, c.syncState.state, c.osClockState, profile)
+
+	if needsTTSCAnnounce {
+		c.announcedClockClass = c.syncState.clockClass
+		c.announcedClockAccuracy = c.syncState.clockAccuracy
+		c.io.emitClockClass(c.syncState.clockClass, c.cfgName)
+	}
+	if needsDownstreamUpdate {
+		c.updateDownstreamData(c.cfgName)
+	}
+}
+
+// updateState updates the BC/TSC state machine using TBCClock's owned
+// syncState and data. Returns whether a TTSC clock class announcement is
+// needed and whether downstream data needs updating.
+func (c *TBCClock) updateState() (needsTTSCAnnounce, needsDownstreamUpdate bool) {
+	dpllState := PTP_NOTSET
+	ts2phcState := PTP_FREERUN
+	updateDownstreamData := false
+	leadingInterface := c.getLeadingInterfaceBC()
+	if leadingInterface == LEADING_INTERFACE_UNKNOWN {
+		glog.Infof("Leading interface is not yet identified, clock state reporting delayed.")
+		c.syncState.leadingIFace = leadingInterface
+		return false, false
+	}
+
+	c.syncState.sourceLost = false
+	c.syncState.leadingIFace = leadingInterface
+	if len(c.data) > 0 {
+		for _, d := range c.data {
 			switch d.ProcessName {
 			case DPLL:
 				dpllState = d.State
@@ -122,209 +162,177 @@ func (e *EventHandler) updateBCState(event Event) (clockSyncState, bool, bool) {
 			}
 		}
 	} else {
-		glog.Info("initializing default e.clkSyncState for ", cfgName)
-		e.clkSyncState[cfgName].state = PTP_FREERUN
-		e.clkSyncState[cfgName].clockClass = protocol.ClockClassFreerun
-		e.clkSyncState[cfgName].clockAccuracy = fbprotocol.ClockAccuracyUnknown
-		e.clkSyncState[cfgName].lastLoggedTime = time.Now().Unix()
-		e.clkSyncState[cfgName].leadingIFace = leadingInterface
-		e.clkSyncState[cfgName].clkLog = fmt.Sprintf("T-BC[%d]:[%s] %s offset %d T-BC-STATUS %s\n",
-			e.clkSyncState[cfgName].lastLoggedTime, cfgName, leadingInterface, e.clkSyncState[cfgName].clockOffset,
-			e.clkSyncState[cfgName].state)
-		return *e.clkSyncState[cfgName], false, false
+		glog.Info("initializing default clkSyncState for ", c.cfgName)
+		c.syncState.state = PTP_FREERUN
+		c.syncState.clockClass = protocol.ClockClassFreerun
+		c.syncState.clockAccuracy = fbprotocol.ClockAccuracyUnknown
+		c.syncState.lastLoggedTime = time.Now().Unix()
+		c.syncState.leadingIFace = leadingInterface
+		c.syncState.clkLog = fmt.Sprintf("T-BC[%d]:[%s] %s offset %d T-BC-STATUS %s\n",
+			c.syncState.lastLoggedTime, c.cfgName, leadingInterface, c.syncState.clockOffset,
+			c.syncState.state)
+		return false, false
 	}
 
-	isTTSC := (e.LeadingClockData.clockID != "" && e.LeadingClockData.controlledPortsConfig == "")
+	isTTSC := (c.leadingClockData.clockID != "" && c.leadingClockData.controlledPortsConfig == "")
 
-	glog.V(14).Info("current BC state: ", e.clkSyncState[cfgName].state)
-	switch e.clkSyncState[cfgName].state {
+	glog.V(14).Info("current BC state: ", c.syncState.state)
+	switch c.syncState.state {
 	case PTP_NOTSET, PTP_FREERUN:
-		if !e.isSourceLostBC(cfgName) && e.inSyncCondition(cfgName) {
-			e.clkSyncState[cfgName].state = PTP_LOCKED
+		if !c.isSourceLostBC() && c.inSyncCondition() {
+			c.syncState.state = PTP_LOCKED
 			glog.Info("BC FSM: FREERUN to LOCKED")
-			e.LeadingClockData.lastInSpec = true
+			c.leadingClockData.lastInSpec = true
 			updateDownstreamData = true
 		}
 	case PTP_LOCKED:
-		if e.freeRunCondition(cfgName) || e.hasNonLeadingDPLLFault(cfgName, leadingInterface) {
-			e.clkSyncState[cfgName].state = PTP_FREERUN
-			e.clkSyncState[cfgName].clockClass = protocol.ClockClassFreerun
+		if c.freeRunCondition() || c.hasNonLeadingDPLLFault() {
+			c.syncState.state = PTP_FREERUN
+			c.syncState.clockClass = protocol.ClockClassFreerun
 			glog.Info("BC FSM: LOCKED to FREERUN")
 			updateDownstreamData = true
-		} else if e.isSourceLostBC(cfgName) {
-			e.clkSyncState[cfgName].state = PTP_HOLDOVER
-			e.clkSyncState[cfgName].clockClass = fbprotocol.ClockClass(135)
+		} else if c.isSourceLostBC() {
+			c.syncState.state = PTP_HOLDOVER
+			c.syncState.clockClass = fbprotocol.ClockClass(135)
 			glog.Info("BC FSM: LOCKED to HOLDOVER")
-			e.LeadingClockData.lastInSpec = true
+			c.leadingClockData.lastInSpec = true
 			updateDownstreamData = true
 		} else {
-			if *e.LeadingClockData.upstreamTimeProperties != *e.LeadingClockData.downstreamTimeProperties {
-				e.LeadingClockData.downstreamTimeProperties = e.LeadingClockData.upstreamTimeProperties
+			if *c.leadingClockData.upstreamTimeProperties != *c.leadingClockData.downstreamTimeProperties {
+				c.leadingClockData.downstreamTimeProperties = c.leadingClockData.upstreamTimeProperties
 				updateDownstreamData = true
 			}
-			if *e.LeadingClockData.upstreamParentDataSet != *e.LeadingClockData.downstreamParentDataSet {
-				e.LeadingClockData.downstreamParentDataSet = e.LeadingClockData.upstreamParentDataSet
+			if *c.leadingClockData.upstreamParentDataSet != *c.leadingClockData.downstreamParentDataSet {
+				c.leadingClockData.downstreamParentDataSet = c.leadingClockData.upstreamParentDataSet
 				updateDownstreamData = true
 			}
-			if e.LeadingClockData.upstreamParentDataSet.GrandmasterClockClass == uint8(protocol.ClockClassFreerun) {
+			if c.leadingClockData.upstreamParentDataSet.GrandmasterClockClass == uint8(protocol.ClockClassFreerun) {
 				updateDownstreamData = false // Don't propagate uptream free run and instead let future call move to holdover/freerun
-			} else if e.clkSyncState[cfgName].clockClass != fbprotocol.ClockClass(e.LeadingClockData.upstreamParentDataSet.GrandmasterClockClass) && !isTTSC {
-				e.clkSyncState[cfgName].clockClass = fbprotocol.ClockClass(e.LeadingClockData.upstreamParentDataSet.GrandmasterClockClass)
-				e.clkSyncState[cfgName].clockAccuracy = fbprotocol.ClockAccuracy(e.LeadingClockData.upstreamParentDataSet.GrandmasterClockAccuracy)
+			} else if !isTTSC {
+				upstreamClass := fbprotocol.ClockClass(c.leadingClockData.upstreamParentDataSet.GrandmasterClockClass)
+				upstreamAccuracy := fbprotocol.ClockAccuracy(c.leadingClockData.upstreamParentDataSet.GrandmasterClockAccuracy)
+				if c.syncState.clockClass != upstreamClass || c.syncState.clockAccuracy != upstreamAccuracy {
+					c.syncState.clockClass = upstreamClass
+					c.syncState.clockAccuracy = upstreamAccuracy
+				}
 			}
 		}
 	case PTP_HOLDOVER:
-		nonLeadingFault := e.hasNonLeadingDPLLFault(cfgName, leadingInterface)
+		nonLeadingFault := c.hasNonLeadingDPLLFault()
 		switch {
-		case nonLeadingFault || e.freeRunCondition(cfgName):
-			e.clkSyncState[cfgName].state = PTP_FREERUN
-			e.clkSyncState[cfgName].clockClass = protocol.ClockClassFreerun
+		case nonLeadingFault || c.freeRunCondition():
+			c.syncState.state = PTP_FREERUN
+			c.syncState.clockClass = protocol.ClockClassFreerun
 			glog.Info("BC FSM: HOLDOVER to FREERUN")
 			updateDownstreamData = true
-		case e.inSyncCondition(cfgName) && !e.isSourceLostBC(cfgName):
-			e.clkSyncState[cfgName].state = PTP_LOCKED
+		case c.inSyncCondition() && !c.isSourceLostBC():
+			c.syncState.state = PTP_LOCKED
 			glog.Info("BC FSM: HOLDOVER to LOCKED")
 			updateDownstreamData = true
 		default:
-			if event.IFace == leadingInterface {
-				inSpec := false
-				if e.LeadingClockData.lastInSpec {
-					inSpec = e.inSpecCondition(cfgName)
-				}
-				if e.LeadingClockData.lastInSpec != inSpec {
-					e.LeadingClockData.lastInSpec = inSpec
-					if !inSpec {
-						if e.clkSyncState[cfgName].clockClass != fbprotocol.ClockClass(165) {
-							e.clkSyncState[cfgName].clockClass = fbprotocol.ClockClass(165)
-							glog.Info("BC FSM: HOLDOVER sub-state Out Of Spec")
-							updateDownstreamData = true
-						}
-					} else {
-						if e.clkSyncState[cfgName].clockClass != fbprotocol.ClockClass(135) {
-							e.clkSyncState[cfgName].clockClass = fbprotocol.ClockClass(135)
-							glog.Info("BC FSM: HOLDOVER sub-state In Spec")
-							updateDownstreamData = true
-						}
+			inSpec := false
+			if c.leadingClockData.lastInSpec {
+				inSpec = c.inSpecCondition()
+			}
+			if c.leadingClockData.lastInSpec != inSpec {
+				c.leadingClockData.lastInSpec = inSpec
+				if !inSpec {
+					if c.syncState.clockClass != fbprotocol.ClockClass(165) {
+						c.syncState.clockClass = fbprotocol.ClockClass(165)
+						glog.Info("BC FSM: HOLDOVER sub-state Out Of Spec")
+						updateDownstreamData = true
+					}
+				} else {
+					if c.syncState.clockClass != fbprotocol.ClockClass(135) {
+						c.syncState.clockClass = fbprotocol.ClockClass(135)
+						glog.Info("BC FSM: HOLDOVER sub-state In Spec")
+						updateDownstreamData = true
 					}
 				}
 			}
 		}
 	}
-	e.clkSyncState[cfgName].leadingIFace = leadingInterface
-	e.clkSyncState[cfgName].clockAccuracy = fbprotocol.ClockAccuracyUnknown
-
-	gSycState := e.clkSyncState[cfgName]
-	rclockSyncState := clockSyncState{
-		state:         gSycState.state,
-		clockClass:    gSycState.clockClass,
-		clockAccuracy: gSycState.clockAccuracy,
-		sourceLost:    gSycState.sourceLost,
-		leadingIFace:  gSycState.leadingIFace,
+	c.syncState.leadingIFace = leadingInterface
+	if c.syncState.state != PTP_LOCKED {
+		c.syncState.clockAccuracy = fbprotocol.ClockAccuracyUnknown
 	}
 
-	switch gSycState.state {
+	switch c.syncState.state {
 	case PTP_FREERUN:
-		e.clkSyncState[cfgName].clockOffset = FaultyPhaseOffset
+		c.syncState.clockOffset = FaultyPhaseOffset
 	case PTP_HOLDOVER:
-		e.clkSyncState[cfgName].clockOffset = e.getCalculatedHoldoverOffset(cfgName)
+		c.syncState.clockOffset = c.getCalculatedHoldoverOffset()
 	default:
-		e.clkSyncState[cfgName].clockOffset = e.getLargestOffset(cfgName)
+		c.syncState.clockOffset = c.getLargestOffset()
 	}
 
-	if isTTSC && e.clkSyncState[cfgName].clockClass != fbprotocol.ClockClassSlaveOnly {
-		e.clkSyncState[cfgName].clockClass = fbprotocol.ClockClassSlaveOnly
+	if isTTSC && c.syncState.clockClass != fbprotocol.ClockClassSlaveOnly {
+		c.syncState.clockClass = fbprotocol.ClockClassSlaveOnly
 	}
-	needsTTSCAnnounce := false
-	needsDownstreamUpdate := false
-	if updateDownstreamData && e.clkSyncState[cfgName].clockClass != protocol.ClockClassUninitialized {
+	if updateDownstreamData && c.syncState.clockClass != protocol.ClockClassUninitialized {
 		if isTTSC {
-			// Set clock class fields under lock; the caller will emit after releasing the lock
-			e.setClockClassLocked(e.clkSyncState[cfgName].clockClass, e.clkSyncState[cfgName].clockAccuracy)
 			needsTTSCAnnounce = true
 		} else {
 			needsDownstreamUpdate = true
 		}
 	}
-	// this will reduce log noise and prints 1 per sec
 	logTime := time.Now().Unix()
-	if e.clkSyncState[cfgName].lastLoggedTime != logTime {
-		clkLog := fmt.Sprintf("T-BC[%d]:[%s] %s offset %d T-BC-STATUS %s\n",
-			logTime, cfgName, gSycState.leadingIFace, e.clkSyncState[cfgName].clockOffset, gSycState.state)
-		e.clkSyncState[cfgName].lastLoggedTime = logTime
-		e.clkSyncState[cfgName].clkLog = clkLog
-		rclockSyncState.clkLog = clkLog
+	if c.syncState.lastLoggedTime != logTime {
+		c.syncState.clkLog = fmt.Sprintf("T-BC[%d]:[%s] %s offset %d T-BC-STATUS %s\n",
+			logTime, c.cfgName, leadingInterface, c.syncState.clockOffset, c.syncState.state)
+		c.syncState.lastLoggedTime = logTime
 		glog.Infof("dpll State %s, tsphc state %s, BC state %s, BC offset %d",
-			dpllState, ts2phcState, e.clkSyncState[cfgName].state, e.clkSyncState[cfgName].clockOffset)
+			dpllState, ts2phcState, c.syncState.state, c.syncState.clockOffset)
 	}
-	return rclockSyncState, needsTTSCAnnounce, needsDownstreamUpdate
+	return needsTTSCAnnounce, needsDownstreamUpdate
 }
 
-// UpdateUpstreamParentDataSet updates the upstream time properties, parent data set, and current data set
-// for the leading clock and triggers downstream data updates when changes are detected.
-func (e *EventHandler) UpdateUpstreamParentDataSet(parentDS protocol.ParentDataSet) {
-	if !parentDS.Equal(e.LeadingClockData.upstreamParentDataSet) {
-		e.LeadingClockData.upstreamParentDataSet = &parentDS
+func (c *TBCClock) ParentDSUpdate(parentDS protocol.ParentDataSet) {
+	c.UpdateUpstreamParentDataSet(parentDS)
+	c.evaluateState()
+}
+
+func (c *TBCClock) UpdateUpstreamParentDataSet(parentDS protocol.ParentDataSet) {
+	c.io.Lock()
+	defer c.io.Unlock()
+	if !parentDS.Equal(c.leadingClockData.upstreamParentDataSet) {
+		c.leadingClockData.upstreamParentDataSet = &parentDS
 	}
 }
 
-func (e *EventHandler) updateDownstreamData(cfgName string) {
-	e.Lock()
-	data, ok := e.clkSyncState[cfgName]
-	if !ok {
-		e.Unlock()
-		return
-	}
-	state := data.state
-
-	// Cancel any in-flight downstream update for this config before launching
-	// a new one. This prevents stale goroutines from overwriting state that a
-	// newer transition has already set.
-	if cancel, exists := e.downstreamCancel[cfgName]; exists {
-		cancel()
+func (c *TBCClock) updateDownstreamData(cfgName string) {
+	if c.downstreamCancel != nil {
+		c.downstreamCancel()
 	}
 	ctx, cancel := context.WithCancel(context.Background())
-	e.downstreamCancel[cfgName] = cancel
-	e.Unlock()
+	c.downstreamCancel = cancel
 
-	if state == PTP_LOCKED {
-		go e.downstreamAnnounceIWF(ctx, cfgName)
+	if c.syncState.state == PTP_LOCKED {
+		go c.downstreamAnnounceIWF(ctx, cfgName)
 	} else {
-		go e.announceLocalData(cfgName)
+		go c.announceLocalData(cfgName)
 	}
 }
 
-// EmitClockClass emits the current clock class and accuracy for the specified configuration.
-func (e *EventHandler) EmitClockClass(cfgName string) {
-	e.Lock()
-	state, ok := e.clkSyncState[cfgName]
-	if !ok {
-		glog.Warningf("EmitClockClass: no clkSyncState entry for %s, skipping", cfgName)
-		e.Unlock()
+// EmitClockClass re-emits the current clock class to the socket for replay.
+func (c *TBCClock) EmitClockClass(cfgName string) {
+	if c.announcedClockClass == 0 {
 		return
 	}
-	clockClass := state.clockClass
-	clockAccuracy := state.clockAccuracy
-	e.Unlock()
-	e.announceClockClass(clockClass, clockAccuracy, cfgName)
+	c.io.emitClockClass(c.announcedClockClass, cfgName)
 }
 
 // Implements Rec. ITU-T G.8275 (2024) Amd. 1 (08/2024)
 // Table VIII.3 − T-BC-/ T-BC-P/ T-BC-A Announce message contents
 // for free-run (acquiring), holdover within / out of the specification
-func (e *EventHandler) announceLocalData(cfgName string) {
-	// Snapshot shared data under lock to prevent data races with updateBCState
-	e.Lock()
-	clockID := e.LeadingClockData.clockID
-	controlledPortsConfig := e.LeadingClockData.controlledPortsConfig
-	downstreamTimeProperties := e.LeadingClockData.downstreamTimeProperties
-	state, ok := e.clkSyncState[cfgName]
-	if !ok {
-		e.Unlock()
-		return
-	}
-	clockClass := state.clockClass
-	clockAccuracy := state.clockAccuracy
-	e.Unlock()
+func (c *TBCClock) announceLocalData(cfgName string) {
+	c.io.Lock()
+	clockID := c.leadingClockData.clockID
+	controlledPortsConfig := c.leadingClockData.controlledPortsConfig
+	downstreamTimeProperties := c.leadingClockData.downstreamTimeProperties
+	clockClass := c.syncState.clockClass
+	clockAccuracy := c.syncState.clockAccuracy
+	c.io.Unlock()
 
 	egp := protocol.ExternalGrandmasterProperties{
 		GrandmasterIdentity: clockID,
@@ -332,11 +340,13 @@ func (e *EventHandler) announceLocalData(cfgName string) {
 	}
 	glog.Infof("EGP %++v", egp)
 	go func() {
-		if err := pmc.SetExternalGMPropertiesNP(controlledPortsConfig, egp); err != nil {
+		if err := c.io.setExternalGMPropertiesNP(controlledPortsConfig, egp); err != nil {
 			glog.Errorf("Failed to set external GM properties: %v", err)
 		}
 	}()
-	e.announceClockClass(clockClass, clockAccuracy, cfgName)
+	c.announcedClockClass = clockClass
+	c.announcedClockAccuracy = clockAccuracy
+	c.io.emitClockClass(clockClass, cfgName)
 	gs := protocol.GrandmasterSettings{
 		ClockQuality: fbprotocol.ClockQuality{
 			ClockClass:              clockClass,
@@ -356,7 +366,7 @@ func (e *EventHandler) announceLocalData(cfgName string) {
 		gs.TimePropertiesDS.TimeTraceable = false
 		// TODO: get the real freq traceability status when implemented
 		gs.TimePropertiesDS.FrequencyTraceable = false
-		gs.TimePropertiesDS.CurrentUtcOffset = int32(leap.GetUtcOffset())
+		gs.TimePropertiesDS.CurrentUtcOffset = int32(c.io.getUtcOffset())
 	case fbprotocol.ClockClass(165), fbprotocol.ClockClass(135):
 		if downstreamTimeProperties == nil {
 			glog.Info("Pending upstream clock data acquisition, skip updates")
@@ -378,47 +388,39 @@ func (e *EventHandler) announceLocalData(cfgName string) {
 	default:
 	}
 	go func() {
-		if err := pmc.SetGMSettings(controlledPortsConfig, gs); err != nil {
+		if err := c.io.setGMSettings(controlledPortsConfig, gs); err != nil {
 			glog.Errorf("Failed to set GM settings: %v", err)
 		}
 	}()
 	go func() {
-		if err := pmc.SetGMSettings(cfgName, gs); err != nil {
+		if err := c.io.setGMSettings(cfgName, gs); err != nil {
 			glog.Errorf("Failed to set GM settings: %v", err)
 		}
 	}()
 }
 
-// applyIfLockedBC acquires the lock, checks that the BC state is still
-// PTP_LOCKED, and if so runs fn under the lock. Returns false if the state
-// is no longer LOCKED (fn is not called). The lock is always released via defer.
-func (e *EventHandler) applyIfLockedBC(cfgName, context string, fn func()) bool {
-	e.Lock()
-	defer e.Unlock()
-	stateData, ok := e.clkSyncState[cfgName]
-	if !ok || stateData.state != PTP_LOCKED {
-		state := PTP_NOTSET
-		if ok {
-			state = stateData.state
-		}
-		glog.Infof("downstreamAnnounceIWF: BC state is %s (not LOCKED) %s, aborting", state, context)
+func (c *TBCClock) applyIfLockedBC(context string, fn func()) bool {
+	c.io.Lock()
+	defer c.io.Unlock()
+	if c.syncState.state != PTP_LOCKED {
+		glog.Infof("downstreamAnnounceIWF: BC state is %s (not LOCKED) %s, aborting", c.syncState.state, context)
 		return false
 	}
 	fn()
 	return true
 }
 
-// this function runs in a goroutine
-func (e *EventHandler) downstreamAnnounceIWF(ctx context.Context, cfgName string) {
+// downstreamAnnounceIWF fetches upstream parent/time/current datasets via PMC and propagates them to the controlled
+// downstream ports as GM settings.
+func (c *TBCClock) downstreamAnnounceIWF(ctx context.Context, cfgName string) {
 	ptpCfgName := strings.Replace(cfgName, "ts2phc", "ptp4l", 1)
 	glog.Infof("downstreamAnnounceIWF: %s", ptpCfgName)
 
-	// Snapshot controlledPortsConfig under lock
-	e.Lock()
-	controlledPortsConfig := e.LeadingClockData.controlledPortsConfig
-	e.Unlock()
+	c.io.Lock()
+	controlledPortsConfig := c.leadingClockData.controlledPortsConfig
+	c.io.Unlock()
 
-	upsteamData, fetchErr := pmc.GetParentTimeAndCurrentDS(cfgName)
+	upsteamData, fetchErr := c.io.getParentTimeAndCurrentDS(cfgName)
 	if fetchErr != nil {
 		glog.Error("Failed to fetch upstream data, downstream data can not be updated.")
 		return
@@ -429,10 +431,10 @@ func (e *EventHandler) downstreamAnnounceIWF(ctx context.Context, cfgName string
 		return
 	}
 
-	if !e.applyIfLockedBC(cfgName, "after PMC fetch", func() {
-		e.LeadingClockData.upstreamParentDataSet = &upsteamData.ParentDataSet
-		e.LeadingClockData.upstreamTimeProperties = &upsteamData.TimePropertiesDS
-		e.LeadingClockData.upstreamCurrentDSStepsRemoved = upsteamData.CurrentDS.StepsRemoved
+	if !c.applyIfLockedBC("after PMC fetch", func() {
+		c.leadingClockData.upstreamParentDataSet = &upsteamData.ParentDataSet
+		c.leadingClockData.upstreamTimeProperties = &upsteamData.TimePropertiesDS
+		c.leadingClockData.upstreamCurrentDSStepsRemoved = upsteamData.CurrentDS.StepsRemoved
 	}) {
 		return
 	}
@@ -452,23 +454,23 @@ func (e *EventHandler) downstreamAnnounceIWF(ctx context.Context, cfgName string
 	}
 	es := protocol.ExternalGrandmasterProperties{
 		GrandmasterIdentity: upsteamData.ParentDataSet.GrandmasterIdentity,
-		// stepsRemoved at this point is already incremented, representing the current clock position
-		StepsRemoved: upsteamData.CurrentDS.StepsRemoved,
+		StepsRemoved:        upsteamData.CurrentDS.StepsRemoved,
 	}
 	glog.Infof("%++v", es)
-	e.announceClockClass(gs.ClockQuality.ClockClass, gs.ClockQuality.ClockAccuracy, cfgName)
+	c.announcedClockClass = gs.ClockQuality.ClockClass
+	c.announcedClockAccuracy = gs.ClockQuality.ClockAccuracy
+	c.io.emitClockClass(gs.ClockQuality.ClockClass, cfgName)
 
-	// Re-check we're still LOCKED right before each write: gs/es are a stale snapshot if a slow PMC call let the BC move to HOLDOVER/FREERUN in the meantime.
-	if !e.applyIfLockedBC(cfgName, "before downstream PMC writes", func() {
-		if err := pmc.SetExternalGMPropertiesNP(controlledPortsConfig, es); err != nil {
+	if !c.applyIfLockedBC("before downstream PMC writes", func() {
+		if err := c.io.setExternalGMPropertiesNP(controlledPortsConfig, es); err != nil {
 			glog.Error(err)
 		}
 	}) {
 		return
 	}
 
-	if !e.applyIfLockedBC(cfgName, "before SetGMSettings", func() {
-		if err := pmc.SetGMSettings(controlledPortsConfig, gs); err != nil {
+	if !c.applyIfLockedBC("before SetGMSettings", func() {
+		if err := c.io.setGMSettings(controlledPortsConfig, gs); err != nil {
 			glog.Error(err)
 		}
 	}) {
@@ -481,56 +483,81 @@ func (e *EventHandler) downstreamAnnounceIWF(ctx context.Context, cfgName string
 		return
 	}
 
-	e.applyIfLockedBC(cfgName, "after downstream announce", func() {
-		e.LeadingClockData.downstreamParentDataSet = &upsteamData.ParentDataSet
-		e.LeadingClockData.downstreamTimeProperties = &upsteamData.TimePropertiesDS
+	c.applyIfLockedBC("after downstream announce", func() {
+		c.leadingClockData.downstreamParentDataSet = &upsteamData.ParentDataSet
+		c.leadingClockData.downstreamTimeProperties = &upsteamData.TimePropertiesDS
 	})
 }
 
-func (e *EventHandler) inSyncCondition(cfgName string) bool {
-	if e.LeadingClockData.inSyncConditionThreshold == 0 {
+// hasNonLeadingDPLLFault returns true when the leading DPLL is locked but at
+// least one non-leading DPLL is not locked, indicating a follower fault that
+// should force the composite clock to FREERUN.
+func (c *TBCClock) hasNonLeadingDPLLFault() bool {
+	leadingInterface := c.syncState.leadingIFace
+	if leadingInterface == LEADING_INTERFACE_UNKNOWN {
+		return false
+	}
+	for _, d := range c.data {
+		if d.ProcessName != DPLL {
+			continue
+		}
+		leadingDetail := d.GetDataDetails(leadingInterface)
+		if leadingDetail == nil || leadingDetail.State != PTP_LOCKED {
+			return false
+		}
+		for _, dd := range d.Details {
+			if dd.IFace != leadingInterface && dd.State != PTP_LOCKED {
+				glog.Infof("non-leading DPLL %s is %s while leading %s is locked, composite DPLL forced to FREERUN",
+					dd.IFace, dd.State, leadingInterface)
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func (c *TBCClock) inSyncCondition() bool {
+	if c.leadingClockData.inSyncConditionThreshold == 0 {
 		glog.Info("Leading clock in-sync condition is pending initialization")
 		return false
 	}
 
-	worstOffset := e.getLargestOffset(cfgName)
-	if math.Abs(float64(worstOffset)) < float64(e.LeadingClockData.inSyncConditionThreshold) {
-		e.LeadingClockData.inSyncThresholdCounter++
-		if e.LeadingClockData.inSyncThresholdCounter >= e.LeadingClockData.inSyncConditionTimes {
+	worstOffset := c.getLargestOffset()
+	if math.Abs(float64(worstOffset)) < float64(c.leadingClockData.inSyncConditionThreshold) {
+		c.leadingClockData.inSyncThresholdCounter++
+		if c.leadingClockData.inSyncThresholdCounter >= c.leadingClockData.inSyncConditionTimes {
 			return true
 		}
 	} else {
-		e.LeadingClockData.inSyncThresholdCounter = 0
+		c.leadingClockData.inSyncThresholdCounter = 0
 	}
 
 	glog.Info("sync condition not reached: worst offset ", worstOffset, " count ",
-		e.LeadingClockData.inSyncThresholdCounter, " out of ", e.LeadingClockData.inSyncConditionTimes)
+		c.leadingClockData.inSyncThresholdCounter, " out of ", c.leadingClockData.inSyncConditionTimes)
 
 	return false
 }
 
-func (e *EventHandler) isSourceLostBC(cfgName string) bool {
+func (c *TBCClock) isSourceLostBC() bool {
 	ptpLost := true
 	dpllLost := false
 	dpllLostIface := ""
-	if data, ok := e.data[cfgName]; ok {
-		for _, d := range data {
-			if d.ProcessName == PTP4l {
-				for _, dd := range d.Details {
-					if dd.State == PTP_LOCKED {
-						ptpLost = false
-					}
+	for _, d := range c.data {
+		if d.ProcessName == PTP4l {
+			for _, dd := range d.Details {
+				if dd.State == PTP_LOCKED {
+					ptpLost = false
 				}
 			}
-			if d.ProcessName == DPLL {
-				glog.V(14).Infof("isSourceLostBC[%s]", cfgName)
-				for _, dd := range d.Details {
-					glog.V(14).Infof("  DPLL detail: iface=%s state=%s signalSource=%s sourceLost=%t offset=%d time=%d metrics=%+v", dd.IFace, dd.State, dd.signalSource, dd.sourceLost, dd.Offset, dd.time, dd.Metrics)
-					if dd.State != PTP_LOCKED {
-						dpllLost = true
-						dpllLostIface = dd.IFace
-						break
-					}
+		}
+		if d.ProcessName == DPLL {
+			glog.V(14).Infof("isSourceLostBC[%s]", c.cfgName)
+			for _, dd := range d.Details {
+				glog.V(14).Infof("  DPLL detail: iface=%s state=%s signalSource=%s sourceLost=%t offset=%d time=%d metrics=%+v", dd.IFace, dd.State, dd.signalSource, dd.sourceLost, dd.Offset, dd.time, dd.Metrics)
+				if dd.State != PTP_LOCKED {
+					dpllLost = true
+					dpllLostIface = dd.IFace
+					break
 				}
 			}
 		}
@@ -545,32 +572,30 @@ func (e *EventHandler) isSourceLostBC(cfgName string) bool {
 	return ptpLost || dpllLost
 }
 
-func (e *EventHandler) getLargestOffset(cfgName string) int64 {
+func (c *TBCClock) getLargestOffset() int64 {
 	worstOffset := FaultyPhaseOffset
 	staleTime := time.Now().UnixMilli() - StaleEventAfter
-	if data, ok := e.data[cfgName]; ok {
-		for _, d := range data {
-			if d.window.IsEmpty() {
+	for _, d := range c.data {
+		if d.window.IsEmpty() {
+			continue
+		}
+		if !d.window.IsFull() {
+			glog.Infof("Largest offset %d (window not full for %s)", FaultyPhaseOffset, d.ProcessName)
+			return FaultyPhaseOffset
+		}
+		for _, dd := range d.Details {
+			if dd.time < staleTime {
 				continue
 			}
-			if !d.window.IsFull() {
-				glog.Infof("Largest offset %d (window not full for %s)", FaultyPhaseOffset, d.ProcessName)
-				return FaultyPhaseOffset
-			}
-			for _, dd := range d.Details {
-				if dd.time < staleTime {
-					continue
-				}
-				if worstOffset == FaultyPhaseOffset {
-					if dd.IFace == e.clkSyncState[cfgName].leadingIFace {
-						worstOffset = int64(d.window.Mean())
-					} else {
-						worstOffset = dd.Offset
-					}
+			if worstOffset == FaultyPhaseOffset {
+				if dd.IFace == c.syncState.leadingIFace {
+					worstOffset = int64(d.window.Mean())
 				} else {
-					if math.Abs(float64(dd.Offset)) > math.Abs(float64(worstOffset)) {
-						worstOffset = dd.Offset
-					}
+					worstOffset = dd.Offset
+				}
+			} else {
+				if math.Abs(float64(dd.Offset)) > math.Abs(float64(worstOffset)) {
+					worstOffset = dd.Offset
 				}
 			}
 		}
@@ -579,66 +604,57 @@ func (e *EventHandler) getLargestOffset(cfgName string) int64 {
 	return worstOffset
 }
 
-func (e *EventHandler) getCalculatedHoldoverOffset(cfgName string) int64 {
-	if data, ok := e.data[cfgName]; ok {
-		for _, d := range data {
-			if d.ProcessName == DPLL {
-				return int64(d.window.LastInserted())
-			}
+func (c *TBCClock) getCalculatedHoldoverOffset() int64 {
+	for _, d := range c.data {
+		if d.ProcessName == DPLL {
+			return int64(d.window.LastInserted())
 		}
 	}
 	return FaultyPhaseOffset // No DPLL entries yet return faulty
 }
 
-func (e *EventHandler) freeRunCondition(cfgName string) bool {
-	if e.LeadingClockData.toFreeRunThreshold == 0 {
+func (c *TBCClock) freeRunCondition() bool {
+	if c.leadingClockData.toFreeRunThreshold == 0 {
 		glog.Info("Leading clock free-run condition is pending initialization")
 		return true
 	}
-	if data, ok := e.data[cfgName]; ok {
-		for _, d := range data {
-			switch d.ProcessName {
-			case DPLL:
-				for _, dd := range d.Details {
-					if dd.IFace == e.clkSyncState[cfgName].leadingIFace {
-						if math.Abs(float64(dd.Offset)) > float64(e.LeadingClockData.toFreeRunThreshold) {
-							glog.Infof("free-run condition on DPLL %s", dd.IFace)
-							return true
-						}
+	for _, d := range c.data {
+		switch d.ProcessName {
+		case DPLL:
+			for _, dd := range d.Details {
+				if dd.IFace == c.syncState.leadingIFace {
+					if math.Abs(float64(dd.Offset)) > float64(c.leadingClockData.toFreeRunThreshold) {
+						glog.Infof("free-run condition on DPLL %s", dd.IFace)
+						return true
 					}
 				}
-			case PTP4l:
-				if d.window.IsEmpty() {
-					continue
-				}
-				// Use the window mean rather than per-detail offsets: the active TR port
-				// (which feeds the window via sendPtp4lOffsetEvent) may have a different
-				// interface name than the DPLL leading interface on the same NIC.
-				ptp4lAvgOffset := int64(d.window.Mean())
-				if math.Abs(float64(ptp4lAvgOffset)) > float64(e.LeadingClockData.toFreeRunThreshold) {
-					glog.Infof("free-run condition on PTP4l, avg offset %d", ptp4lAvgOffset)
-					return true
-				}
+			}
+		case PTP4l:
+			if d.window.IsEmpty() {
+				continue
+			}
+			ptp4lAvgOffset := int64(d.window.Mean())
+			if math.Abs(float64(ptp4lAvgOffset)) > float64(c.leadingClockData.toFreeRunThreshold) {
+				glog.Infof("free-run condition on PTP4l, avg offset %d", ptp4lAvgOffset)
+				return true
 			}
 		}
 	}
 	return false
 }
 
-func (e *EventHandler) inSpecCondition(cfgName string) bool {
-	if e.LeadingClockData.MaxInSpecOffset == 0 {
+func (c *TBCClock) inSpecCondition() bool {
+	if c.leadingClockData.MaxInSpecOffset == 0 {
 		glog.Info("Leading clock in-spec condition is pending initialization")
 		return false
 	}
-	if data, ok := e.data[cfgName]; ok {
-		for _, d := range data {
-			if d.ProcessName == DPLL {
-				for _, dd := range d.Details {
-					if dd.IFace == e.clkSyncState[cfgName].leadingIFace {
-						if math.Abs(float64(dd.Offset)) > float64(e.LeadingClockData.MaxInSpecOffset) {
-							glog.Infof("out-of-spec condition on DPLL ", dd.IFace)
-							return false
-						}
+	for _, d := range c.data {
+		if d.ProcessName == DPLL {
+			for _, dd := range d.Details {
+				if dd.IFace == c.syncState.leadingIFace {
+					if math.Abs(float64(dd.Offset)) > float64(c.leadingClockData.MaxInSpecOffset) {
+						glog.Infof("out-of-spec condition on DPLL ", dd.IFace)
+						return false
 					}
 				}
 			}
@@ -647,9 +663,9 @@ func (e *EventHandler) inSpecCondition(cfgName string) bool {
 	return true
 }
 
-func (e *EventHandler) getLeadingInterfaceBC() string {
-	if e.LeadingClockData.leadingInterface != "" {
-		return e.LeadingClockData.leadingInterface
+func (c *TBCClock) getLeadingInterfaceBC() string {
+	if c.leadingClockData.leadingInterface != "" {
+		return c.leadingClockData.leadingInterface
 	}
 	return LEADING_INTERFACE_UNKNOWN
 }
@@ -671,8 +687,6 @@ func (e *EventHandler) convergeConfig(event Event) Event {
 					glog.V(14).Infof("convergeConfig: checking DPLL iface=%s phcGroup=%q alias=%q vs ptp4l alias=%q aliasMatch=%v samePhc=%v",
 						dp.IFace, dpPhc, alias.GetAlias(dp.IFace), alias.GetAlias(iface), aliasMatch, samePhc)
 					if aliasMatch || samePhc {
-						// We want to process ptp4l having a separate config with ts2phc and dpll events having ts2phc config
-						// so in the rare occurrence of ptp4l state change we modify the event.CfgName
 						glog.V(14).Infof("convergeConfig: remapping ptp4l event cfgName %s -> %s (iface %s matched DPLL iface %s)",
 							event.CfgName, cfg, iface, dp.IFace)
 						event.CfgName = cfg
@@ -681,11 +695,81 @@ func (e *EventHandler) convergeConfig(event Event) Event {
 			}
 		}
 	}
-	e.updateLeadingClockData(event)
 	return event
 }
 
-func (e *EventHandler) updateLeadingClockData(event Event) {
+func emitOverallSyncStateIfChanged(io clockIO, overallSyncState *PTPState, clockState, osClockState PTPState, profile string) {
+	next := worstOfState(clockState, osClockState)
+	if next != *overallSyncState {
+		*overallSyncState = next
+		io.sendIPC(ipc.Message{
+			Type:    ipc.TypeSyncState,
+			Profile: profile,
+			Values:  ipc.SyncStateValue{State: ptpStateToIPCState(next)},
+		})
+	}
+}
+
+func worstOfState(a, b PTPState) PTPState {
+	if a == PTP_NOTSET || b == PTP_NOTSET {
+		return PTP_NOTSET
+	}
+	if a == PTP_FREERUN || b == PTP_FREERUN {
+		return PTP_FREERUN
+	}
+	if a == PTP_HOLDOVER || b == PTP_HOLDOVER {
+		return PTP_HOLDOVER
+	}
+	return PTP_LOCKED
+}
+
+func (c *TBCClock) SystemClockUpdate(osClockState PTPState) {
+	c.osClockState = osClockState
+	profile := strings.Replace(c.cfgName, "ts2phc", "ptp4l", 1)
+	emitOverallSyncStateIfChanged(c.io, &c.overallSyncState, c.syncState.state, c.osClockState, profile)
+}
+
+func ptpStateToIPCState(s PTPState) string {
+	switch s {
+	case PTP_LOCKED:
+		return ipc.StateLocked
+	case PTP_HOLDOVER:
+		return ipc.StateHoldover
+	default:
+		return ipc.StateFreerun
+	}
+}
+
+func (c *TBCClock) processSyncE(event Event) {
+	ptp, ok := event.Data.(*PTPData)
+	if !ok || ptp == nil {
+		return
+	}
+	profile := strings.Replace(c.cfgName, "ts2phc", "ptp4l", 1)
+
+	eecState, hasEEC := ptp.Values[EEC_STATE].(string)
+	if hasEEC {
+		c.io.sendIPC(ipc.Message{
+			Type:    ipc.TypeSyncEState,
+			Profile: profile,
+			IFace:   event.IFace,
+			Values:  ipc.SyncEStateValue{State: eecState},
+		})
+	}
+
+	ql, hasQL := ptp.Values[QL].(byte)
+	extQL, hasExtQL := ptp.Values[EXT_QL].(byte)
+	if hasQL || hasExtQL {
+		c.io.sendIPC(ipc.Message{
+			Type:    ipc.TypeSyncEClockQuality,
+			Profile: profile,
+			IFace:   event.IFace,
+			Values:  ipc.SyncEClockQualityValue{QL: int(ql), ExtendedQL: int(extQL)},
+		})
+	}
+}
+
+func (c *TBCClock) updateLeadingClockData(event Event) {
 	ptp, ok := event.Data.(*PTPData)
 	if !ok {
 		return
@@ -694,32 +778,32 @@ func (e *EventHandler) updateLeadingClockData(event Event) {
 	case PTP4lProcessName:
 		cpc, found := ptp.Values[ControlledPortsConfig].(string)
 		if found {
-			e.LeadingClockData.controlledPortsConfig = cpc
+			c.leadingClockData.controlledPortsConfig = cpc
 		}
 		id, found := ptp.Values[ClockIDKey].(string)
 		if found {
-			e.LeadingClockData.clockID = id
+			c.leadingClockData.clockID = id
 		}
 	case DPLL:
 		ls, found := ptp.Values[LeadingSource].(bool)
 		if found && ls {
-			e.LeadingClockData.leadingInterface = event.IFace
+			c.leadingClockData.leadingInterface = event.IFace
 		}
 		inSyncTh, found := ptp.Values[InSyncConditionThreshold].(uint64)
 		if found {
-			e.LeadingClockData.inSyncConditionThreshold = int(inSyncTh)
+			c.leadingClockData.inSyncConditionThreshold = int(inSyncTh)
 		}
 		inSyncTimes, found := ptp.Values[InSyncConditionTimes].(uint64)
 		if found {
-			e.LeadingClockData.inSyncConditionTimes = int(inSyncTimes)
+			c.leadingClockData.inSyncConditionTimes = int(inSyncTimes)
 		}
 		toFreeRunTh, found := ptp.Values[ToFreeRunThreshold].(uint64)
 		if found {
-			e.LeadingClockData.toFreeRunThreshold = int(toFreeRunTh)
+			c.leadingClockData.toFreeRunThreshold = int(toFreeRunTh)
 		}
 		maxInSpec, found := ptp.Values[MaxInSpecOffset].(uint64)
 		if found {
-			e.LeadingClockData.MaxInSpecOffset = maxInSpec
+			c.leadingClockData.MaxInSpecOffset = maxInSpec
 		}
 	}
 }

--- a/pkg/event/event_tbc_pmc_test.go
+++ b/pkg/event/event_tbc_pmc_test.go
@@ -29,12 +29,19 @@ func ensureLeapMocked(t *testing.T) {
 	})
 }
 
-func newPMCTestEventHandler() *EventHandler {
-	return &EventHandler{
-		data:             map[string][]*Data{},
-		clkSyncState:     map[string]*clockSyncState{},
-		downstreamCancel: map[string]context.CancelFunc{},
-		LeadingClockData: newLeadingClockParams(),
+func newPMCTestTBCClock() *TBCClock {
+	handler := &EventHandler{
+		data:   map[string][]*Data{},
+		clocks: map[string]Clock{},
+	}
+	return &TBCClock{
+		io:               handler,
+		leadingClockData: newLeadingClockParams(),
+		syncState: clockSyncState{
+			state:         PTP_FREERUN,
+			clockClass:    protocol.ClockClassUninitialized,
+			clockAccuracy: fbprotocol.ClockAccuracyUnknown,
+		},
 	}
 }
 
@@ -51,34 +58,22 @@ func filterSetCalls(calls []pmc.SetCall, method string) []pmc.SetCall {
 // --- applyIfLockedBC ---
 
 func TestApplyIfLockedBC_LockedRunsFn(t *testing.T) {
-	e := newPMCTestEventHandler()
-	cfgName := testCfgName
-	e.clkSyncState[cfgName] = &clockSyncState{state: PTP_LOCKED}
+	bc := newPMCTestTBCClock()
+	bc.syncState = clockSyncState{state: PTP_LOCKED}
 
 	called := false
-	ok := e.applyIfLockedBC(cfgName, "test", func() { called = true })
+	ok := bc.applyIfLockedBC("test", func() { called = true })
 
 	assert.True(t, ok)
 	assert.True(t, called)
 }
 
 func TestApplyIfLockedBC_NotLockedSkipsFn(t *testing.T) {
-	e := newPMCTestEventHandler()
-	cfgName := testCfgName
-	e.clkSyncState[cfgName] = &clockSyncState{state: PTP_FREERUN}
+	bc := newPMCTestTBCClock()
+	bc.syncState = clockSyncState{state: PTP_FREERUN}
 
 	called := false
-	ok := e.applyIfLockedBC(cfgName, "test", func() { called = true })
-
-	assert.False(t, ok)
-	assert.False(t, called)
-}
-
-func TestApplyIfLockedBC_MissingConfigSkipsFn(t *testing.T) {
-	e := newPMCTestEventHandler()
-
-	called := false
-	ok := e.applyIfLockedBC("nonexistent", "test", func() { called = true })
+	ok := bc.applyIfLockedBC("test", func() { called = true })
 
 	assert.False(t, ok)
 	assert.False(t, called)
@@ -91,16 +86,16 @@ func TestAnnounceLocalData_Freerun_SetsGMSettingsAndEGP(t *testing.T) {
 	mock := &pmc.MockClient{}
 	pmc.SetMock(mock)
 	defer pmc.ResetMock()
-	e := newPMCTestEventHandler()
+	bc := newPMCTestTBCClock()
 	cfgName := testCfgName
-	e.LeadingClockData.clockID = "001122.fffe.334455"
-	e.LeadingClockData.controlledPortsConfig = testControlledCfg
-	e.clkSyncState[cfgName] = &clockSyncState{
+	bc.leadingClockData.clockID = "001122.fffe.334455"
+	bc.leadingClockData.controlledPortsConfig = testControlledCfg
+	bc.syncState = clockSyncState{
 		state:      PTP_FREERUN,
 		clockClass: protocol.ClockClassFreerun,
 	}
 
-	e.announceLocalData(cfgName)
+	bc.announceLocalData(cfgName)
 
 	// 3 async goroutines: 1 EGP + 2 GM settings
 	if !assert.Eventually(t, func() bool {
@@ -143,21 +138,21 @@ func TestAnnounceLocalData_Holdover135_SetsTimeProperties(t *testing.T) {
 	mock := &pmc.MockClient{}
 	pmc.SetMock(mock)
 	defer pmc.ResetMock()
-	e := newPMCTestEventHandler()
+	bc := newPMCTestTBCClock()
 	cfgName := testCfgName
-	e.LeadingClockData.clockID = "aabbcc.fffe.ddeeff"
-	e.LeadingClockData.controlledPortsConfig = testControlledCfg
-	e.LeadingClockData.downstreamTimeProperties = &protocol.TimePropertiesDS{
+	bc.leadingClockData.clockID = "aabbcc.fffe.ddeeff"
+	bc.leadingClockData.controlledPortsConfig = testControlledCfg
+	bc.leadingClockData.downstreamTimeProperties = &protocol.TimePropertiesDS{
 		CurrentUtcOffset:      37,
 		CurrentUtcOffsetValid: true,
 		Leap61:                true,
 	}
-	e.clkSyncState[cfgName] = &clockSyncState{
+	bc.syncState = clockSyncState{
 		state:      PTP_HOLDOVER,
 		clockClass: fbprotocol.ClockClass(135),
 	}
 
-	e.announceLocalData(cfgName)
+	bc.announceLocalData(cfgName)
 
 	if !assert.Eventually(t, func() bool {
 		return len(filterSetCalls(mock.SnapshotSetCalls(), "SetGMSettings")) >= 2
@@ -188,19 +183,19 @@ func TestAnnounceLocalData_Holdover165_NotTimeTraceable(t *testing.T) {
 	mock := &pmc.MockClient{}
 	pmc.SetMock(mock)
 	defer pmc.ResetMock()
-	e := newPMCTestEventHandler()
+	bc := newPMCTestTBCClock()
 	cfgName := testCfgName
-	e.LeadingClockData.clockID = "aabbcc.fffe.ddeeff"
-	e.LeadingClockData.controlledPortsConfig = testControlledCfg
-	e.LeadingClockData.downstreamTimeProperties = &protocol.TimePropertiesDS{
+	bc.leadingClockData.clockID = "aabbcc.fffe.ddeeff"
+	bc.leadingClockData.controlledPortsConfig = testControlledCfg
+	bc.leadingClockData.downstreamTimeProperties = &protocol.TimePropertiesDS{
 		CurrentUtcOffset: 37,
 	}
-	e.clkSyncState[cfgName] = &clockSyncState{
+	bc.syncState = clockSyncState{
 		state:      PTP_HOLDOVER,
 		clockClass: fbprotocol.ClockClass(165),
 	}
 
-	e.announceLocalData(cfgName)
+	bc.announceLocalData(cfgName)
 
 	if !assert.Eventually(t, func() bool {
 		return len(filterSetCalls(mock.SnapshotSetCalls(), "SetGMSettings")) >= 2
@@ -227,18 +222,18 @@ func TestAnnounceLocalData_NilDownstreamTimeProperties_SkipsGMSettings(t *testin
 	mock := &pmc.MockClient{}
 	pmc.SetMock(mock)
 	defer pmc.ResetMock()
-	e := newPMCTestEventHandler()
+	bc := newPMCTestTBCClock()
 	cfgName := testCfgName
 
-	e.LeadingClockData.clockID = "aabbcc.fffe.ddeeff"
-	e.LeadingClockData.controlledPortsConfig = testControlledCfg
-	e.LeadingClockData.downstreamTimeProperties = nil
-	e.clkSyncState[cfgName] = &clockSyncState{
+	bc.leadingClockData.clockID = "aabbcc.fffe.ddeeff"
+	bc.leadingClockData.controlledPortsConfig = testControlledCfg
+	bc.leadingClockData.downstreamTimeProperties = nil
+	bc.syncState = clockSyncState{
 		state:      PTP_HOLDOVER,
 		clockClass: fbprotocol.ClockClass(135),
 	}
 
-	e.announceLocalData(cfgName)
+	bc.announceLocalData(cfgName)
 
 	// EGP runs in a goroutine; GM settings should be skipped
 	if !assert.Eventually(t, func() bool {
@@ -252,19 +247,6 @@ func TestAnnounceLocalData_NilDownstreamTimeProperties_SkipsGMSettings(t *testin
 
 	gmCalls := filterSetCalls(mock.SnapshotSetCalls(), "SetGMSettings")
 	assert.Empty(t, gmCalls)
-}
-
-func TestAnnounceLocalData_MissingClkSyncState_Returns(t *testing.T) {
-	mock := &pmc.MockClient{}
-	pmc.SetMock(mock)
-	defer pmc.ResetMock()
-	e := newPMCTestEventHandler()
-
-	e.announceLocalData("nonexistent")
-
-	// Returns synchronously before launching any goroutines
-	assert.Empty(t, mock.SnapshotSetCalls())
-	assert.Empty(t, mock.SnapshotGetCalls())
 }
 
 // --- downstreamAnnounceIWF ---
@@ -293,12 +275,12 @@ func TestDownstreamAnnounceIWF_Locked_FetchesAndSetsDownstream(t *testing.T) {
 	pmc.SetMock(mock)
 	defer pmc.ResetMock()
 
-	e := newPMCTestEventHandler()
-	e.LeadingClockData.controlledPortsConfig = testControlledCfg
-	e.clkSyncState[cfgName] = &clockSyncState{state: PTP_LOCKED}
+	bc := newPMCTestTBCClock()
+	bc.leadingClockData.controlledPortsConfig = testControlledCfg
+	bc.syncState = clockSyncState{state: PTP_LOCKED}
 
 	ctx := context.Background()
-	e.downstreamAnnounceIWF(ctx, cfgName)
+	bc.downstreamAnnounceIWF(ctx, cfgName)
 
 	getCalls := mock.SnapshotGetCalls()
 	if !assert.Len(t, getCalls, 1) {
@@ -330,9 +312,9 @@ func TestDownstreamAnnounceIWF_Locked_FetchesAndSetsDownstream(t *testing.T) {
 	assert.True(t, gs.TimePropertiesDS.PtpTimescale)
 	assert.True(t, gs.TimePropertiesDS.TimeTraceable)
 
-	assert.Equal(t, uint8(6), e.LeadingClockData.upstreamParentDataSet.GrandmasterClockClass)
-	assert.Equal(t, uint8(6), e.LeadingClockData.downstreamParentDataSet.GrandmasterClockClass)
-	assert.Equal(t, uint16(1), e.LeadingClockData.upstreamCurrentDSStepsRemoved)
+	assert.Equal(t, uint8(6), bc.leadingClockData.upstreamParentDataSet.GrandmasterClockClass)
+	assert.Equal(t, uint8(6), bc.leadingClockData.downstreamParentDataSet.GrandmasterClockClass)
+	assert.Equal(t, uint16(1), bc.leadingClockData.upstreamCurrentDSStepsRemoved)
 }
 
 func TestDownstreamAnnounceIWF_FetchError_ReturnsEarly(t *testing.T) {
@@ -341,12 +323,12 @@ func TestDownstreamAnnounceIWF_FetchError_ReturnsEarly(t *testing.T) {
 	}
 	pmc.SetMock(mock)
 	defer pmc.ResetMock()
-	e := newPMCTestEventHandler()
+	bc := newPMCTestTBCClock()
 	cfgName := testCfgName
-	e.clkSyncState[cfgName] = &clockSyncState{state: PTP_LOCKED}
+	bc.syncState = clockSyncState{state: PTP_LOCKED}
 
 	ctx := context.Background()
-	e.downstreamAnnounceIWF(ctx, cfgName)
+	bc.downstreamAnnounceIWF(ctx, cfgName)
 
 	getCalls := mock.SnapshotGetCalls()
 	if !assert.Len(t, getCalls, 1) {
@@ -363,12 +345,12 @@ func TestDownstreamAnnounceIWF_NotLocked_AbortsAfterFetch(t *testing.T) {
 	}
 	pmc.SetMock(mock)
 	defer pmc.ResetMock()
-	e := newPMCTestEventHandler()
+	bc := newPMCTestTBCClock()
 	cfgName := testCfgName
-	e.clkSyncState[cfgName] = &clockSyncState{state: PTP_FREERUN}
+	bc.syncState = clockSyncState{state: PTP_FREERUN}
 
 	ctx := context.Background()
-	e.downstreamAnnounceIWF(ctx, cfgName)
+	bc.downstreamAnnounceIWF(ctx, cfgName)
 
 	getCalls := mock.SnapshotGetCalls()
 	if !assert.Len(t, getCalls, 1) {
@@ -385,14 +367,14 @@ func TestDownstreamAnnounceIWF_CancelledBeforeAnnounce(t *testing.T) {
 	}
 	pmc.SetMock(mock)
 	defer pmc.ResetMock()
-	e := newPMCTestEventHandler()
+	bc := newPMCTestTBCClock()
 	cfgName := testCfgName
-	e.clkSyncState[cfgName] = &clockSyncState{state: PTP_LOCKED}
+	bc.syncState = clockSyncState{state: PTP_LOCKED}
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	e.downstreamAnnounceIWF(ctx, cfgName)
+	bc.downstreamAnnounceIWF(ctx, cfgName)
 
 	getCalls := mock.SnapshotGetCalls()
 	if !assert.Len(t, getCalls, 1) {
@@ -412,12 +394,12 @@ func TestUpdateDownstreamData_Locked_CallsDownstreamAnnounceIWF(t *testing.T) {
 	}
 	pmc.SetMock(mock)
 	defer pmc.ResetMock()
-	e := newPMCTestEventHandler()
+	bc := newPMCTestTBCClock()
 	cfgName := testCfgName
-	e.LeadingClockData.controlledPortsConfig = testControlledCfg
-	e.clkSyncState[cfgName] = &clockSyncState{state: PTP_LOCKED}
+	bc.leadingClockData.controlledPortsConfig = testControlledCfg
+	bc.syncState = clockSyncState{state: PTP_LOCKED}
 
-	e.updateDownstreamData(cfgName)
+	bc.updateDownstreamData(cfgName)
 
 	if !assert.Eventually(t, func() bool {
 		return len(mock.SnapshotGetCalls()) >= 1
@@ -434,31 +416,18 @@ func TestUpdateDownstreamData_Freerun_CallsAnnounceLocalData(t *testing.T) {
 	mock := &pmc.MockClient{}
 	pmc.SetMock(mock)
 	defer pmc.ResetMock()
-	e := newPMCTestEventHandler()
+	bc := newPMCTestTBCClock()
 	cfgName := testCfgName
-	e.LeadingClockData.clockID = "001122.fffe.334455"
-	e.LeadingClockData.controlledPortsConfig = testControlledCfg
-	e.clkSyncState[cfgName] = &clockSyncState{
+	bc.leadingClockData.clockID = "001122.fffe.334455"
+	bc.leadingClockData.controlledPortsConfig = testControlledCfg
+	bc.syncState = clockSyncState{
 		state:      PTP_FREERUN,
 		clockClass: protocol.ClockClassFreerun,
 	}
 
-	e.updateDownstreamData(cfgName)
+	bc.updateDownstreamData(cfgName)
 
 	assert.Eventually(t, func() bool {
 		return len(filterSetCalls(mock.SnapshotSetCalls(), "SetExternalGMPropertiesNP")) >= 1
 	}, 1*time.Second, 10*time.Millisecond)
-}
-
-func TestUpdateDownstreamData_MissingConfig_Returns(t *testing.T) {
-	mock := &pmc.MockClient{}
-	pmc.SetMock(mock)
-	defer pmc.ResetMock()
-	e := newPMCTestEventHandler()
-
-	e.updateDownstreamData("nonexistent")
-
-	// Returns synchronously before launching any goroutines
-	assert.Empty(t, mock.SnapshotSetCalls())
-	assert.Empty(t, mock.SnapshotGetCalls())
 }

--- a/pkg/event/event_test.go
+++ b/pkg/event/event_test.go
@@ -2,20 +2,26 @@ package event_test
 
 import (
 	"bufio"
+	"encoding/json"
 	"log"
 	"net"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/golang/glog"
 	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/event"
+	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/ipc"
 	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/leap"
 	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/pmc"
 	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/protocol"
 	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/testhelpers"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	fbprotocol "github.com/facebook/time/ptp/protocol"
 )
@@ -25,6 +31,15 @@ func TestMain(m *testing.M) {
 	defer teardownTests()
 	os.Exit(m.Run())
 }
+
+const (
+	testBCCfgPTP4l  = "ptp4l.0.config"
+	testBCCfgTS2PHC = "ts2phc.0.config"
+	testClockID     = "001122.fffe.334455"
+	testHelpStr     = "test"
+	testFromLabel   = "from"
+	testIfaceLabel  = "iface"
+)
 
 var (
 	staleSocketTimeout = 100 * time.Millisecond
@@ -304,7 +319,7 @@ func TestEventHandler_ProcessEvents(t *testing.T) {
 	eChannel := make(chan event.Event, 100)
 	closeChn := make(chan bool)
 	go listenToEvents(closeChn, logOut)
-	eventManager := event.Init("node", true, "/tmp/go.sock", eChannel, closeChn, nil, nil, nil)
+	eventManager := event.Init("node", true, "/tmp/go.sock", eChannel, closeChn, nil, nil, nil, nil)
 	go eventManager.ProcessEvents()
 	assert.NoError(t, leap.MockLeapFile())
 	defer func() {
@@ -460,4 +475,1081 @@ func sendEvents(cfgName string, iface string, processName event.EventSource, sta
 		}
 	}
 	return e
+}
+
+func sendBCEvent(cfgName string, processName event.EventSource,
+	state event.PTPState, values map[event.ValueType]interface{},
+	sourceLost bool) event.Event {
+	return event.Event{
+		Source:     processName,
+		IFace:      "ens1f0",
+		CfgName:    cfgName,
+		ClockType:  event.TBC,
+		Time:       time.Now().UnixMilli(),
+		WriteToLog: true,
+		Data: &event.PTPData{
+			State:      state,
+			Values:     values,
+			SourceLost: sourceLost,
+		},
+	}
+}
+
+func drainForPattern(logOut <-chan string, pattern string, timeout time.Duration) bool {
+	deadline := time.After(timeout)
+	for {
+		select {
+		case msg := <-logOut:
+			if strings.Contains(msg, pattern) {
+				return true
+			}
+		case <-deadline:
+			return false
+		}
+	}
+}
+
+func TestTBCClockClassThroughProcessEvents(t *testing.T) {
+	pmcMock := &pmc.MockClient{
+		ParentTimeCurrentDSResult: pmc.ParentTimeCurrentDS{
+			ParentDataSet: protocol.ParentDataSet{
+				GrandmasterClockClass:    6,
+				GrandmasterClockAccuracy: 0x21,
+			},
+			TimePropertiesDS: protocol.TimePropertiesDS{
+				CurrentUtcOffset:      37,
+				CurrentUtcOffsetValid: true,
+				PtpTimescale:          true,
+				TimeTraceable:         true,
+			},
+			CurrentDS: protocol.CurrentDS{StepsRemoved: 1},
+		},
+	}
+	pmc.SetMock(pmcMock)
+	defer pmc.ResetMock()
+
+	dir, err := os.MkdirTemp("", "bc-test")
+	assert.NoError(t, err)
+	defer os.RemoveAll(dir)
+	socketPath := filepath.Join(dir, "t.sock")
+
+	logOut := make(chan string, 100)
+	listener, err := Listen(socketPath)
+	assert.NoError(t, err)
+	defer listener.Close()
+	go func() {
+		for {
+			fd, acceptErr := listener.Accept()
+			if acceptErr != nil {
+				return
+			}
+			go ProcessTestEvents(fd, logOut)
+		}
+	}()
+
+	eChannel := make(chan event.Event, 100)
+	closeChn := make(chan bool)
+	assert.NoError(t, leap.MockLeapFile())
+	defer func() {
+		close(leap.LeapMgr.Close)
+		time.Sleep(100 * time.Millisecond)
+	}()
+
+	eventManager := event.Init("node", true, socketPath, eChannel, closeChn, nil, nil, nil, nil)
+	go eventManager.ProcessEvents()
+	defer func() { closeChn <- true }()
+
+	clk, addErr := eventManager.AddClock(testBCCfgPTP4l, event.TBC)
+	assert.NoError(t, addErr)
+	bc := clk.(*event.TBCClock)
+	bc.UpdateUpstreamParentDataSet(protocol.ParentDataSet{
+		GrandmasterClockClass:    6,
+		GrandmasterClockAccuracy: 0x21,
+	})
+
+	time.Sleep(500 * time.Millisecond)
+
+	const (
+		bcCfgDPLL  = testBCCfgTS2PHC
+		bcCfgPTP4l = testBCCfgPTP4l
+	)
+
+	// First DPLL event carries leading source configuration.
+	// AddEvent's first call creates the detail but does NOT insert into the
+	// window, so we need WindowSize+1 events per source to fill the window.
+	eChannel <- sendBCEvent(bcCfgDPLL, event.DPLL, event.PTP_LOCKED,
+		map[event.ValueType]interface{}{
+			event.LeadingSource:            true,
+			event.InSyncConditionThreshold: uint64(10000),
+			event.InSyncConditionTimes:     uint64(1),
+			event.ToFreeRunThreshold:       uint64(1500),
+			event.MaxInSpecOffset:          uint64(500),
+			event.OFFSET:                   int64(10),
+		}, false)
+	time.Sleep(100 * time.Millisecond)
+
+	// 10 more DPLL events to fill the DPLL window (first event created the detail,
+	// these 10 fill WindowSize=10)
+	for i := 0; i < 10; i++ {
+		eChannel <- sendBCEvent(bcCfgDPLL, event.DPLL, event.PTP_LOCKED,
+			map[event.ValueType]interface{}{event.OFFSET: int64(10)}, false)
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	// First PTP4l event carries downstream port configuration
+	eChannel <- sendBCEvent(bcCfgPTP4l, event.PTP4l, event.PTP_LOCKED,
+		map[event.ValueType]interface{}{
+			event.ControlledPortsConfig: testBCCfgPTP4l,
+			event.ClockIDKey:            testClockID,
+			event.OFFSET:                int64(10),
+		}, false)
+	time.Sleep(100 * time.Millisecond)
+
+	// 10 more PTP4l events to fill the PTP4l window; the last triggers FREERUN→LOCKED
+	for i := 0; i < 10; i++ {
+		eChannel <- sendBCEvent(bcCfgPTP4l, event.PTP4l, event.PTP_LOCKED,
+			map[event.ValueType]interface{}{event.OFFSET: int64(10)}, false)
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	// One more DPLL event in LOCKED state triggers "stay LOCKED" path:
+	// upstream ParentDataSet (class 6) != downstream (class 0) → needsDownstreamUpdate
+	// → downstreamAnnounceIWF → announceClockClass(6)
+	eChannel <- sendBCEvent(bcCfgDPLL, event.DPLL, event.PTP_LOCKED,
+		map[event.ValueType]interface{}{event.OFFSET: int64(10)}, false)
+
+	assert.True(t, drainForPattern(logOut, "CLOCK_CLASS_CHANGE 6", 5*time.Second),
+		"expected CLOCK_CLASS_CHANGE 6 after BC reaches LOCKED")
+
+	// Phase 2: PTP4l source lost triggers LOCKED→HOLDOVER (class 135)
+	// → announceLocalData → announceClockClass(135)
+	eChannel <- sendBCEvent(bcCfgPTP4l, event.PTP4l, event.PTP_FREERUN,
+		map[event.ValueType]interface{}{event.OFFSET: int64(10)}, true)
+
+	assert.True(t, drainForPattern(logOut, "CLOCK_CLASS_CHANGE 135", 5*time.Second),
+		"expected CLOCK_CLASS_CHANGE 135 after BC enters HOLDOVER")
+}
+
+func waitForMetric(gauge *prometheus.GaugeVec, cfgName string, expected float64, timeout time.Duration) bool {
+	deadline := time.After(timeout)
+	for {
+		val := testutil.ToFloat64(gauge.With(prometheus.Labels{
+			"process": "ptp4l", "config": cfgName, "node": "testnode", //nolint:goconst
+		}))
+		if val == expected {
+			return true
+		}
+		select {
+		case <-deadline:
+			return false
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+}
+
+func TestTBCClockClassMetric(t *testing.T) {
+	pmcMock := &pmc.MockClient{
+		ParentTimeCurrentDSResult: pmc.ParentTimeCurrentDS{
+			ParentDataSet: protocol.ParentDataSet{
+				GrandmasterClockClass:    6,
+				GrandmasterClockAccuracy: 0x21,
+			},
+			TimePropertiesDS: protocol.TimePropertiesDS{
+				CurrentUtcOffset:      37,
+				CurrentUtcOffsetValid: true,
+				PtpTimescale:          true,
+				TimeTraceable:         true,
+			},
+			CurrentDS: protocol.CurrentDS{StepsRemoved: 1},
+		},
+	}
+	pmc.SetMock(pmcMock)
+	defer pmc.ResetMock()
+
+	assert.NoError(t, leap.MockLeapFile())
+	defer func() {
+		close(leap.LeapMgr.Close)
+		time.Sleep(100 * time.Millisecond)
+	}()
+
+	clockClassGauge := prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "test_ptp_clock_class",
+			Help: "test clock class metric",
+		},
+		[]string{"process", "config", "node"},
+	)
+	offsetGauge := prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "test_ptp_offset",
+			Help: "test offset metric",
+		},
+		[]string{testFromLabel, "process", "node", testIfaceLabel},
+	)
+	clockStateGauge := prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "test_ptp_clock_state",
+			Help: "test clock state metric",
+		},
+		[]string{"process", "node", testIfaceLabel},
+	)
+
+	eChannel := make(chan event.Event, 100)
+	closeChn := make(chan bool)
+	eventManager := event.Init("testnode", false, "", eChannel, closeChn, offsetGauge, clockStateGauge, clockClassGauge, nil)
+	go eventManager.ProcessEvents()
+	defer func() { closeChn <- true }()
+
+	clk, addErr := eventManager.AddClock(testBCCfgPTP4l, event.TBC)
+	assert.NoError(t, addErr)
+	bc := clk.(*event.TBCClock)
+	bc.UpdateUpstreamParentDataSet(protocol.ParentDataSet{
+		GrandmasterClockClass:    6,
+		GrandmasterClockAccuracy: 0x21,
+	})
+
+	time.Sleep(500 * time.Millisecond)
+
+	const (
+		bcCfgDPLL  = testBCCfgTS2PHC
+		bcCfgPTP4l = testBCCfgPTP4l
+	)
+
+	// Fill DPLL window: first event creates detail, next 10 fill WindowSize=10
+	eChannel <- sendBCEvent(bcCfgDPLL, event.DPLL, event.PTP_LOCKED,
+		map[event.ValueType]interface{}{
+			event.LeadingSource:            true,
+			event.InSyncConditionThreshold: uint64(10000),
+			event.InSyncConditionTimes:     uint64(1),
+			event.ToFreeRunThreshold:       uint64(1500),
+			event.MaxInSpecOffset:          uint64(500),
+			event.OFFSET:                   int64(10),
+		}, false)
+	time.Sleep(100 * time.Millisecond)
+
+	for i := 0; i < 10; i++ {
+		eChannel <- sendBCEvent(bcCfgDPLL, event.DPLL, event.PTP_LOCKED,
+			map[event.ValueType]interface{}{event.OFFSET: int64(10)}, false)
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	// Fill PTP4l window
+	eChannel <- sendBCEvent(bcCfgPTP4l, event.PTP4l, event.PTP_LOCKED,
+		map[event.ValueType]interface{}{
+			event.ControlledPortsConfig: testBCCfgPTP4l,
+			event.ClockIDKey:            testClockID,
+			event.OFFSET:                int64(10),
+		}, false)
+	time.Sleep(100 * time.Millisecond)
+
+	for i := 0; i < 10; i++ {
+		eChannel <- sendBCEvent(bcCfgPTP4l, event.PTP4l, event.PTP_LOCKED,
+			map[event.ValueType]interface{}{event.OFFSET: int64(10)}, false)
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	// Trigger "stay LOCKED" → upstream data mismatch → announceClockClass(6)
+	eChannel <- sendBCEvent(bcCfgDPLL, event.DPLL, event.PTP_LOCKED,
+		map[event.ValueType]interface{}{event.OFFSET: int64(10)}, false)
+
+	assert.True(t, waitForMetric(clockClassGauge, bcCfgPTP4l, 6, 5*time.Second),
+		"expected clock class metric = 6 for %s after LOCKED", bcCfgPTP4l)
+
+	// PTP4l source lost → LOCKED→HOLDOVER (class 135)
+	eChannel <- sendBCEvent(bcCfgPTP4l, event.PTP4l, event.PTP_FREERUN,
+		map[event.ValueType]interface{}{event.OFFSET: int64(10)}, true)
+
+	assert.True(t, waitForMetric(clockClassGauge, bcCfgPTP4l, 135, 5*time.Second),
+		"expected clock class metric = 135 for %s after HOLDOVER", bcCfgPTP4l)
+}
+
+// drainIPCMessages collects all IPC messages available on the channel within the timeout.
+func drainIPCMessages(ch <-chan ipc.Message, timeout time.Duration) []ipc.Message {
+	var msgs []ipc.Message
+	deadline := time.After(timeout)
+	for {
+		select {
+		case msg := <-ch:
+			msgs = append(msgs, msg)
+		case <-deadline:
+			return msgs
+		}
+	}
+}
+
+// waitForIPCMessage waits for an IPC message matching the given type and returns it.
+func waitForIPCMessage(ch <-chan ipc.Message, msgType string, timeout time.Duration) (ipc.Message, bool) {
+	deadline := time.After(timeout)
+	for {
+		select {
+		case msg := <-ch:
+			if msg.Type == msgType {
+				return msg, true
+			}
+		case <-deadline:
+			return ipc.Message{}, false
+		}
+	}
+}
+
+// startIPCSocketListener creates a Unix socket, starts an ipc.Writer draining
+// the cache, and returns a channel of decoded messages read from the socket.
+// The returned cleanup function must be deferred.
+func startIPCSocketListener(t *testing.T, cache *ipc.Cache, closeCh chan bool) (<-chan ipc.Message, func()) {
+	t.Helper()
+	dir, err := os.MkdirTemp("", "ipc-test")
+	require.NoError(t, err)
+	socketPath := filepath.Join(dir, "ipc.sock")
+
+	listener, err := Listen(socketPath)
+	require.NoError(t, err)
+
+	msgCh := make(chan ipc.Message, 100)
+
+	go ipc.NewWriter(socketPath, cache.Out(), closeCh).Run()
+
+	go func() {
+		for {
+			conn, acceptErr := listener.Accept()
+			if acceptErr != nil {
+				return
+			}
+			go func(c net.Conn) {
+				dec := json.NewDecoder(c)
+				for {
+					var msg ipc.Message
+					if decErr := dec.Decode(&msg); decErr != nil {
+						return
+					}
+					msgCh <- msg
+				}
+			}(conn)
+		}
+	}()
+
+	cleanup := func() {
+		listener.Close()
+		os.RemoveAll(dir)
+	}
+
+	return msgCh, cleanup
+}
+
+func TestMultiClockIPCIsolation(t *testing.T) {
+	pmcMock := &pmc.MockClient{
+		ParentTimeCurrentDSResult: pmc.ParentTimeCurrentDS{
+			ParentDataSet: protocol.ParentDataSet{
+				GrandmasterClockClass:    6,
+				GrandmasterClockAccuracy: 0x21,
+			},
+			TimePropertiesDS: protocol.TimePropertiesDS{
+				CurrentUtcOffset:      37,
+				CurrentUtcOffsetValid: true,
+				PtpTimescale:          true,
+				TimeTraceable:         true,
+			},
+			CurrentDS: protocol.CurrentDS{StepsRemoved: 1},
+		},
+		GMSettingsResult: protocol.GrandmasterSettings{
+			TimePropertiesDS: protocol.TimePropertiesDS{
+				TimeTraceable:      true,
+				FrequencyTraceable: true,
+			},
+		},
+	}
+	pmc.SetMock(pmcMock)
+	defer pmc.ResetMock()
+
+	assert.NoError(t, leap.MockLeapFile())
+	defer func() {
+		close(leap.LeapMgr.Close)
+		time.Sleep(100 * time.Millisecond)
+	}()
+
+	clockClassGauge := prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{Name: "test_multi_ipc_clock_class", Help: testHelpStr},
+		[]string{"process", "config", "node"},
+	)
+	offsetGauge := prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{Name: "test_multi_ipc_offset", Help: testHelpStr},
+		[]string{testFromLabel, "process", "node", testIfaceLabel},
+	)
+	clockStateGauge := prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{Name: "test_multi_ipc_clock_state", Help: testHelpStr},
+		[]string{"process", "node", testIfaceLabel},
+	)
+
+	cache := ipc.NewCache(100, true)
+	eChannel := make(chan event.Event, 100)
+	closeChn := make(chan bool)
+	eventManager := event.Init("node", false, "", eChannel, closeChn, offsetGauge, clockStateGauge, clockClassGauge, cache)
+	go eventManager.ProcessEvents()
+	defer func() { close(closeChn) }()
+
+	socketCh, cleanup := startIPCSocketListener(t, cache, closeChn)
+	defer cleanup()
+
+	const (
+		gmCfg    = "ts2phc.0.config"
+		gmIface  = "ens1f0"
+		tbcPTP4l = "ptp4l.1.config"
+		tbcTS2HC = "ts2phc.1.config"
+		tbcIface = "ens2f0"
+	)
+
+	// Register GM clock
+	_, addErr := eventManager.AddClock(gmCfg, event.GM)
+	require.NoError(t, addErr)
+
+	// Register T-BC clock
+	clk, addErr := eventManager.AddClock(tbcPTP4l, event.TBC)
+	require.NoError(t, addErr)
+	bc := clk.(*event.TBCClock)
+	bc.UpdateUpstreamParentDataSet(protocol.ParentDataSet{
+		GrandmasterClockClass:    6,
+		GrandmasterClockAccuracy: 0x21,
+	})
+
+	time.Sleep(200 * time.Millisecond)
+
+	// --- Helpers ---
+
+	assertNoProfile := func(t *testing.T, msgs []ipc.Message, profile, phase string) {
+		t.Helper()
+		for _, msg := range msgs {
+			if msg.Profile == profile {
+				t.Errorf("%s: unexpected IPC message for profile %s: type=%s values=%v",
+					phase, profile, msg.Type, msg.Values)
+			}
+		}
+	}
+
+	sendGM := func(process event.EventSource, state event.PTPState, sourceLost bool) event.Event {
+		return sendEvents(gmCfg, gmIface, process, state,
+			map[event.ValueType]interface{}{event.OFFSET: int64(0), event.GPS_STATUS: 3},
+			false, sourceLost)
+	}
+
+	sendTBC := func(cfgName string, processName event.EventSource,
+		state event.PTPState, values map[event.ValueType]interface{},
+		sourceLost bool) event.Event {
+		return event.Event{
+			Source:     processName,
+			IFace:      tbcIface,
+			CfgName:    cfgName,
+			ClockType:  event.TBC,
+			Time:       time.Now().UnixMilli(),
+			WriteToLog: true,
+			Data: &event.PTPData{
+				State:      state,
+				Values:     values,
+				SourceLost: sourceLost,
+			},
+		}
+	}
+
+	// =====================================================================
+	// Phase 1: GM FREERUN → LOCKED (GNSS/DPLL toggling)
+	// =====================================================================
+
+	eChannel <- sendGM(event.DPLL, event.PTP_LOCKED, false)
+	eChannel <- sendGM(event.GNSS, event.PTP_LOCKED, false)
+	time.Sleep(100 * time.Millisecond)
+
+	eChannel <- sendGM(event.TS2PHCProcessName, event.PTP_FREERUN, false)
+	time.Sleep(100 * time.Millisecond)
+
+	drainIPCMessages(socketCh, 500*time.Millisecond)
+
+	eChannel <- sendGM(event.TS2PHCProcessName, event.PTP_LOCKED, false)
+
+	msgs := drainIPCMessages(socketCh, 2*time.Second)
+
+	var gotGMPTPStateLocked bool
+	for _, msg := range msgs {
+		if msg.Type == ipc.TypePTPState {
+			sv, ok := msg.Values.(ipc.StateValue)
+			if ok && sv.State == ipc.StateLocked {
+				gotGMPTPStateLocked = true
+				assert.Equal(t, gmCfg, msg.Profile, "phase1: ptp_state profile should match GM config")
+			}
+		}
+	}
+	assert.True(t, gotGMPTPStateLocked, "phase1: expected ptp_state LOCKED for GM")
+	assertNoProfile(t, msgs, tbcPTP4l, "phase1")
+
+	// =====================================================================
+	// Phase 2: GM LOCKED → HOLDOVER (DPLL holdover)
+	// =====================================================================
+
+	drainIPCMessages(socketCh, 200*time.Millisecond)
+
+	eChannel <- sendGM(event.DPLL, event.PTP_HOLDOVER, false)
+
+	msgs = drainIPCMessages(socketCh, 2*time.Second)
+
+	var gotGMStateHoldover, gotGMClockClass7 bool
+	for _, msg := range msgs {
+		if msg.Type == ipc.TypePTPState {
+			sv, ok := msg.Values.(ipc.StateValue)
+			if ok && sv.State == ipc.StateHoldover {
+				gotGMStateHoldover = true
+			}
+		}
+		if msg.Type == ipc.TypeClockClass {
+			cv, ok := msg.Values.(ipc.ClockClassValue)
+			if ok && cv.ClockClass == 7 {
+				gotGMClockClass7 = true
+			}
+		}
+	}
+	assert.True(t, gotGMStateHoldover, "phase2: expected ptp_state HOLDOVER for GM")
+	assert.True(t, gotGMClockClass7, "phase2: expected clock_class 7 for GM")
+	assertNoProfile(t, msgs, tbcPTP4l, "phase2")
+
+	// =====================================================================
+	// Phase 3: GM HOLDOVER → FREERUN (DPLL freerun)
+	// =====================================================================
+
+	drainIPCMessages(socketCh, 200*time.Millisecond)
+
+	eChannel <- sendGM(event.DPLL, event.PTP_FREERUN, false)
+
+	msgs = drainIPCMessages(socketCh, 2*time.Second)
+
+	var gotGMStateFreerun, gotGMClockClass248 bool
+	for _, msg := range msgs {
+		if msg.Type == ipc.TypePTPState {
+			sv, ok := msg.Values.(ipc.StateValue)
+			if ok && sv.State == ipc.StateFreerun {
+				gotGMStateFreerun = true
+			}
+		}
+		if msg.Type == ipc.TypeClockClass {
+			cv, ok := msg.Values.(ipc.ClockClassValue)
+			if ok && cv.ClockClass == 248 {
+				gotGMClockClass248 = true
+			}
+		}
+	}
+	assert.True(t, gotGMStateFreerun, "phase3: expected ptp_state FREERUN for GM")
+	assert.True(t, gotGMClockClass248, "phase3: expected clock_class 248 for GM")
+	assertNoProfile(t, msgs, tbcPTP4l, "phase3")
+
+	// =====================================================================
+	// Phase 4: GM dedup check
+	// =====================================================================
+
+	drainIPCMessages(socketCh, 200*time.Millisecond)
+
+	for i := 0; i < 5; i++ {
+		eChannel <- sendGM(event.DPLL, event.PTP_FREERUN, false)
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	dedup := drainIPCMessages(socketCh, 500*time.Millisecond)
+	assert.Empty(t, dedup, "phase4: duplicate GM events should not produce IPC messages")
+
+	// =====================================================================
+	// Phase 5: T-BC FREERUN → LOCKED
+	// =====================================================================
+
+	drainIPCMessages(socketCh, 200*time.Millisecond)
+
+	eChannel <- sendTBC(tbcTS2HC, event.DPLL, event.PTP_LOCKED,
+		map[event.ValueType]interface{}{
+			event.LeadingSource:            true,
+			event.InSyncConditionThreshold: uint64(10000),
+			event.InSyncConditionTimes:     uint64(1),
+			event.ToFreeRunThreshold:       uint64(1500),
+			event.MaxInSpecOffset:          uint64(500),
+			event.OFFSET:                   int64(10),
+		}, false)
+	time.Sleep(100 * time.Millisecond)
+
+	for i := 0; i < 10; i++ {
+		eChannel <- sendTBC(tbcTS2HC, event.DPLL, event.PTP_LOCKED,
+			map[event.ValueType]interface{}{event.OFFSET: int64(10)}, false)
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	eChannel <- sendTBC(tbcPTP4l, event.PTP4l, event.PTP_LOCKED,
+		map[event.ValueType]interface{}{
+			event.ControlledPortsConfig: tbcPTP4l,
+			event.ClockIDKey:            testClockID,
+			event.OFFSET:                int64(10),
+		}, false)
+	time.Sleep(100 * time.Millisecond)
+
+	for i := 0; i < 10; i++ {
+		eChannel <- sendTBC(tbcPTP4l, event.PTP4l, event.PTP_LOCKED,
+			map[event.ValueType]interface{}{event.OFFSET: int64(10)}, false)
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	msgs = drainIPCMessages(socketCh, 2*time.Second)
+
+	var gotTBCStateLocked bool
+	for _, msg := range msgs {
+		if msg.Type == ipc.TypePTPState {
+			sv, ok := msg.Values.(ipc.StateValue)
+			if ok && sv.State == ipc.StateLocked {
+				gotTBCStateLocked = true
+				assert.Equal(t, tbcPTP4l, msg.Profile, "phase5: ptp_state profile should match T-BC config")
+				assert.Equal(t, tbcIface, msg.IFace, "phase5: ptp_state iface should be T-BC interface")
+			}
+		}
+	}
+	assert.True(t, gotTBCStateLocked, "phase5: expected ptp_state LOCKED for T-BC")
+	assertNoProfile(t, msgs, gmCfg, "phase5")
+
+	// =====================================================================
+	// Phase 6: T-BC LOCKED → HOLDOVER (source lost)
+	// =====================================================================
+
+	drainIPCMessages(socketCh, 200*time.Millisecond)
+
+	eChannel <- sendTBC(tbcPTP4l, event.PTP4l, event.PTP_FREERUN,
+		map[event.ValueType]interface{}{event.OFFSET: int64(10)}, true)
+
+	msgs = drainIPCMessages(socketCh, 2*time.Second)
+
+	var gotTBCStateHoldover, gotTBCClockClass135 bool
+	for _, msg := range msgs {
+		if msg.Type == ipc.TypePTPState {
+			sv, ok := msg.Values.(ipc.StateValue)
+			if ok && sv.State == ipc.StateHoldover {
+				gotTBCStateHoldover = true
+			}
+		}
+		if msg.Type == ipc.TypeClockClass {
+			cv, ok := msg.Values.(ipc.ClockClassValue)
+			if ok && cv.ClockClass == 135 {
+				gotTBCClockClass135 = true
+			}
+		}
+	}
+	assert.True(t, gotTBCStateHoldover, "phase6: expected ptp_state HOLDOVER for T-BC")
+	assert.True(t, gotTBCClockClass135, "phase6: expected clock_class 135 for T-BC")
+	assertNoProfile(t, msgs, gmCfg, "phase6")
+
+	// =====================================================================
+	// Phase 7: T-BC HOLDOVER → FREERUN (large offset)
+	// =====================================================================
+
+	drainIPCMessages(socketCh, 200*time.Millisecond)
+
+	eChannel <- sendTBC(tbcTS2HC, event.DPLL, event.PTP_LOCKED,
+		map[event.ValueType]interface{}{event.OFFSET: int64(50000)}, false)
+
+	msgs = drainIPCMessages(socketCh, 2*time.Second)
+
+	var gotTBCStateFreerun, gotTBCClockClass248 bool
+	for _, msg := range msgs {
+		if msg.Type == ipc.TypePTPState {
+			sv, ok := msg.Values.(ipc.StateValue)
+			if ok && sv.State == ipc.StateFreerun {
+				gotTBCStateFreerun = true
+			}
+		}
+		if msg.Type == ipc.TypeClockClass {
+			cv, ok := msg.Values.(ipc.ClockClassValue)
+			if ok && cv.ClockClass == 248 {
+				gotTBCClockClass248 = true
+			}
+		}
+	}
+	assert.True(t, gotTBCStateFreerun, "phase7: expected ptp_state FREERUN for T-BC")
+	assert.True(t, gotTBCClockClass248, "phase7: expected clock_class 248 for T-BC")
+	assertNoProfile(t, msgs, gmCfg, "phase7")
+
+	// =====================================================================
+	// Phase 8: T-BC dedup check
+	// =====================================================================
+
+	drainIPCMessages(socketCh, 200*time.Millisecond)
+
+	for i := 0; i < 5; i++ {
+		eChannel <- sendTBC(tbcTS2HC, event.DPLL, event.PTP_LOCKED,
+			map[event.ValueType]interface{}{event.OFFSET: int64(50000)}, false)
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	dedup = drainIPCMessages(socketCh, 500*time.Millisecond)
+	assert.Empty(t, dedup, "phase8: duplicate T-BC events should not produce IPC messages")
+}
+
+func TestOverallClockStateIntegration(t *testing.T) {
+	pmcMock := &pmc.MockClient{
+		ParentTimeCurrentDSResult: pmc.ParentTimeCurrentDS{
+			ParentDataSet: protocol.ParentDataSet{
+				GrandmasterClockClass:    6,
+				GrandmasterClockAccuracy: 0x21,
+			},
+			TimePropertiesDS: protocol.TimePropertiesDS{
+				CurrentUtcOffset:      37,
+				CurrentUtcOffsetValid: true,
+				PtpTimescale:          true,
+				TimeTraceable:         true,
+			},
+			CurrentDS: protocol.CurrentDS{StepsRemoved: 1},
+		},
+	}
+	pmc.SetMock(pmcMock)
+	defer pmc.ResetMock()
+
+	assert.NoError(t, leap.MockLeapFile())
+	defer func() {
+		close(leap.LeapMgr.Close)
+		time.Sleep(100 * time.Millisecond)
+	}()
+
+	clockClassGauge := prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{Name: "test_overall_clock_class", Help: testHelpStr},
+		[]string{"process", "config", "node"},
+	)
+	offsetGauge := prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{Name: "test_overall_offset", Help: testHelpStr},
+		[]string{testFromLabel, "process", "node", testIfaceLabel},
+	)
+	clockStateGauge := prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{Name: "test_overall_clock_state", Help: testHelpStr},
+		[]string{"process", "node", testIfaceLabel},
+	)
+
+	cache := ipc.NewCache(100, true)
+	eChannel := make(chan event.Event, 100)
+	closeChn := make(chan bool)
+	eventManager := event.Init("node", false, "", eChannel, closeChn, offsetGauge, clockStateGauge, clockClassGauge, cache)
+	go eventManager.ProcessEvents()
+	defer func() { close(closeChn) }()
+
+	socketCh, cleanup := startIPCSocketListener(t, cache, closeChn)
+	defer cleanup()
+
+	// Register two TBCClocks
+	clk1, err := eventManager.AddClock(testBCCfgPTP4l, event.TBC)
+	require.NoError(t, err)
+	bc1 := clk1.(*event.TBCClock)
+	bc1.UpdateUpstreamParentDataSet(protocol.ParentDataSet{
+		GrandmasterClockClass:    6,
+		GrandmasterClockAccuracy: 0x21,
+	})
+
+	clk2, err := eventManager.AddClock("ptp4l.1.config", event.TBC)
+	require.NoError(t, err)
+	bc2 := clk2.(*event.TBCClock)
+	bc2.UpdateUpstreamParentDataSet(protocol.ParentDataSet{
+		GrandmasterClockClass:    6,
+		GrandmasterClockAccuracy: 0x21,
+	})
+
+	time.Sleep(200 * time.Millisecond)
+
+	// --- Phase 1: Lock both TBCClocks' PTP state ---
+
+	lockTBCClock := func(cfgDPLL, cfgPTP4l string) {
+		eChannel <- sendBCEvent(cfgDPLL, event.DPLL, event.PTP_LOCKED,
+			map[event.ValueType]interface{}{
+				event.LeadingSource:            true,
+				event.InSyncConditionThreshold: uint64(10000),
+				event.InSyncConditionTimes:     uint64(1),
+				event.ToFreeRunThreshold:       uint64(1500),
+				event.MaxInSpecOffset:          uint64(500),
+				event.OFFSET:                   int64(10),
+			}, false)
+		time.Sleep(100 * time.Millisecond)
+
+		for i := 0; i < 10; i++ {
+			eChannel <- sendBCEvent(cfgDPLL, event.DPLL, event.PTP_LOCKED,
+				map[event.ValueType]interface{}{event.OFFSET: int64(10)}, false)
+			time.Sleep(50 * time.Millisecond)
+		}
+
+		eChannel <- sendBCEvent(cfgPTP4l, event.PTP4l, event.PTP_LOCKED,
+			map[event.ValueType]interface{}{
+				event.ControlledPortsConfig: cfgPTP4l,
+				event.ClockIDKey:            testClockID,
+				event.OFFSET:                int64(10),
+			}, false)
+		time.Sleep(100 * time.Millisecond)
+
+		for i := 0; i < 10; i++ {
+			eChannel <- sendBCEvent(cfgPTP4l, event.PTP4l, event.PTP_LOCKED,
+				map[event.ValueType]interface{}{event.OFFSET: int64(10)}, false)
+			time.Sleep(50 * time.Millisecond)
+		}
+	}
+
+	lockTBCClock(testBCCfgTS2PHC, testBCCfgPTP4l)
+	lockTBCClock("ts2phc.1.config", "ptp4l.1.config")
+
+	// Drain all messages from PTP locking phase via the CEPv2 socket
+	msgs := drainIPCMessages(socketCh, 2*time.Second)
+
+	// Verify we got ptp_state LOCKED but sync_state should be FREERUN
+	// (os clock is still FREERUN since no PHC2SYS event yet)
+	var gotPTPLocked int
+	var gotSyncStateFreerun int
+	for _, msg := range msgs {
+		if msg.Type == ipc.TypePTPState {
+			if sv, ok := msg.Values.(ipc.StateValue); ok && sv.State == ipc.StateLocked {
+				gotPTPLocked++
+			}
+		}
+		if msg.Type == ipc.TypeSyncState {
+			if sv, ok := msg.Values.(ipc.SyncStateValue); ok && sv.State == ipc.StateFreerun {
+				gotSyncStateFreerun++
+			}
+		}
+	}
+	assert.GreaterOrEqual(t, gotPTPLocked, 2, "expected ptp_state LOCKED for both profiles")
+
+	// --- Phase 2: Send PHC2SYS LOCKED event ---
+
+	drainIPCMessages(socketCh, 200*time.Millisecond)
+
+	eChannel <- event.Event{
+		Source:    event.PHC2SYS,
+		IFace:     "CLOCK_REALTIME",
+		CfgName:   testBCCfgPTP4l,
+		ClockType: event.TBC,
+		Time:      time.Now().UnixMilli(),
+		Data: &event.PTPData{
+			State:  event.PTP_LOCKED,
+			Values: map[event.ValueType]interface{}{event.OFFSET: int64(5)},
+		},
+	}
+
+	msgs = drainIPCMessages(socketCh, 2*time.Second)
+
+	var osClockCount int
+	var syncStateLocked int
+	syncStateProfiles := map[string]bool{}
+	for _, msg := range msgs {
+		if msg.Type == ipc.TypeOSClockState {
+			osClockCount++
+			sv, ok := msg.Values.(ipc.StateValue)
+			require.True(t, ok)
+			assert.Equal(t, ipc.StateLocked, sv.State)
+		}
+		if msg.Type == ipc.TypeSyncState {
+			sv, ok := msg.Values.(ipc.SyncStateValue)
+			if ok && sv.State == ipc.StateLocked {
+				syncStateLocked++
+				syncStateProfiles[msg.Profile] = true
+			}
+		}
+	}
+	assert.Equal(t, 1, osClockCount, "os_clock_state should be emitted exactly once")
+	assert.Equal(t, 2, syncStateLocked, "sync_state LOCKED should be emitted for both profiles")
+	assert.True(t, syncStateProfiles[testBCCfgPTP4l], "sync_state should include profile 0")
+	assert.True(t, syncStateProfiles["ptp4l.1.config"], "sync_state should include profile 1")
+
+	// --- Phase 3: Send PHC2SYS FREERUN → overall drops to FREERUN ---
+
+	drainIPCMessages(socketCh, 200*time.Millisecond)
+
+	eChannel <- event.Event{
+		Source:    event.PHC2SYS,
+		IFace:     "CLOCK_REALTIME",
+		CfgName:   testBCCfgPTP4l,
+		ClockType: event.TBC,
+		Time:      time.Now().UnixMilli(),
+		Data: &event.PTPData{
+			State:  event.PTP_FREERUN,
+			Values: map[event.ValueType]interface{}{event.OFFSET: int64(0)},
+		},
+	}
+
+	msgs = drainIPCMessages(socketCh, 2*time.Second)
+
+	var syncStateFreerunCount int
+	for _, msg := range msgs {
+		if msg.Type == ipc.TypeSyncState {
+			sv, ok := msg.Values.(ipc.SyncStateValue)
+			if ok && sv.State == ipc.StateFreerun {
+				syncStateFreerunCount++
+			}
+		}
+	}
+	assert.Equal(t, 2, syncStateFreerunCount, "sync_state FREERUN should be emitted for both profiles")
+
+	// --- Phase 4: Duplicate PHC2SYS FREERUN → no new messages on socket ---
+
+	drainIPCMessages(socketCh, 200*time.Millisecond)
+
+	eChannel <- event.Event{
+		Source:    event.PHC2SYS,
+		IFace:     "CLOCK_REALTIME",
+		CfgName:   testBCCfgPTP4l,
+		ClockType: event.TBC,
+		Time:      time.Now().UnixMilli(),
+		Data: &event.PTPData{
+			State:  event.PTP_FREERUN,
+			Values: map[event.ValueType]interface{}{event.OFFSET: int64(0)},
+		},
+	}
+
+	dedup := drainIPCMessages(socketCh, 500*time.Millisecond)
+	osClockDedup := 0
+	syncStateDedup := 0
+	for _, msg := range dedup {
+		if msg.Type == ipc.TypeOSClockState {
+			osClockDedup++
+		}
+		if msg.Type == ipc.TypeSyncState {
+			syncStateDedup++
+		}
+	}
+	assert.Equal(t, 0, osClockDedup, "duplicate os_clock_state should not be emitted on socket")
+	assert.Equal(t, 0, syncStateDedup, "duplicate sync_state should not be emitted on socket")
+}
+
+func TestSyncEIPCIntegration(t *testing.T) {
+	pmcMock := &pmc.MockClient{
+		ParentTimeCurrentDSResult: pmc.ParentTimeCurrentDS{
+			ParentDataSet: protocol.ParentDataSet{
+				GrandmasterClockClass:    6,
+				GrandmasterClockAccuracy: 0x21,
+			},
+			TimePropertiesDS: protocol.TimePropertiesDS{
+				CurrentUtcOffset:      37,
+				CurrentUtcOffsetValid: true,
+				PtpTimescale:          true,
+				TimeTraceable:         true,
+			},
+			CurrentDS: protocol.CurrentDS{StepsRemoved: 1},
+		},
+	}
+	pmc.SetMock(pmcMock)
+	defer pmc.ResetMock()
+
+	assert.NoError(t, leap.MockLeapFile())
+	defer func() {
+		close(leap.LeapMgr.Close)
+		time.Sleep(100 * time.Millisecond)
+	}()
+
+	clockClassGauge := prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{Name: "test_synce_clock_class", Help: testHelpStr},
+		[]string{"process", "config", "node"},
+	)
+	offsetGauge := prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{Name: "test_synce_offset", Help: testHelpStr},
+		[]string{testFromLabel, "process", "node", testIfaceLabel},
+	)
+	clockStateGauge := prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{Name: "test_synce_clock_state", Help: testHelpStr},
+		[]string{"process", "node", testIfaceLabel},
+	)
+
+	cache := ipc.NewCache(100, true)
+	eChannel := make(chan event.Event, 100)
+	closeChn := make(chan bool)
+	eventManager := event.Init("node", false, "", eChannel, closeChn, offsetGauge, clockStateGauge, clockClassGauge, cache)
+	go eventManager.ProcessEvents()
+	defer func() { close(closeChn) }()
+
+	socketCh, cleanup := startIPCSocketListener(t, cache, closeChn)
+	defer cleanup()
+
+	_, err := eventManager.AddClock(testBCCfgPTP4l, event.TBC)
+	require.NoError(t, err)
+
+	time.Sleep(200 * time.Millisecond)
+
+	// --- Phase 1: SyncE state event → synce_state arrives on socket ---
+
+	eChannel <- event.Event{
+		Source:     event.SYNCE,
+		IFace:      "ens7f0",
+		CfgName:    "synce4l.0.config",
+		Time:       time.Now().UnixMilli(),
+		WriteToLog: true,
+		Data: &event.PTPData{
+			State: event.PTP_LOCKED,
+			Values: map[event.ValueType]interface{}{
+				event.EEC_STATE:      "EEC_LOCKED",
+				event.DEVICE:         "synce1",
+				event.NETWORK_OPTION: 1,
+			},
+		},
+	}
+
+	msg, ok := waitForIPCMessage(socketCh, ipc.TypeSyncEState, 2*time.Second)
+	assert.True(t, ok, "expected synce_state message on socket")
+	if ok {
+		assert.Equal(t, testBCCfgPTP4l, msg.Profile)
+		assert.Equal(t, "ens7f0", msg.IFace)
+		sv, svOK := msg.Values.(ipc.SyncEStateValue)
+		require.True(t, svOK)
+		assert.Equal(t, "EEC_LOCKED", sv.State)
+	}
+
+	// --- Phase 2: SyncE clock quality event → synce_clock_quality arrives on socket ---
+
+	drainIPCMessages(socketCh, 200*time.Millisecond)
+
+	eChannel <- event.Event{
+		Source:     event.SYNCE,
+		IFace:      "ens7f0",
+		CfgName:    "synce4l.0.config",
+		Time:       time.Now().UnixMilli(),
+		WriteToLog: true,
+		Data: &event.PTPData{
+			State: event.PTP_LOCKED,
+			Values: map[event.ValueType]interface{}{
+				event.QL:             byte(4),
+				event.EXT_QL:         byte(0xFF),
+				event.CLOCK_QUALITY:  "PRS",
+				event.DEVICE:         "synce1",
+				event.NETWORK_OPTION: 1,
+			},
+		},
+	}
+
+	msg, ok = waitForIPCMessage(socketCh, ipc.TypeSyncEClockQuality, 2*time.Second)
+	assert.True(t, ok, "expected synce_clock_quality message on socket")
+	if ok {
+		assert.Equal(t, testBCCfgPTP4l, msg.Profile)
+		qv, qvOK := msg.Values.(ipc.SyncEClockQualityValue)
+		require.True(t, qvOK)
+		assert.Equal(t, 4, qv.QL)
+		assert.Equal(t, 0xFF, qv.ExtendedQL)
+	}
+
+	// --- Phase 3: Verify SyncE does NOT produce ptp_state or sync_state on socket ---
+
+	drainIPCMessages(socketCh, 200*time.Millisecond)
+
+	eChannel <- event.Event{
+		Source:     event.SYNCE,
+		IFace:      "ens7f0",
+		CfgName:    "synce4l.0.config",
+		Time:       time.Now().UnixMilli(),
+		WriteToLog: true,
+		Data: &event.PTPData{
+			State: event.PTP_FREERUN,
+			Values: map[event.ValueType]interface{}{
+				event.EEC_STATE:      "EEC_FREERUN",
+				event.DEVICE:         "synce1",
+				event.NETWORK_OPTION: 1,
+			},
+		},
+	}
+
+	msgs := drainIPCMessages(socketCh, 1*time.Second)
+	var foundSyncEFreerun bool
+	for _, m := range msgs {
+		assert.NotEqual(t, ipc.TypePTPState, m.Type, "SyncE should not produce ptp_state on socket")
+		assert.NotEqual(t, ipc.TypeSyncState, m.Type, "SyncE should not produce sync_state on socket")
+		if m.Type == ipc.TypeSyncEState {
+			sv, svOK := m.Values.(ipc.SyncEStateValue)
+			if svOK && sv.State == "EEC_FREERUN" {
+				foundSyncEFreerun = true
+			}
+		}
+	}
+	assert.True(t, foundSyncEFreerun, "expected synce_state EEC_FREERUN on socket")
 }

--- a/pkg/event/event_test_helpers_test.go
+++ b/pkg/event/event_test_helpers_test.go
@@ -12,17 +12,28 @@ type EventHandlerForTests struct {
 // NewEventHandlerForTests creates an EventHandlerForTests wrapping
 // a minimal EventHandler for socket logic tests.
 func NewEventHandlerForTests(socketPath string) *EventHandlerForTests {
+	handler := newTestEventHandler(socketPath)
 	return &EventHandlerForTests{
-		EventHandler: newTestEventHandler(socketPath),
+		EventHandler: handler,
 	}
 }
 
-// SetClockClass populates the clock sync state for the given config
-// so that EmitClockClass has data to emit.
+// SetClockClass registers a TBC clock with the given announced clock class.
 func (t *EventHandlerForTests) SetClockClass(cfgName string, clockClass uint8) {
 	t.Lock()
 	defer t.Unlock()
-	t.clkSyncState[cfgName] = &clockSyncState{
-		clockClass: fbprotocol.ClockClass(clockClass),
+	if t.clocks == nil {
+		t.clocks = map[string]Clock{}
 	}
+	t.clocks[cfgName] = &TBCClock{
+		cfgName:             cfgName,
+		io:                  t.EventHandler,
+		announcedClockClass: fbprotocol.ClockClass(clockClass),
+		leadingClockData:    newLeadingClockParams(),
+	}
+}
+
+// EmitClockClass delegates to EventHandler.EmitClockClass.
+func (t *EventHandlerForTests) EmitClockClass(cfgName string) {
+	t.EventHandler.EmitClockClass(cfgName)
 }

--- a/pkg/event/stats.go
+++ b/pkg/event/stats.go
@@ -33,15 +33,17 @@ type DataMetric struct {
 
 // DataDetails .. details for data
 type DataDetails struct {
-	IFace        string
-	State        PTPState
-	ClockType    ClockType
-	Metrics      map[ValueType]DataMetric
-	time         int64
-	logData      string
-	signalSource EventSource // GNSS PPS
-	sourceLost   bool
-	Offset       int64
+	IFace              string
+	State              PTPState
+	ClockType          ClockType
+	Metrics            map[ValueType]DataMetric
+	time               int64
+	logData            string
+	signalSource       EventSource // GNSS PPS
+	sourceLost         bool
+	Offset             int64
+	outOfSpec          bool
+	frequencyTraceable bool
 }
 
 // UpdateState .. update process state
@@ -88,6 +90,7 @@ func (d *Data) AddEvent(event Event) {
 	var sourceLost bool
 	var offset int64
 	var hasOffset bool
+	var outOfSpec, frequencyTraceable bool
 
 	switch data := event.Data.(type) {
 	case *GNSSData:
@@ -102,6 +105,8 @@ func (d *Data) AddEvent(event Event) {
 	case *PTPData:
 		state = data.State
 		sourceLost = data.SourceLost
+		outOfSpec = data.OutOfSpec
+		frequencyTraceable = data.FrequencyTraceable
 		if off, fnd := data.Values[OFFSET]; fnd {
 			offset = off.(int64)
 			hasOffset = true
@@ -113,6 +118,8 @@ func (d *Data) AddEvent(event Event) {
 			if dd.time <= event.Time {
 				dd.State = state
 				dd.sourceLost = sourceLost
+				dd.outOfSpec = outOfSpec
+				dd.frequencyTraceable = frequencyTraceable
 				dd.ClockType = event.ClockType
 				dd.time = event.Time
 				dd.logData = event.GetLogData()
@@ -128,13 +135,15 @@ func (d *Data) AddEvent(event Event) {
 	}
 
 	details := &DataDetails{
-		ClockType:  event.ClockType,
-		Metrics:    map[ValueType]DataMetric{},
-		IFace:      event.IFace,
-		time:       event.Time,
-		logData:    event.GetLogData(),
-		State:      state,
-		sourceLost: sourceLost,
+		ClockType:          event.ClockType,
+		Metrics:            map[ValueType]DataMetric{},
+		IFace:              event.IFace,
+		time:               event.Time,
+		logData:            event.GetLogData(),
+		State:              state,
+		sourceLost:         sourceLost,
+		outOfSpec:          outOfSpec,
+		frequencyTraceable: frequencyTraceable,
 	}
 	if ptp, ok := event.Data.(*PTPData); ok {
 		leading, found := ptp.Values[LeadingSource]

--- a/pkg/ipc/cache.go
+++ b/pkg/ipc/cache.go
@@ -1,0 +1,117 @@
+package ipc
+
+import (
+	"sync"
+	"time"
+)
+
+type cacheKey struct {
+	msgType string
+	profile string
+}
+
+// Cache tracks the latest IPC message per (type, profile) and provides
+// a channel for outbound messages. It deduplicates by suppressing
+// messages whose values match the last-emitted state for the same key.
+// When enabled is false, Send is a no-op.
+type Cache struct {
+	enabled bool
+	mu      sync.Mutex
+	store   map[cacheKey]Message
+	outCh   chan Message
+}
+
+// NewCache creates a cache with a buffered outbound channel of the given size.
+// When enabled is false the cache discards all messages.
+func NewCache(bufSize int, enabled bool) *Cache {
+	c := &Cache{
+		enabled: enabled,
+		store:   make(map[cacheKey]Message),
+	}
+	if enabled {
+		c.outCh = make(chan Message, bufSize)
+	}
+	return c
+}
+
+// Send stores a message in the cache and writes it to the outbound channel.
+// Returns false if the message is a duplicate (same Values and IFace as the
+// last message for this type/profile key). The write to the outbound channel
+// is non-blocking: if the channel is full, the message is stored but not queued.
+func (c *Cache) Send(msg Message) bool {
+	if !c.enabled {
+		return false
+	}
+	if msg.Version == 0 {
+		msg.Version = Version
+	}
+	if msg.Timestamp == "" {
+		msg.Timestamp = time.Now().UTC().Format(time.RFC3339Nano)
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	key := cacheKey{msgType: msg.Type, profile: msg.Profile}
+	if prev, ok := c.store[key]; ok && valuesEqual(prev, msg) {
+		return false
+	}
+	c.store[key] = msg
+
+	select {
+	case c.outCh <- msg:
+	default:
+	}
+	return true
+}
+
+// Snapshot returns a copy of all cached messages.
+func (c *Cache) Snapshot() []Message {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	msgs := make([]Message, 0, len(c.store))
+	for _, msg := range c.store {
+		msgs = append(msgs, msg)
+	}
+	return msgs
+}
+
+// Clear removes all cached messages.
+func (c *Cache) Clear() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.store = make(map[cacheKey]Message)
+}
+
+// Out returns the read-only outbound message channel.
+func (c *Cache) Out() <-chan Message {
+	return c.outCh
+}
+
+func valuesEqual(a, b Message) bool {
+	if a.IFace != b.IFace {
+		return false
+	}
+	switch av := a.Values.(type) {
+	case StateValue:
+		bv, ok := b.Values.(StateValue)
+		return ok && av == bv
+	case GNSSStateValue:
+		bv, ok := b.Values.(GNSSStateValue)
+		return ok && av == bv
+	case SyncStateValue:
+		bv, ok := b.Values.(SyncStateValue)
+		return ok && av == bv
+	case SyncEStateValue:
+		bv, ok := b.Values.(SyncEStateValue)
+		return ok && av == bv
+	case ClockClassValue:
+		bv, ok := b.Values.(ClockClassValue)
+		return ok && av == bv
+	case SyncEClockQualityValue:
+		bv, ok := b.Values.(SyncEClockQualityValue)
+		return ok && av == bv
+	default:
+		return false
+	}
+}

--- a/pkg/ipc/cache_test.go
+++ b/pkg/ipc/cache_test.go
@@ -1,0 +1,200 @@
+package ipc
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	testProfile = "ptp4l.0.config"
+	testIFace   = "ens2f0"
+)
+
+func TestCacheSendAndDedup(t *testing.T) {
+	c := NewCache(10, true)
+
+	msg := Message{
+		Type:    TypePTPState,
+		Profile: testProfile,
+		IFace:   testIFace,
+		Values:  StateValue{State: StateLocked},
+	}
+
+	assert.True(t, c.Send(msg), "first send should store")
+	assert.False(t, c.Send(msg), "duplicate should be suppressed")
+
+	updated := msg
+	updated.Values = StateValue{State: StateFreerun}
+	assert.True(t, c.Send(updated), "changed values should store")
+	assert.False(t, c.Send(updated), "same changed values should be suppressed")
+}
+
+func TestCacheSendDifferentKeys(t *testing.T) {
+	c := NewCache(10, true)
+
+	ptpMsg := Message{
+		Type:    TypePTPState,
+		Profile: testProfile,
+		Values:  StateValue{State: StateLocked},
+	}
+	clockMsg := Message{
+		Type:    TypeClockClass,
+		Profile: testProfile,
+		Values:  ClockClassValue{ClockClass: 6},
+	}
+
+	assert.True(t, c.Send(ptpMsg))
+	assert.True(t, c.Send(clockMsg))
+
+	snap := c.Snapshot()
+	assert.Len(t, snap, 2)
+}
+
+func TestCacheSendDifferentProfiles(t *testing.T) {
+	c := NewCache(10, true)
+
+	msg0 := Message{
+		Type:    TypePTPState,
+		Profile: testProfile,
+		Values:  StateValue{State: StateLocked},
+	}
+	msg1 := Message{
+		Type:    TypePTPState,
+		Profile: "ptp4l.1.config",
+		Values:  StateValue{State: StateFreerun},
+	}
+
+	assert.True(t, c.Send(msg0))
+	assert.True(t, c.Send(msg1))
+
+	snap := c.Snapshot()
+	assert.Len(t, snap, 2)
+}
+
+func TestCacheOutChannel(t *testing.T) {
+	c := NewCache(10, true)
+
+	msg := Message{
+		Type:    TypePTPState,
+		Profile: testProfile,
+		Values:  StateValue{State: StateLocked},
+	}
+	c.Send(msg)
+
+	select {
+	case got := <-c.Out():
+		assert.Equal(t, TypePTPState, got.Type)
+		assert.Equal(t, StateValue{State: StateLocked}, got.Values)
+	case <-time.After(time.Second):
+		t.Fatal("expected message on outbound channel")
+	}
+
+	// Duplicate should not produce a channel message
+	c.Send(msg)
+	select {
+	case <-c.Out():
+		t.Fatal("duplicate should not produce outbound message")
+	case <-time.After(50 * time.Millisecond):
+	}
+}
+
+func TestCacheOutChannelNonBlocking(t *testing.T) {
+	c := NewCache(1, true) // buffer size 1
+
+	msg1 := Message{Type: TypePTPState, Profile: testProfile, Values: StateValue{State: StateLocked}}
+	msg2 := Message{Type: TypeClockClass, Profile: testProfile, Values: ClockClassValue{ClockClass: 6}}
+
+	c.Send(msg1) // fills the channel buffer
+	c.Send(msg2) // should not block even though channel is full
+
+	snap := c.Snapshot()
+	assert.Len(t, snap, 2, "both messages should be in the cache store even if channel is full")
+}
+
+func TestCacheSnapshot(t *testing.T) {
+	c := NewCache(10, true)
+
+	c.Send(Message{Type: TypePTPState, Profile: testProfile, Values: StateValue{State: StateLocked}})
+	c.Send(Message{Type: TypeClockClass, Profile: testProfile, Values: ClockClassValue{ClockClass: 7}})
+
+	snap := c.Snapshot()
+	require.Len(t, snap, 2)
+
+	types := map[string]bool{}
+	for _, m := range snap {
+		types[m.Type] = true
+	}
+	assert.True(t, types[TypePTPState])
+	assert.True(t, types[TypeClockClass])
+}
+
+func TestCacheClear(t *testing.T) {
+	c := NewCache(10, true)
+
+	c.Send(Message{Type: TypePTPState, Profile: testProfile, Values: StateValue{State: StateLocked}})
+	assert.Len(t, c.Snapshot(), 1)
+
+	c.Clear()
+	assert.Len(t, c.Snapshot(), 0)
+
+	// After clear, same message should be accepted again (no longer a duplicate)
+	assert.True(t, c.Send(Message{Type: TypePTPState, Profile: testProfile, Values: StateValue{State: StateLocked}}))
+}
+
+func TestCacheAutoFillsVersionAndTimestamp(t *testing.T) {
+	c := NewCache(10, true)
+
+	msg := Message{
+		Type:    TypePTPState,
+		Profile: testProfile,
+		Values:  StateValue{State: StateLocked},
+	}
+	c.Send(msg)
+
+	got := <-c.Out()
+	assert.Equal(t, Version, got.Version)
+	assert.NotEmpty(t, got.Timestamp)
+
+	_, err := time.Parse(time.RFC3339Nano, got.Timestamp)
+	assert.NoError(t, err, "timestamp should be valid RFC3339Nano")
+}
+
+func TestCachePreservesExplicitVersionAndTimestamp(t *testing.T) {
+	c := NewCache(10, true)
+
+	msg := Message{
+		Version:   42,
+		Timestamp: "2024-01-15T10:30:00.123456789Z",
+		Type:      TypePTPState,
+		Profile:   testProfile,
+		Values:    StateValue{State: StateLocked},
+	}
+	c.Send(msg)
+
+	got := <-c.Out()
+	assert.Equal(t, 42, got.Version)
+	assert.Equal(t, "2024-01-15T10:30:00.123456789Z", got.Timestamp)
+}
+
+func TestCacheIFaceChangeIsNotDuplicate(t *testing.T) {
+	c := NewCache(10, true)
+
+	msg1 := Message{
+		Type:    TypePTPState,
+		Profile: testProfile,
+		IFace:   testIFace,
+		Values:  StateValue{State: StateLocked},
+	}
+	msg2 := Message{
+		Type:    TypePTPState,
+		Profile: testProfile,
+		IFace:   "ens3f0",
+		Values:  StateValue{State: StateLocked},
+	}
+
+	assert.True(t, c.Send(msg1))
+	assert.True(t, c.Send(msg2), "different IFace should not be treated as duplicate")
+}

--- a/pkg/ipc/ipc.go
+++ b/pkg/ipc/ipc.go
@@ -124,7 +124,8 @@ func (m *Message) UnmarshalJSON(data []byte) error {
 
 // StateValue carries a PTP or OS clock synchronization state.
 type StateValue struct {
-	State string `json:"state"`
+	State  string `json:"state"`
+	Offset int64  `json:"offset,omitempty"`
 }
 
 // Value implements Value.

--- a/pkg/ipc/ipc_test.go
+++ b/pkg/ipc/ipc_test.go
@@ -19,7 +19,7 @@ func TestMessageJSON(t *testing.T) {
 			msg: Message{
 				Version: Version, Type: TypePTPState,
 				Timestamp: "2024-01-15T10:30:00.123456789Z",
-				Profile:   "ptp4l.0.config", IFace: "ens2f0",
+				Profile:   testProfile, IFace: testIFace,
 				Values: StateValue{State: StateLocked},
 			},
 			wantValues: StateValue{State: StateLocked},
@@ -28,7 +28,7 @@ func TestMessageJSON(t *testing.T) {
 			name: "gnss state value",
 			msg: Message{
 				Version: Version, Type: TypeGNSSState,
-				Profile: "ts2phc.0.config", IFace: "ens2f0",
+				Profile: "ts2phc.0.config", IFace: testIFace,
 				Values: GNSSStateValue{State: GNSSSynchronized},
 			},
 			wantValues: GNSSStateValue{State: GNSSSynchronized},
@@ -37,7 +37,7 @@ func TestMessageJSON(t *testing.T) {
 			name: "sync state value",
 			msg: Message{
 				Version: Version, Type: TypeSyncState,
-				Profile: "ptp4l.0.config",
+				Profile: testProfile,
 				Values:  SyncStateValue{State: StateLocked},
 			},
 			wantValues: SyncStateValue{State: StateLocked},
@@ -55,7 +55,7 @@ func TestMessageJSON(t *testing.T) {
 			name: "clock class value",
 			msg: Message{
 				Version: Version, Type: TypeClockClass,
-				Profile: "ptp4l.0.config",
+				Profile: testProfile,
 				Values:  ClockClassValue{ClockClass: 6},
 			},
 			wantValues: ClockClassValue{ClockClass: 6},

--- a/pkg/ipc/writer.go
+++ b/pkg/ipc/writer.go
@@ -1,0 +1,144 @@
+package ipc
+
+import (
+	"context"
+	"net"
+	"sync"
+	"time"
+
+	"github.com/golang/glog"
+	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/utils"
+)
+
+const (
+	writerDialTimeout  = 5 * time.Second
+	writerWriteTimeout = 5 * time.Second
+)
+
+// Writer drains a Message channel and writes each message to a Unix socket
+// as newline-delimited JSON. It manages its own connection with exponential
+// backoff reconnection, independent of the CEPv1 event socket.
+type Writer struct {
+	socketPath  string
+	msgCh       <-chan Message
+	closeCh     <-chan bool
+	conn        net.Conn
+	connMu      sync.Mutex
+	reconnectMu sync.Mutex
+}
+
+// NewWriter creates a Writer that will connect to socketPath, read messages
+// from msgCh, and shut down when closeCh receives a value or is closed.
+func NewWriter(socketPath string, msgCh <-chan Message, closeCh <-chan bool) *Writer {
+	return &Writer{
+		socketPath: socketPath,
+		msgCh:      msgCh,
+		closeCh:    closeCh,
+	}
+}
+
+// Run is the blocking entry point — call as a goroutine.
+// It establishes a connection to the CEPv2 socket and drains the message channel,
+// writing each message as newline-delimited JSON. It retries the connection
+// indefinitely until shutdown.
+func (w *Writer) Run() {
+	defer w.setConn(nil)
+
+	if !w.reconnect() {
+		return
+	}
+
+	for {
+		select {
+		case <-w.closeCh:
+			return
+		case msg := <-w.msgCh:
+			w.write(msg)
+		}
+	}
+}
+
+func (w *Writer) getConn() net.Conn {
+	w.connMu.Lock()
+	defer w.connMu.Unlock()
+	return w.conn
+}
+
+func (w *Writer) setConn(c net.Conn) {
+	w.connMu.Lock()
+	old := w.conn
+	w.conn = c
+	w.connMu.Unlock()
+	if old != nil && old != c {
+		if err := old.Close(); err != nil {
+			glog.Warningf("IPC writer: failed to close old connection: %v", err)
+		}
+	}
+}
+
+// reconnect retries indefinitely until a connection is established or closeCh
+// fires. Each round uses exponential backoff (10 attempts, 100ms→5s). If a
+// round is exhausted the cycle restarts, so the Writer never gives up.
+func (w *Writer) reconnect() bool {
+	w.reconnectMu.Lock()
+	defer w.reconnectMu.Unlock()
+
+	if w.getConn() != nil {
+		return true
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		select {
+		case <-w.closeCh:
+			cancel()
+		case <-ctx.Done():
+		}
+	}()
+	defer cancel()
+
+	dialer := net.Dialer{Timeout: writerDialTimeout}
+	dialFn := func() (net.Conn, error) { return dialer.DialContext(ctx, "unix", w.socketPath) }
+
+	for {
+		newConn := utils.ReconnectWithBackoff(ctx, dialFn, utils.DefaultReconnectConfig())
+		if newConn != nil {
+			w.setConn(newConn)
+			return true
+		}
+		select {
+		case <-ctx.Done():
+			return false
+		default:
+			glog.Warning("IPC writer: reconnect round exhausted, retrying")
+		}
+	}
+}
+
+func (w *Writer) write(msg Message) {
+	for {
+		select {
+		case <-w.closeCh:
+			return
+		default:
+		}
+
+		conn := w.getConn()
+		if conn == nil {
+			if !w.reconnect() {
+				return
+			}
+			conn = w.getConn()
+		}
+
+		if err := conn.SetWriteDeadline(time.Now().Add(writerWriteTimeout)); err != nil {
+			glog.Warningf("IPC writer: failed to set write deadline: %v", err)
+		}
+		if err := Encode(conn, []Message{msg}); err != nil {
+			glog.Errorf("IPC writer: write error: %v", err)
+			w.setConn(nil)
+			continue
+		}
+		return
+	}
+}

--- a/pkg/parser/chronyd_parser.go
+++ b/pkg/parser/chronyd_parser.go
@@ -1,0 +1,65 @@
+package parser
+
+import (
+	"regexp"
+
+	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/parser/constants"
+)
+
+var (
+	// chronyd[1234][chronyd.0.config]: Selected source 192.168.1.1 (1.2.3.4)
+	chronydSelectedSourceRegex = regexp.MustCompile(
+		`chronyd\[\d+\]\[(?P<config_name>.*\.\d+\.config)\]:\s+Selected source\s+`,
+	)
+	// chronyd[1234][chronyd.0.config]: Can't synchronise: no selectable sources
+	chronydNoSelectableSourcesRegex = regexp.MustCompile(
+		`chronyd\[\d+\]\[(?P<config_name>.*\.\d+\.config)\]:\s+.*no selectable sources`,
+	)
+)
+
+type chronydParsed struct {
+	ConfigName string
+	Locked     bool
+}
+
+func (p *chronydParsed) Populate(_ string, matched, fields []string) error {
+	for i, field := range fields {
+		switch field {
+		case "config_name":
+			p.ConfigName = matched[i]
+		}
+	}
+	return nil
+}
+
+// NewChronydExtractor creates a new metrics extractor for chronyd process
+func NewChronydExtractor() *BaseMetricsExtractor[*chronydParsed] {
+	return &BaseMetricsExtractor[*chronydParsed]{
+		ProcessNameStr: constants.CHRONYD,
+		NewParsed:      func() *chronydParsed { return &chronydParsed{} },
+		RegexExtractorPairs: []RegexExtractorPair[*chronydParsed]{
+			{
+				Regex: chronydSelectedSourceRegex,
+				Extractor: func(_ *chronydParsed) (*Metrics, *PTPEvent, error) {
+					return &Metrics{
+						Iface:      constants.ClockRealTime,
+						ClockState: constants.ClockStateLocked,
+						Offset:     0,
+						Source:     constants.CHRONYD,
+					}, nil, nil
+				},
+			},
+			{
+				Regex: chronydNoSelectableSourcesRegex,
+				Extractor: func(_ *chronydParsed) (*Metrics, *PTPEvent, error) {
+					return &Metrics{
+						Iface:      constants.ClockRealTime,
+						ClockState: constants.ClockStateFreeRun,
+						Offset:     0,
+						Source:     constants.CHRONYD,
+					}, nil, nil
+				},
+			},
+		},
+	}
+}

--- a/pkg/parser/chronyd_parser_test.go
+++ b/pkg/parser/chronyd_parser_test.go
@@ -1,0 +1,74 @@
+package parser_test
+
+import (
+	"testing"
+
+	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/parser"
+	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/parser/constants"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestChronydParser(t *testing.T) {
+	tests := []struct {
+		name           string
+		logLine        string
+		expectedMetric *parser.Metrics
+		noMatch        bool
+	}{
+		{
+			name:    "Selected source locks clock",
+			logLine: "chronyd[12345][chronyd.0.config]: Selected source 192.168.1.1 (1.2.3.4)",
+			expectedMetric: &parser.Metrics{
+				Iface:      constants.ClockRealTime,
+				ClockState: constants.ClockStateLocked,
+				Offset:     0,
+				Source:     constants.CHRONYD,
+			},
+		},
+		{
+			name:    "No selectable sources means freerun",
+			logLine: "chronyd[12345][chronyd.0.config]: Can't synchronise: no selectable sources",
+			expectedMetric: &parser.Metrics{
+				Iface:      constants.ClockRealTime,
+				ClockState: constants.ClockStateFreeRun,
+				Offset:     0,
+				Source:     constants.CHRONYD,
+			},
+		},
+		{
+			name:    "Selected source with different config index",
+			logLine: "chronyd[99][chronyd.1.config]: Selected source 10.0.0.1",
+			expectedMetric: &parser.Metrics{
+				Iface:      constants.ClockRealTime,
+				ClockState: constants.ClockStateLocked,
+				Offset:     0,
+				Source:     constants.CHRONYD,
+			},
+		},
+		{
+			name:    "Unrelated chronyd log line",
+			logLine: "chronyd[12345][chronyd.0.config]: System clock wrong by 0.000001 seconds",
+			noMatch: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			extractor := parser.NewChronydExtractor()
+			metric, _, err := extractor.Extract(tt.logLine)
+
+			if tt.noMatch {
+				assert.Nil(t, metric)
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, metric)
+			assert.Equal(t, tt.expectedMetric.Iface, metric.Iface)
+			assert.Equal(t, tt.expectedMetric.ClockState, metric.ClockState)
+			assert.Equal(t, tt.expectedMetric.Offset, metric.Offset)
+			assert.Equal(t, tt.expectedMetric.Source, metric.Source)
+		})
+	}
+}

--- a/pkg/parser/constants/process.go
+++ b/pkg/parser/constants/process.go
@@ -16,4 +16,6 @@ const (
 	SYNCE = "synce"
 	// DPLL ...
 	DPLL = "dpll"
+	// CHRONYD ...
+	CHRONYD = "chronyd"
 )


### PR DESCRIPTION
Refactors the EventHandler to manage Clock objects which contain state
decisions specific to the type of clock.

Moves state logic out of EventHandler, having it serve as a dispatcher
of events that come in, serving only relevant events to each clock.

Each clock object will calculate its new state after an event and send
any change in state as an IPC event to send to cloud event proxy v2.

Cloud event proxy 1 logic remains untouched and working. Can be removed
in a future commit.

Assisted by AI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary of updates

* **New Features**
  * Added IPC caching and an IPC writer for improved, deduplicated socket message delivery.
  * Added chronyd support: parsing and event emission for chronyd-selected and no-source cases.
* **Bug Fixes**
  * Improved boundary-clock clock-class reporting and upstream dataset updates with stricter gating.
  * Per-port and per-clock handling for T-BC is now aligned with the finalized clock type.
* **Tests**
  * Expanded integration coverage for clock-class transitions, IPC behavior, and metrics (including multi-clock isolation).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->