### PR TITLE
Add process startup ordering

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -3,6 +3,7 @@ package daemon
 import (
 	"bufio"
 	"cmp"
+	"context"
 	"fmt"
 	"io"
 	"math"
@@ -167,6 +168,7 @@ type ProcessManager struct {
 	eventChannel    chan event.Event
 	ptpEventHandler *event.EventHandler
 	daemon          *Daemon
+	suppressionGate *EventSuppressionGate
 }
 
 // findProcessesByName returns a list of processes with the given name
@@ -263,6 +265,9 @@ func (p *ProcessManager) UpdateSynceConfig(config *synce.Relations) {
 // managed connection with reconnection support.
 func (p *ProcessManager) EmitProcessStatusLogs() {
 	for _, proc := range p.process {
+		if p.ShouldSuppressEvent(orchestratorProcessName(proc), EventTypeClockClassChange) {
+			continue
+		}
 		status := PtpProcessUp
 		if proc.Stopped() {
 			status = PtpProcessDown
@@ -283,6 +288,15 @@ func (p *ProcessManager) EmitClockClassLogs() {
 			}
 		}
 	}
+}
+
+// ShouldSuppressEvent checks whether a process-level event should be suppressed
+// based on the orchestrator's failure semantics and downtime thresholds.
+func (p *ProcessManager) ShouldSuppressEvent(processName string, eventType string) bool {
+	if p.suppressionGate == nil {
+		return false
+	}
+	return p.suppressionGate.ShouldSuppressEvent(processName, eventType)
 }
 
 type tBCProcessAttributes struct {
@@ -466,6 +480,9 @@ type Daemon struct {
 
 	delayedPhc2sys   atomic.Bool
 	delayedPhc2sysMu sync.Mutex // protects skipInitialStartup on phc2sys processes
+
+	processOrchestrator       *ProcessOrchestrator
+	processOrchestratorCancel context.CancelFunc
 }
 
 type initialStateSyncer interface{ SyncInitialState() }
@@ -877,53 +894,61 @@ func (dn *Daemon) applyNodePTPProfiles() error {
 	// Reset the live gate BEFORE starting processes so that socket-writers
 	// block until /emit-logs completes replay after the sidecar restart.
 	dn.liveGate.Reset()
-	// Start all the process
-	for _, p := range dn.processManager.process {
-		if p != nil {
-			p.eventCh = dn.processManager.eventChannel
-			for _, d := range p.depProcess {
-				if d != nil {
-					time.Sleep(3 * time.Second)
-					glog.Infof("Starting %s", d.Name())
-					go d.CmdRun(false)
-					time.Sleep(3 * time.Second)
-					dn.pluginManager.AfterRunPTPCommand(&p.nodeProfile, d.Name())
-					d.MonitorProcess(config.ProcessConfig{
-						ClockType:    p.clockType,
-						ConfigName:   p.configName,
-						EventChannel: dn.processManager.eventChannel,
-						GMThreshold: config.Threshold{
-							Max:             p.ptpClockThreshold.MaxOffsetThreshold,
-							Min:             p.ptpClockThreshold.MinOffsetThreshold,
-							HoldOverTimeout: p.ptpClockThreshold.HoldOverTimeout,
-						},
-						InitialPTPState: event.PTP_FREERUN,
-					})
-					// Pre-populate event state immediately after the EventChannel
-					// is set up so that hardware-slaved DPLLs (e.g. E830 CF) are
-					// present in the event data before the async monitoring goroutine
-					// completes its own initial dump.
-					if syncer, ok := d.(initialStateSyncer); ok {
-						syncer.SyncInitialState()
+
+	orchestratedClockType := dn.detectOrchestratedClockType()
+	if orchestratedClockType != event.ClockUnset {
+		glog.Infof("Using process orchestrator for clock type %s", orchestratedClockType)
+		dn.processOrchestrator = dn.buildOrchestrator(orchestratedClockType)
+		ctx, cancel := context.WithCancel(context.Background())
+		dn.processOrchestratorCancel = cancel
+		dn.startProcessesWithOrchestrator(ctx)
+	} else {
+		// Flat start loop for non-telecom profiles (OC, unconfigured, etc.)
+		for _, p := range dn.processManager.process {
+			if p != nil {
+				p.eventCh = dn.processManager.eventChannel
+				for _, d := range p.depProcess {
+					if d != nil {
+						time.Sleep(3 * time.Second)
+						glog.Infof("Starting %s", d.Name())
+						go d.CmdRun(false)
+						time.Sleep(3 * time.Second)
+						dn.pluginManager.AfterRunPTPCommand(&p.nodeProfile, d.Name())
+						d.MonitorProcess(config.ProcessConfig{
+							ClockType:    p.clockType,
+							ConfigName:   p.configName,
+							EventChannel: dn.processManager.eventChannel,
+							GMThreshold: config.Threshold{
+								Max:             p.ptpClockThreshold.MaxOffsetThreshold,
+								Min:             p.ptpClockThreshold.MinOffsetThreshold,
+								HoldOverTimeout: p.ptpClockThreshold.HoldOverTimeout,
+							},
+							InitialPTPState: event.PTP_FREERUN,
+						})
+						// Pre-populate event state immediately after the EventChannel
+						// is set up so that hardware-slaved DPLLs (e.g. E830 CF) are
+						// present in the event data before the async monitoring goroutine
+						// completes its own initial dump.
+						if syncer, ok := d.(initialStateSyncer); ok {
+							syncer.SyncInitialState()
+						}
+						glog.Infof("enabling dep process %s with Max %d Min %d Holdover %d", d.Name(), p.ptpClockThreshold.MaxOffsetThreshold, p.ptpClockThreshold.MinOffsetThreshold, p.ptpClockThreshold.HoldOverTimeout)
 					}
-					glog.Infof("enabling dep process %s with Max %d Min %d Holdover %d", d.Name(), p.ptpClockThreshold.MaxOffsetThreshold, p.ptpClockThreshold.MinOffsetThreshold, p.ptpClockThreshold.HoldOverTimeout)
 				}
+				if p.skipInitialStartup != "" {
+					glog.Infof("Delaying %s startup: %s", p.name, p.skipInitialStartup)
+					continue
+				}
+				go p.cmdRun(dn.stdoutToSocket, &dn.pluginManager)
+				dn.pluginManager.AfterRunPTPCommand(&p.nodeProfile, p.name)
 			}
-			if p.skipInitialStartup != "" {
-				glog.Infof("Delaying %s startup: %s", p.name, p.skipInitialStartup)
-				continue
-			}
-			go p.cmdRun(dn.stdoutToSocket, &dn.pluginManager)
-			dn.pluginManager.AfterRunPTPCommand(&p.nodeProfile, p.name)
 		}
-	}
-	// Arm the delayed-phc2sys flag now that the startup loop is complete.
-	// Keeping it false during the loop ensures HandleDelayedPhc2sysStartup
-	// cannot clear skipInitialStartup and race with the loop's skip check.
-	for _, p := range dn.processManager.process {
-		if p != nil && p.skipInitialStartup != "" {
-			dn.delayedPhc2sys.Store(true)
-			break
+		// Arm the delayed-phc2sys flag for the flat loop path.
+		for _, p := range dn.processManager.process {
+			if p != nil && p.skipInitialStartup != "" {
+				dn.delayedPhc2sys.Store(true)
+				break
+			}
 		}
 	}
 	dn.hwconfigsMu.Lock()
@@ -1030,26 +1055,8 @@ func (dn *Daemon) applyNodePtpProfile(runID int, nodeProfile *ptpv1.PtpProfile) 
 
 	ptpHAEnabled := len(listHaProfiles(nodeProfile)) > 0
 
-	var clockType event.ClockType
-	profileClockType, found := (*nodeProfile).PtpSettings["clockType"]
-	var leadingNic string
-	var upstreamPorts []string
-	if found {
-		switch profileClockType {
-		case TGM:
-			clockType = event.GM
-		case TBC:
-			clockType = event.BC
-			leadingNic = (*nodeProfile).PtpSettings["leadingInterface"]
-			if portsStr, ok := (*nodeProfile).PtpSettings["upstreamPort"]; ok {
-				upstreamPorts = strings.Split(portsStr, ",")
-			}
-		default:
-			clockType = event.ClockUnset
-		}
-	} else {
-		clockType = event.ClockUnset
-	}
+	profileClockType := (*nodeProfile).PtpSettings["clockType"]
+	clockType, leadingNic, upstreamPorts := resolveProfileClockType((*nodeProfile).PtpSettings)
 
 	// If unset default to clock type inferred from ptp4l
 	if clockType == event.ClockUnset {
@@ -1901,21 +1908,38 @@ func (p *ptpProcess) cmdRun(stdoutToSocket bool, pm *plugin.PluginManager) {
 			err = cmd.Start()
 			if err != nil {
 				glog.Errorf("CmdRun() error starting %s: %v", p.name, err)
+			} else if p.dn != nil && p.dn.processOrchestrator != nil {
+				orchName := orchestratorProcessName(p)
+				result := p.dn.processOrchestrator.OnProcessRestart(orchName, time.Now())
+				if p.dn.processManager.suppressionGate != nil {
+					p.dn.processManager.suppressionGate.OnProcessRestarted(orchName, result)
+				}
 			}
 
 			<-doneCh
 			err = cmd.Wait()
 
 			glog.Infof("done waiting for %s...", p.name)
+			if p.dn != nil && p.dn.processOrchestrator != nil && !p.Stopped() {
+				orchName := orchestratorProcessName(p)
+				// Failure semantics (EnterHoldover, FlipSyncDirection) are handled by the
+				// existing T-BC state machine via port-loss detection, not by the orchestrator directly.
+				p.dn.processOrchestrator.OnProcessExit(orchName, time.Now())
+				if p.dn.processManager.suppressionGate != nil {
+					p.dn.processManager.suppressionGate.OnProcessFailed(orchName)
+				}
+			}
 			if err != nil {
 				glog.Errorf("CmdRun() error waiting for %s: %v", p.name, err)
 			}
-			if stdoutToSocket && p.c != nil {
-				glog.V(14).Infof("cmdRun[%s]: process ended, sending DOWN via socket", p.name)
-				processStatus(p.c, p.name, p.messageTag, PtpProcessDown)
-			} else {
-				glog.V(14).Infof("cmdRun[%s]: process ended, sending DOWN via prometheus", p.name)
-				processStatus(nil, p.name, p.messageTag, PtpProcessDown)
+			if !p.dn.processManager.ShouldSuppressEvent(orchestratorProcessName(p), EventTypeClockClassChange) {
+				if stdoutToSocket && p.c != nil {
+					glog.V(14).Infof("cmdRun[%s]: process ended, sending DOWN via socket", p.name)
+					processStatus(p.c, p.name, p.messageTag, PtpProcessDown)
+				} else {
+					glog.V(14).Infof("cmdRun[%s]: process ended, sending DOWN via prometheus", p.name)
+					processStatus(nil, p.name, p.messageTag, PtpProcessDown)
+				}
 			}
 			p.updateGMStatusOnProcessDown(p.name)
 		}
@@ -2045,9 +2069,10 @@ func (p *ptpProcess) cmdSetEnabled(enabled bool) {
 func getPTPThreshold(nodeProfile *ptpv1.PtpProfile) *ptpv1.PtpClockThreshold {
 	if nodeProfile.PtpClockThreshold != nil {
 		return &ptpv1.PtpClockThreshold{
-			HoldOverTimeout:    nodeProfile.PtpClockThreshold.HoldOverTimeout,
-			MaxOffsetThreshold: nodeProfile.PtpClockThreshold.MaxOffsetThreshold,
-			MinOffsetThreshold: nodeProfile.PtpClockThreshold.MinOffsetThreshold,
+			HoldOverTimeout:           nodeProfile.PtpClockThreshold.HoldOverTimeout,
+			MaxOffsetThreshold:        nodeProfile.PtpClockThreshold.MaxOffsetThreshold,
+			MinOffsetThreshold:        nodeProfile.PtpClockThreshold.MinOffsetThreshold,
+			ProcessDowntimeThresholds: nodeProfile.PtpClockThreshold.ProcessDowntimeThresholds,
 		}
 	} else {
 		return &ptpv1.PtpClockThreshold{
@@ -2060,6 +2085,326 @@ func getPTPThreshold(nodeProfile *ptpv1.PtpProfile) *ptpv1.PtpClockThreshold {
 
 func (p *ptpProcess) MonitorEvent(offset float64, clockState string) {
 	// not implemented
+}
+
+// resolveProfileClockType determines the clock type, leading NIC, and upstream ports
+// from the profile's PtpSettings["clockType"] declaration.
+func resolveProfileClockType(settings map[string]string) (clockType event.ClockType, leadingNic string, upstreamPorts []string) {
+	profileClockType, found := settings["clockType"]
+	if !found {
+		return event.ClockUnset, "", nil
+	}
+	switch profileClockType {
+	case TBC:
+		clockType = event.BC
+		leadingNic = settings["leadingInterface"]
+		if portsStr, ok := settings["upstreamPort"]; ok {
+			upstreamPorts = strings.Split(portsStr, ",")
+		}
+	case TGM:
+		clockType = event.GM
+	default:
+		clockType = event.ClockUnset
+	}
+	return
+}
+
+// detectOrchestratedClockType scans the node profiles to determine if we have
+// a T-BC configuration that should use the orchestrator.
+// T-GM orchestration is not yet enabled — T-GM profiles use the flat start loop.
+func (dn *Daemon) detectOrchestratedClockType() event.ClockType {
+	for _, profile := range dn.ptpUpdate.NodeProfiles {
+		ct, _, _ := resolveProfileClockType(profile.PtpSettings)
+		if ct == event.BC {
+			return event.BC
+		}
+	}
+	return event.ClockUnset
+}
+
+// bcStateAdapter provides BCStateObserver by reading the T-BC FSM state from
+// the ptp4l-TR process's lastAppliedState. S2 (PTP_LOCKED) means the offset
+// filter passed and the T-BC is synchronized.
+type bcStateAdapter struct {
+	proc *ptpProcess
+}
+
+func (a *bcStateAdapter) CurrentState() event.PTPState {
+	if a.proc == nil {
+		return event.PTP_FREERUN
+	}
+	state := a.proc.tBCAttributes.lastAppliedState
+	if state == event.PTP_NOTSET {
+		return event.PTP_FREERUN
+	}
+	return state
+}
+
+// findPTPSourceAdapter locates the PTP source process (ptp4l-TR for T-BC, ts2phc for T-GM)
+// and returns a ptpSourceAdapter for it. This provides servo state and offset data
+// to preconditions that gate downstream processes.
+func (dn *Daemon) findPTPSourceAdapter(clockType event.ClockType) *ptpSourceAdapter {
+	for _, p := range dn.processManager.process {
+		if p == nil {
+			continue
+		}
+		switch clockType {
+		case event.BC:
+			if p.name == ptp4lProcessName && len(p.tBCAttributes.trIfaceNames) > 0 {
+				return &ptpSourceAdapter{proc: p}
+			}
+		case event.GM:
+			if p.name == ts2phcProcessName {
+				return &ptpSourceAdapter{proc: p}
+			}
+		}
+	}
+	return &ptpSourceAdapter{}
+}
+
+// findBCStateAdapter locates the ptp4l-TR process and returns a bcStateAdapter.
+func (dn *Daemon) findBCStateAdapter() *bcStateAdapter {
+	for _, p := range dn.processManager.process {
+		if p == nil {
+			continue
+		}
+		if p.name == ptp4lProcessName && len(p.tBCAttributes.trIfaceNames) > 0 {
+			return &bcStateAdapter{proc: p}
+		}
+	}
+	return &bcStateAdapter{}
+}
+
+// orchestratorProcessName maps a ptpProcess to its orchestrator plan name.
+// For T-BC: ptp4l with upstream ports is "ptp4l-tr", ptp4l with controllingProfile is "ptp4l-tt".
+// For T-GM: processes use their binary name directly.
+func orchestratorProcessName(p *ptpProcess) string {
+	if p.name == ptp4lProcessName {
+		if len(p.tBCAttributes.trIfaceNames) > 0 {
+			return "ptp4l-tr"
+		}
+		if cp := p.nodeProfile.PtpSettings["controllingProfile"]; cp != "" {
+			return "ptp4l-tt"
+		}
+	}
+	if p.name == syncEProcessName {
+		return syncEProcessName
+	}
+	return p.name
+}
+
+// orchestratorStateAdapter bridges the circular dependency between the startup plan
+// (which needs a ProcessStateProvider) and the orchestrator (which is created from
+// the plan but itself implements ProcessStateProvider via IsRunning).
+type orchestratorStateAdapter struct {
+	orch *ProcessOrchestrator
+}
+
+func (a *orchestratorStateAdapter) IsRunning(name string) bool {
+	if a.orch == nil {
+		return false
+	}
+	return a.orch.IsRunning(name)
+}
+
+// ptpSourceAdapter provides PTPSourceStateProvider by reading servo state and
+// offset from a ptpProcess at runtime. Until the process reports data, it
+// returns FREERUN and max offset (never qualified).
+type ptpSourceAdapter struct {
+	proc *ptpProcess
+}
+
+func (a *ptpSourceAdapter) ServoState() event.PTPState {
+	if a.proc == nil {
+		return event.PTP_FREERUN
+	}
+	if a.proc.tBCAttributes.lastReportedState == event.PTP_NOTSET {
+		return event.PTP_FREERUN
+	}
+	return a.proc.tBCAttributes.lastReportedState
+}
+
+func (a *ptpSourceAdapter) CurrentOffset() float64 {
+	if a.proc == nil {
+		return 999999999
+	}
+	return a.proc.offset
+}
+
+// buildOrchestrator constructs a ProcessOrchestrator for the given clock type
+// and registers all processes from the ProcessManager with their start/stop callbacks.
+func (dn *Daemon) buildOrchestrator(clockType event.ClockType) *ProcessOrchestrator {
+	processAdapter := &orchestratorStateAdapter{}
+	sourceAdapter := dn.findPTPSourceAdapter(clockType)
+
+	offsetThreshold, requiredSamples := dn.findOrchestratorPreconditionParams(clockType)
+
+	var plan *StartupPlan
+	switch clockType {
+	case event.BC:
+		plan = NewTBCStartupPlan(sourceAdapter, processAdapter, dn.findBCStateAdapter(), offsetThreshold, requiredSamples)
+	case event.GM:
+		plan = NewTGMStartupPlan(sourceAdapter, processAdapter, offsetThreshold, requiredSamples)
+	default:
+		return nil
+	}
+
+	orch := NewProcessOrchestrator(plan)
+	processAdapter.orch = orch
+
+	for _, p := range dn.processManager.process {
+		if p == nil {
+			continue
+		}
+		orchName := orchestratorProcessName(p)
+		proc := p
+		orch.RegisterProcess(orchName,
+			func() error {
+				return dn.startManagedProcess(proc)
+			},
+			func() {
+				proc.cmdStop()
+			},
+		)
+	}
+
+	if plan.FailureSemantics != nil {
+		dn.processManager.suppressionGate = NewEventSuppressionGate(orch.downtime, plan.FailureSemantics)
+	}
+
+	if crdThresholds := dn.findCRDDowntimeThresholds(); crdThresholds != nil {
+		orch.downtime.SetThresholds(crdThresholds)
+	}
+
+	if dn.processManager.ptpEventHandler != nil {
+		pm := dn.processManager
+		srcAdapter := sourceAdapter
+		dn.processManager.ptpEventHandler.ShouldSuppressHoldover = func(ptpLost, dpllLost bool) bool {
+			if dpllLost {
+				return false
+			}
+			if ptpLost && srcAdapter.ServoState() != event.PTP_LOCKED {
+				return false
+			}
+			return pm.ShouldSuppressEvent("ts2phc", EventTypeClockClassChange)
+		}
+	}
+
+	return orch
+}
+
+// findOrchestratorPreconditionParams reads the offset threshold and required samples
+// from the CRD config for use in PTPSourceQualified preconditions.
+// For T-BC it reads from the ptp4l-TR process; for T-GM from ts2phc.
+func (dn *Daemon) findOrchestratorPreconditionParams(clockType event.ClockType) (offsetThreshold float64, requiredSamples int) {
+	offsetThreshold = 100
+	requiredSamples = 3
+
+	for _, p := range dn.processManager.process {
+		if p == nil {
+			continue
+		}
+		switch clockType {
+		case event.BC:
+			if p.name != ptp4lProcessName || len(p.tBCAttributes.trIfaceNames) == 0 {
+				continue
+			}
+		case event.GM:
+			if p.name != ts2phcProcessName {
+				continue
+			}
+		default:
+			return
+		}
+
+		if p.tBCAttributes.offsetThreshold > 0 {
+			offsetThreshold = p.tBCAttributes.offsetThreshold
+		} else if p.ptpClockThreshold != nil && p.ptpClockThreshold.MaxOffsetThreshold > 0 {
+			offsetThreshold = float64(p.ptpClockThreshold.MaxOffsetThreshold)
+		}
+		if s, ok := p.nodeProfile.PtpSettings["inSyncConditionTimes"]; ok {
+			if v, err := strconv.Atoi(s); err == nil && v > 0 {
+				requiredSamples = v
+			}
+		}
+		return
+	}
+	return
+}
+
+// findCRDDowntimeThresholds reads the ProcessDowntimeThresholds from the first
+// ptpProcess that has them configured and maps them to orchestrator process names.
+func (dn *Daemon) findCRDDowntimeThresholds() map[string]time.Duration {
+	for _, p := range dn.processManager.process {
+		if p == nil || p.ptpClockThreshold == nil || p.ptpClockThreshold.ProcessDowntimeThresholds == nil {
+			continue
+		}
+		pdt := p.ptpClockThreshold.ProcessDowntimeThresholds
+		thresholds := make(map[string]time.Duration)
+		if pdt.Ptp4l != nil {
+			d := time.Duration(*pdt.Ptp4l) * time.Second
+			thresholds[orchPtp4lTR] = d
+			thresholds[orchPtp4lTT] = d
+			thresholds[ptp4lProcessName] = d
+		}
+		if pdt.Phc2sys != nil {
+			thresholds[phc2sysProcessName] = time.Duration(*pdt.Phc2sys) * time.Second
+		}
+		if pdt.Ts2phc != nil {
+			thresholds[ts2phcProcessName] = time.Duration(*pdt.Ts2phc) * time.Second
+		}
+		if pdt.Synce4l != nil {
+			thresholds[syncEProcessName] = time.Duration(*pdt.Synce4l) * time.Second
+		}
+		return thresholds
+	}
+	return nil
+}
+
+// startManagedProcess starts a single ptpProcess including its dependency processes.
+// This reproduces the per-process logic from the flat start loop.
+func (dn *Daemon) startManagedProcess(p *ptpProcess) error {
+	p.eventCh = dn.processManager.eventChannel
+	for _, d := range p.depProcess {
+		if d == nil {
+			continue
+		}
+		time.Sleep(3 * time.Second)
+		glog.Infof("orchestrator: starting dep %s for %s", d.Name(), p.name)
+		go d.CmdRun(false)
+		time.Sleep(3 * time.Second)
+		dn.pluginManager.AfterRunPTPCommand(&p.nodeProfile, d.Name())
+		d.MonitorProcess(config.ProcessConfig{
+			ClockType:    p.clockType,
+			ConfigName:   p.configName,
+			EventChannel: dn.processManager.eventChannel,
+			GMThreshold: config.Threshold{
+				Max:             p.ptpClockThreshold.MaxOffsetThreshold,
+				Min:             p.ptpClockThreshold.MinOffsetThreshold,
+				HoldOverTimeout: p.ptpClockThreshold.HoldOverTimeout,
+			},
+			InitialPTPState: event.PTP_FREERUN,
+		})
+		if syncer, ok := d.(initialStateSyncer); ok {
+			syncer.SyncInitialState()
+		}
+		glog.Infof("orchestrator: dep %s started (Max %d Min %d Holdover %d)",
+			d.Name(), p.ptpClockThreshold.MaxOffsetThreshold,
+			p.ptpClockThreshold.MinOffsetThreshold, p.ptpClockThreshold.HoldOverTimeout)
+	}
+	go p.cmdRun(dn.stdoutToSocket, &dn.pluginManager)
+	dn.pluginManager.AfterRunPTPCommand(&p.nodeProfile, p.name)
+	return nil
+}
+
+// startProcessesWithOrchestrator uses the ProcessOrchestrator to start processes
+// in the correct precondition-gated order for T-BC or T-GM profiles.
+func (dn *Daemon) startProcessesWithOrchestrator(ctx context.Context) {
+	go func() {
+		if err := dn.processOrchestrator.Start(ctx); err != nil {
+			glog.Errorf("orchestrator startup failed: %v", err)
+		}
+	}()
 }
 
 // HandleDelayedPhc2sysStartup checks if phc2sys was delayed and if the current offset is within the 1s threshold, starts it.
@@ -2346,6 +2691,12 @@ func (p *ptpProcess) replaceClockID(input string) (output string) {
 func (p *ptpProcess) updateGMStatusOnProcessDown(process string) {
 	// need to update GM status for  following process kill for  ts2phc
 	if process == ts2phcProcessName {
+		// When the orchestrator is suppressing holdover (ts2phc silent restart),
+		// do NOT reset event data — the DPLL and ptp4l windows must remain intact
+		// so getLargestOffset doesn't return FaultyPhaseOffset.
+		if p.dn != nil && p.dn.processManager.ShouldSuppressEvent("ts2phc", EventTypeClockClassChange) {
+			return
+		}
 		// ts2phc process dead should update GM-STATUS
 		// Reset the entire event subsystem
 		// (this nullifies the remaining pieces in the event data if ts2phc was killed during ptp profile change)
@@ -2502,6 +2853,11 @@ func (p *ptpProcess) SyncEDeviceByName(name string) *synce.Config {
 }
 
 func (dn *Daemon) stopAllProcesses() {
+	if dn.processOrchestratorCancel != nil {
+		dn.processOrchestratorCancel()
+		dn.processOrchestratorCancel = nil
+		dn.processOrchestrator = nil
+	}
 	for _, p := range dn.processManager.process {
 		if p != nil {
 			glog.Infof("stopping process.... %s", p.name)

--- a/pkg/daemon/daemon_internal_test.go
+++ b/pkg/daemon/daemon_internal_test.go
@@ -3656,18 +3656,18 @@ func TestDelayedPhc2sysStartup_HAProfile(t *testing.T) {
 func TestFindProcessesByName(t *testing.T) {
 	pm := &ProcessManager{
 		process: []*ptpProcess{
-			{name: "ptp4l"},
-			{name: "phc2sys"},
-			{name: "ptp4l"},
+			{name: ptp4lProcessName},
+			{name: phc2sysProcessName},
+			{name: ptp4lProcessName},
 		},
 	}
 
-	procs := pm.findProcessesByName("ptp4l")
+	procs := pm.findProcessesByName(ptp4lProcessName)
 	assert.Equal(t, 2, len(procs))
-	assert.Equal(t, "ptp4l", procs[0].name)
-	assert.Equal(t, "ptp4l", procs[1].name)
+	assert.Equal(t, ptp4lProcessName, procs[0].name)
+	assert.Equal(t, ptp4lProcessName, procs[1].name)
 
-	procs = pm.findProcessesByName("phc2sys")
+	procs = pm.findProcessesByName(phc2sysProcessName)
 	assert.Equal(t, 1, len(procs))
 
 	procs = pm.findProcessesByName("nonexistent")

--- a/pkg/daemon/downtime.go
+++ b/pkg/daemon/downtime.go
@@ -1,0 +1,176 @@
+package daemon
+
+import (
+	"sync"
+	"time"
+)
+
+// DowntimeResult is the outcome of evaluating process downtime against its threshold.
+type DowntimeResult struct {
+	ProcessName       string
+	Downtime          time.Duration
+	Threshold         time.Duration
+	ThresholdExceeded bool
+}
+
+// DowntimeTracker tracks per-process failure timestamps and threshold evaluation.
+type DowntimeTracker struct {
+	mu         sync.Mutex
+	thresholds map[string]time.Duration
+	failures   map[string]time.Time
+}
+
+// NewDowntimeTracker creates a tracker with the given per-process thresholds.
+func NewDowntimeTracker(thresholds map[string]time.Duration) *DowntimeTracker {
+	t := make(map[string]time.Duration, len(thresholds))
+	for k, v := range thresholds {
+		t[k] = v
+	}
+	return &DowntimeTracker{
+		thresholds: t,
+		failures:   make(map[string]time.Time),
+	}
+}
+
+// RecordFailure stores the failure timestamp for a process.
+func (d *DowntimeTracker) RecordFailure(processName string, failedAt time.Time) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.failures[processName] = failedAt
+}
+
+// EvaluateRestart computes downtime and whether it exceeded the configured threshold.
+func (d *DowntimeTracker) EvaluateRestart(processName string, restartedAt time.Time) DowntimeResult {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	failedAt, recorded := d.failures[processName]
+	if !recorded {
+		return DowntimeResult{ProcessName: processName}
+	}
+
+	downtime := restartedAt.Sub(failedAt)
+	threshold := d.thresholds[processName]
+
+	delete(d.failures, processName)
+
+	return DowntimeResult{
+		ProcessName:       processName,
+		Downtime:          downtime,
+		Threshold:         threshold,
+		ThresholdExceeded: downtime > threshold,
+	}
+}
+
+// SetThresholds replaces all thresholds (used when CRD config is updated).
+func (d *DowntimeTracker) SetThresholds(thresholds map[string]time.Duration) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.thresholds = make(map[string]time.Duration, len(thresholds))
+	for k, v := range thresholds {
+		d.thresholds[k] = v
+	}
+}
+
+// GetThreshold returns the configured threshold for a process.
+func (d *DowntimeTracker) GetThreshold(processName string) time.Duration {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.thresholds[processName]
+}
+
+// Event type constants for suppression gate evaluation.
+const (
+	EventTypePTPStateChange   = "E1"
+	EventTypeOSClockSyncState = "E3"
+	EventTypeClockClassChange = "clock-class-change"
+)
+
+// EventSuppressionGate determines whether state-change events should be emitted
+// based on downtime tracking and per-process failure semantics.
+type EventSuppressionGate struct {
+	mu         sync.Mutex
+	tracker    *DowntimeTracker
+	semantics  map[string]ProcessFailureSemantics
+	suppressed map[string]bool  // processName → currently within suppression window
+	generation map[string]int64 // per-process generation to prevent stale timer clears
+}
+
+// NewEventSuppressionGate creates a gate using the given tracker and semantics.
+func NewEventSuppressionGate(tracker *DowntimeTracker, semantics map[string]ProcessFailureSemantics) *EventSuppressionGate {
+	return &EventSuppressionGate{
+		tracker:    tracker,
+		semantics:  semantics,
+		suppressed: make(map[string]bool),
+		generation: make(map[string]int64),
+	}
+}
+
+// OnProcessFailed marks a process as in suppression window for the full
+// threshold duration. Suppression remains active until the threshold timer
+// expires, even if the process binary restarts sooner (it needs time to
+// reach locked state after starting).
+func (g *EventSuppressionGate) OnProcessFailed(processName string) {
+	g.mu.Lock()
+	g.suppressed[processName] = true
+	g.generation[processName]++
+	gen := g.generation[processName]
+	threshold := g.tracker.GetThreshold(processName)
+	g.mu.Unlock()
+
+	go func() {
+		time.Sleep(threshold)
+		g.mu.Lock()
+		if g.generation[processName] == gen {
+			g.suppressed[processName] = false
+		}
+		g.mu.Unlock()
+	}()
+}
+
+// OnProcessRestarted is called when the process binary restarts. The suppression
+// window is NOT cleared here — it remains active for the full threshold duration
+// set in OnProcessFailed. This ensures that the brief s0 period after restart
+// does not trigger holdover.
+func (g *EventSuppressionGate) OnProcessRestarted(processName string, result DowntimeResult) {
+	if result.ThresholdExceeded {
+		g.mu.Lock()
+		g.suppressed[processName] = false
+		g.mu.Unlock()
+	}
+}
+
+// SetSuppressed explicitly sets the suppression state for a process.
+func (g *EventSuppressionGate) SetSuppressed(processName string, suppressed bool) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	g.suppressed[processName] = suppressed
+}
+
+// ShouldSuppressEvent returns true if the event should NOT be emitted.
+func (g *EventSuppressionGate) ShouldSuppressEvent(processName string, eventType string) bool {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+
+	sem, exists := g.semantics[processName]
+	if !exists {
+		return false
+	}
+
+	switch eventType {
+	case EventTypePTPStateChange:
+		if sem.EmitE1Always {
+			return false
+		}
+	case EventTypeOSClockSyncState:
+		if sem.SuppressE3Always {
+			return true
+		}
+	}
+
+	if sem.SilentRestart && g.suppressed[processName] {
+		return true
+	}
+
+	return false
+}

--- a/pkg/daemon/downtime_test.go
+++ b/pkg/daemon/downtime_test.go
@@ -1,0 +1,222 @@
+package daemon
+
+import (
+	"testing"
+	"time"
+)
+
+const testProcessName = "proc"
+
+func TestDowntimeTracker_RecordAndEvaluate(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name         string
+		threshold    time.Duration
+		downtime     time.Duration
+		wantExceeded bool
+	}{
+		{
+			name:         "within threshold",
+			threshold:    5 * time.Second,
+			downtime:     2 * time.Second,
+			wantExceeded: false,
+		},
+		{
+			name:         "exactly at threshold",
+			threshold:    5 * time.Second,
+			downtime:     5 * time.Second,
+			wantExceeded: false,
+		},
+		{
+			name:         "exceeds threshold",
+			threshold:    5 * time.Second,
+			downtime:     6 * time.Second,
+			wantExceeded: true,
+		},
+		{
+			name:         "zero threshold always exceeded",
+			threshold:    0,
+			downtime:     1 * time.Millisecond,
+			wantExceeded: true,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			tracker := NewDowntimeTracker(map[string]time.Duration{
+				testProcessName: tc.threshold,
+			})
+
+			failedAt := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+			restartedAt := failedAt.Add(tc.downtime)
+
+			tracker.RecordFailure(testProcessName, failedAt)
+			result := tracker.EvaluateRestart(testProcessName, restartedAt)
+
+			if result.ThresholdExceeded != tc.wantExceeded {
+				t.Errorf("ThresholdExceeded = %v, want %v (downtime=%v, threshold=%v)",
+					result.ThresholdExceeded, tc.wantExceeded, result.Downtime, result.Threshold)
+			}
+			if result.Downtime != tc.downtime {
+				t.Errorf("Downtime = %v, want %v", result.Downtime, tc.downtime)
+			}
+			if result.ProcessName != testProcessName {
+				t.Errorf("ProcessName = %q, want %q", result.ProcessName, testProcessName)
+			}
+		})
+	}
+}
+
+func TestDowntimeTracker_NoRecordedFailure(t *testing.T) {
+	t.Parallel()
+	tracker := NewDowntimeTracker(map[string]time.Duration{testProcessName: 5 * time.Second})
+	result := tracker.EvaluateRestart(testProcessName, time.Now())
+	if result.ThresholdExceeded {
+		t.Error("should not exceed threshold when no failure was recorded")
+	}
+	if result.Downtime != 0 {
+		t.Errorf("Downtime should be 0, got %v", result.Downtime)
+	}
+}
+
+func TestDowntimeTracker_EvaluateClearsFailure(t *testing.T) {
+	t.Parallel()
+	tracker := NewDowntimeTracker(map[string]time.Duration{testProcessName: 5 * time.Second})
+
+	failedAt := time.Now()
+	tracker.RecordFailure(testProcessName, failedAt)
+	tracker.EvaluateRestart(testProcessName, failedAt.Add(1*time.Second))
+
+	result := tracker.EvaluateRestart(testProcessName, failedAt.Add(2*time.Second))
+	if result.Downtime != 0 {
+		t.Error("second evaluate should find no recorded failure")
+	}
+}
+
+func TestDowntimeTracker_SetThresholds(t *testing.T) {
+	t.Parallel()
+	tracker := NewDowntimeTracker(map[string]time.Duration{testProcessName: 5 * time.Second})
+
+	tracker.SetThresholds(map[string]time.Duration{testProcessName: 10 * time.Second})
+
+	if got := tracker.GetThreshold(testProcessName); got != 10*time.Second {
+		t.Errorf("threshold = %v, want 10s", got)
+	}
+}
+
+func TestDowntimeTracker_MultipleProcesses(t *testing.T) {
+	t.Parallel()
+	tracker := NewDowntimeTracker(map[string]time.Duration{
+		"a": 5 * time.Second,
+		"b": 1 * time.Second,
+	})
+
+	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	tracker.RecordFailure("a", base)
+	tracker.RecordFailure("b", base)
+
+	resultA := tracker.EvaluateRestart("a", base.Add(3*time.Second))
+	resultB := tracker.EvaluateRestart("b", base.Add(3*time.Second))
+
+	if resultA.ThresholdExceeded {
+		t.Error("process 'a' should be within 5s threshold")
+	}
+	if !resultB.ThresholdExceeded {
+		t.Error("process 'b' should exceed 1s threshold")
+	}
+}
+
+func TestEventSuppressionGate_SuppressE3Always(t *testing.T) {
+	t.Parallel()
+	tracker := NewDowntimeTracker(map[string]time.Duration{})
+	semantics := map[string]ProcessFailureSemantics{
+		orchPtp4lTR: {SuppressE3Always: true},
+	}
+	gate := NewEventSuppressionGate(tracker, semantics)
+
+	if !gate.ShouldSuppressEvent(orchPtp4lTR, EventTypeOSClockSyncState) {
+		t.Error("E3 should always be suppressed for ptp4l-tr")
+	}
+	if gate.ShouldSuppressEvent(orchPtp4lTR, EventTypePTPStateChange) {
+		t.Error("E1 should not be suppressed for ptp4l-tr without EmitE1Always or SilentRestart")
+	}
+}
+
+func TestEventSuppressionGate_EmitE1Always(t *testing.T) {
+	t.Parallel()
+	tracker := NewDowntimeTracker(map[string]time.Duration{})
+	semantics := map[string]ProcessFailureSemantics{
+		orchPtp4lTT: {EmitE1Always: true},
+	}
+	gate := NewEventSuppressionGate(tracker, semantics)
+	gate.OnProcessFailed(orchPtp4lTT)
+
+	if gate.ShouldSuppressEvent(orchPtp4lTT, EventTypePTPStateChange) {
+		t.Error("E1 should never be suppressed when EmitE1Always is set")
+	}
+}
+
+func TestEventSuppressionGate_SilentRestart(t *testing.T) {
+	t.Parallel()
+	tracker := NewDowntimeTracker(map[string]time.Duration{ts2phcProcessName: 50 * time.Millisecond})
+	semantics := map[string]ProcessFailureSemantics{
+		ts2phcProcessName: {SilentRestart: true},
+	}
+	gate := NewEventSuppressionGate(tracker, semantics)
+
+	gate.OnProcessFailed(ts2phcProcessName)
+	if !gate.ShouldSuppressEvent(ts2phcProcessName, EventTypePTPStateChange) {
+		t.Error("events should be suppressed during silent restart window")
+	}
+
+	gate.OnProcessRestarted(ts2phcProcessName, DowntimeResult{ThresholdExceeded: false})
+	if !gate.ShouldSuppressEvent(ts2phcProcessName, EventTypePTPStateChange) {
+		t.Error("events should remain suppressed after restart within threshold (timer still active)")
+	}
+
+	time.Sleep(60 * time.Millisecond)
+	if gate.ShouldSuppressEvent(ts2phcProcessName, EventTypePTPStateChange) {
+		t.Error("events should not be suppressed after threshold timer expires")
+	}
+}
+
+func TestEventSuppressionGate_ThresholdExceeded(t *testing.T) {
+	t.Parallel()
+	tracker := NewDowntimeTracker(map[string]time.Duration{ts2phcProcessName: 5 * time.Second})
+	semantics := map[string]ProcessFailureSemantics{
+		ts2phcProcessName: {SilentRestart: true},
+	}
+	gate := NewEventSuppressionGate(tracker, semantics)
+
+	gate.OnProcessFailed(ts2phcProcessName)
+	gate.OnProcessRestarted(ts2phcProcessName, DowntimeResult{ThresholdExceeded: true})
+	if gate.ShouldSuppressEvent(ts2phcProcessName, EventTypePTPStateChange) {
+		t.Error("events should not be suppressed when threshold is exceeded")
+	}
+}
+
+func TestEventSuppressionGate_UnknownProcess(t *testing.T) {
+	t.Parallel()
+	tracker := NewDowntimeTracker(map[string]time.Duration{})
+	gate := NewEventSuppressionGate(tracker, map[string]ProcessFailureSemantics{})
+
+	if gate.ShouldSuppressEvent("unknown", EventTypePTPStateChange) {
+		t.Error("unknown process should not trigger suppression")
+	}
+}
+
+func TestEventSuppressionGate_ClockClassChange(t *testing.T) {
+	t.Parallel()
+	tracker := NewDowntimeTracker(map[string]time.Duration{})
+	semantics := map[string]ProcessFailureSemantics{
+		testProcessName: {SilentRestart: true},
+	}
+	gate := NewEventSuppressionGate(tracker, semantics)
+	gate.OnProcessFailed(testProcessName)
+
+	if !gate.ShouldSuppressEvent(testProcessName, EventTypeClockClassChange) {
+		t.Error("clock-class-change should be suppressed during silent restart")
+	}
+}

--- a/pkg/daemon/orchestrator.go
+++ b/pkg/daemon/orchestrator.go
@@ -50,7 +50,6 @@ func WithClock(c Clock) OrchestratorOption {
 	}
 }
 
-
 // Clock abstracts time operations for testability.
 type Clock interface {
 	Now() time.Time

--- a/pkg/daemon/orchestrator.go
+++ b/pkg/daemon/orchestrator.go
@@ -1,0 +1,263 @@
+package daemon
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/golang/glog"
+)
+
+// StartupPhase defines one step in the startup sequence.
+type StartupPhase struct {
+	Name         string
+	ProcessNames []string
+	Precondition StartupPrecondition
+}
+
+// ProcessFailureSemantics defines how the system reacts when a specific process fails.
+type ProcessFailureSemantics struct {
+	EnterHoldover     bool
+	FlipSyncDirection bool
+	EmitE1Always      bool
+	SuppressE3Always  bool
+	SilentRestart     bool
+}
+
+// StartupPlan is the complete startup configuration for a clock type.
+type StartupPlan struct {
+	ClockType         string
+	Phases            []StartupPhase
+	FailureSemantics  map[string]ProcessFailureSemantics
+	DefaultThresholds map[string]time.Duration
+}
+
+// OrchestratorOption configures the ProcessOrchestrator.
+type OrchestratorOption func(*ProcessOrchestrator)
+
+// WithPollInterval sets the precondition polling interval.
+func WithPollInterval(d time.Duration) OrchestratorOption {
+	return func(o *ProcessOrchestrator) {
+		o.pollInterval = d
+	}
+}
+
+// WithClock injects a clock source for testability.
+func WithClock(c Clock) OrchestratorOption {
+	return func(o *ProcessOrchestrator) {
+		o.clock = c
+	}
+}
+
+
+// Clock abstracts time operations for testability.
+type Clock interface {
+	Now() time.Time
+	NewTicker(d time.Duration) Ticker
+}
+
+// Ticker abstracts time.Ticker for testability.
+type Ticker interface {
+	C() <-chan time.Time
+	Stop()
+}
+
+type realClock struct{}
+
+func (realClock) Now() time.Time                   { return time.Now() }
+func (realClock) NewTicker(d time.Duration) Ticker { return &realTicker{ticker: time.NewTicker(d)} }
+
+type realTicker struct{ ticker *time.Ticker }
+
+func (t *realTicker) C() <-chan time.Time { return t.ticker.C }
+func (t *realTicker) Stop()               { t.ticker.Stop() }
+
+type managedProcess struct {
+	name    string
+	startFn func() error
+	stopFn  func()
+}
+
+// ProcessOrchestrator manages phased process startup and lifecycle.
+type ProcessOrchestrator struct {
+	mu           sync.Mutex
+	plan         StartupPlan
+	pollInterval time.Duration
+	clock        Clock
+	processes    map[string]*managedProcess
+	running      map[string]bool
+	started      bool
+	cancel       context.CancelFunc
+	done         chan struct{}
+	downtime     *DowntimeTracker
+}
+
+// NewProcessOrchestrator creates an orchestrator from a startup plan.
+func NewProcessOrchestrator(plan *StartupPlan, opts ...OrchestratorOption) *ProcessOrchestrator {
+	o := &ProcessOrchestrator{
+		plan:         *plan,
+		pollInterval: 500 * time.Millisecond,
+		clock:        realClock{},
+		processes:    make(map[string]*managedProcess),
+		running:      make(map[string]bool),
+		done:         make(chan struct{}),
+		downtime:     NewDowntimeTracker(plan.DefaultThresholds),
+	}
+	for _, opt := range opts {
+		opt(o)
+	}
+	return o
+}
+
+// RegisterProcess registers actual start/stop callbacks for a named process.
+func (o *ProcessOrchestrator) RegisterProcess(name string, startFn func() error, stopFn func()) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	o.processes[name] = &managedProcess{name: name, startFn: startFn, stopFn: stopFn}
+}
+
+// Start begins phased startup, blocking until all phases complete or ctx is cancelled.
+func (o *ProcessOrchestrator) Start(ctx context.Context) error {
+	o.mu.Lock()
+	if o.started {
+		o.mu.Unlock()
+		return fmt.Errorf("orchestrator already started")
+	}
+	o.started = true
+	ctx, o.cancel = context.WithCancel(ctx)
+	o.mu.Unlock()
+
+	defer close(o.done)
+	return o.run(ctx)
+}
+
+func (o *ProcessOrchestrator) run(ctx context.Context) error {
+	for i, phase := range o.plan.Phases {
+		if err := o.waitForPrecondition(ctx, phase); err != nil {
+			glog.Warningf("orchestrator: phase %q cancelled: %v", phase.Name, err)
+			return fmt.Errorf("phase %q: %w", phase.Name, err)
+		}
+
+		glog.Infof("orchestrator: starting phase %d/%d %q", i+1, len(o.plan.Phases), phase.Name)
+		if err := o.startPhaseProcesses(phase); err != nil {
+			glog.Errorf("orchestrator: phase %q failed: %v", phase.Name, err)
+			return fmt.Errorf("phase %q: %w", phase.Name, err)
+		}
+	}
+	glog.Infof("orchestrator: all %d phases completed for %s", len(o.plan.Phases), o.plan.ClockType)
+	return nil
+}
+
+func (o *ProcessOrchestrator) waitForPrecondition(ctx context.Context, phase StartupPhase) error {
+	if phase.Precondition == nil || phase.Precondition.Satisfied() {
+		return nil
+	}
+
+	ticker := o.clock.NewTicker(o.pollInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("waiting for precondition %q: %w",
+				phase.Precondition.Name(), ctx.Err())
+		case <-ticker.C():
+			if phase.Precondition.Satisfied() {
+				return nil
+			}
+		}
+	}
+}
+
+func (o *ProcessOrchestrator) startPhaseProcesses(phase StartupPhase) error {
+	for _, name := range phase.ProcessNames {
+		o.mu.Lock()
+		proc, exists := o.processes[name]
+		o.mu.Unlock()
+		if !exists {
+			return fmt.Errorf("process %q not registered", name)
+		}
+
+		if err := proc.startFn(); err != nil {
+			return fmt.Errorf("starting process %q: %w", name, err)
+		}
+		o.mu.Lock()
+		o.running[name] = true
+		o.mu.Unlock()
+		glog.Infof("orchestrator: process %q started", name)
+	}
+	return nil
+}
+
+// Stop performs graceful shutdown of all managed processes in reverse order.
+func (o *ProcessOrchestrator) Stop() {
+	o.mu.Lock()
+	if o.cancel != nil {
+		o.cancel()
+	}
+	o.mu.Unlock()
+
+	<-o.done
+
+	o.mu.Lock()
+	defer o.mu.Unlock()
+
+	for i := len(o.plan.Phases) - 1; i >= 0; i-- {
+		phase := o.plan.Phases[i]
+		for j := len(phase.ProcessNames) - 1; j >= 0; j-- {
+			name := phase.ProcessNames[j]
+			if proc, exists := o.processes[name]; exists && o.running[name] {
+				proc.stopFn()
+				o.running[name] = false
+				glog.Infof("orchestrator: process %q stopped", name)
+			}
+		}
+	}
+}
+
+// OnProcessExit records a process failure and returns the applicable failure semantics.
+func (o *ProcessOrchestrator) OnProcessExit(processName string, exitTime time.Time) ProcessFailureSemantics {
+	o.mu.Lock()
+	o.running[processName] = false
+	o.mu.Unlock()
+
+	o.downtime.RecordFailure(processName, exitTime)
+
+	semantics, exists := o.plan.FailureSemantics[processName]
+	if !exists {
+		return ProcessFailureSemantics{}
+	}
+	glog.Infof("orchestrator: process %q exited at %v, semantics: %+v", processName, exitTime, semantics)
+	return semantics
+}
+
+// OnProcessRestart marks a process as running again and evaluates downtime.
+// Preconditions are bypassed on restart per FR-7 (system was already qualified).
+func (o *ProcessOrchestrator) OnProcessRestart(processName string, restartTime time.Time) DowntimeResult {
+	o.mu.Lock()
+	o.running[processName] = true
+	o.mu.Unlock()
+
+	result := o.downtime.EvaluateRestart(processName, restartTime)
+	glog.Infof("orchestrator: process %q restarted at %v (downtime=%v, exceeded=%v)",
+		processName, restartTime, result.Downtime, result.ThresholdExceeded)
+	return result
+}
+
+// IsRunning implements ProcessStateProvider.
+func (o *ProcessOrchestrator) IsRunning(processName string) bool {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	return o.running[processName]
+}
+
+// DowntimeTracker returns the orchestrator's downtime tracker for use by event gates.
+func (o *ProcessOrchestrator) DowntimeTracker() *DowntimeTracker {
+	return o.downtime
+}
+
+// Done returns a channel that closes when the orchestrator's run loop completes.
+func (o *ProcessOrchestrator) Done() <-chan struct{} {
+	return o.done
+}

--- a/pkg/daemon/orchestrator.go
+++ b/pkg/daemon/orchestrator.go
@@ -138,6 +138,9 @@ func (o *ProcessOrchestrator) run(ctx context.Context) error {
 			glog.Warningf("orchestrator: phase %q cancelled: %v", phase.Name, err)
 			return fmt.Errorf("phase %q: %w", phase.Name, err)
 		}
+		if ctx.Err() != nil {
+			return fmt.Errorf("phase %q: %w", phase.Name, ctx.Err())
+		}
 
 		glog.Infof("orchestrator: starting phase %d/%d %q", i+1, len(o.plan.Phases), phase.Name)
 		if err := o.startPhaseProcesses(phase); err != nil {

--- a/pkg/daemon/orchestrator_integration_test.go
+++ b/pkg/daemon/orchestrator_integration_test.go
@@ -1,0 +1,273 @@
+package daemon
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/event"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIntegration_TBCStartupPlan_PhasedOrder(t *testing.T) {
+	t.Parallel()
+
+	sourceProvider := &mockPTPSourceState{state: event.PTP_LOCKED, offset: 10}
+	processState := &mockProcessState{running: map[string]bool{}}
+	bcObserver := &mockBCState{state: event.PTP_LOCKED}
+
+	plan := NewTBCStartupPlan(sourceProvider, processState, bcObserver, 100, 3)
+	orch := NewProcessOrchestrator(plan, WithPollInterval(5*time.Millisecond))
+
+	var mu sync.Mutex
+	var startOrder []string
+	record := func(name string) func() error {
+		return func() error {
+			mu.Lock()
+			startOrder = append(startOrder, name)
+			mu.Unlock()
+			processState.mu.Lock()
+			processState.running[name] = true
+			processState.mu.Unlock()
+			return nil
+		}
+	}
+
+	for _, name := range []string{orchPtp4lTR, phc2sysProcessName, ts2phcProcessName, orchPtp4lTT} {
+		orch.RegisterProcess(name, record(name), func() {})
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	err := orch.Start(ctx)
+	require.NoError(t, err)
+
+	mu.Lock()
+	order := append([]string{}, startOrder...)
+	mu.Unlock()
+
+	assert.Equal(t, []string{orchPtp4lTR, phc2sysProcessName, ts2phcProcessName, orchPtp4lTT}, order,
+		"T-BC processes must start in phased order")
+}
+
+func TestIntegration_TBCLifecycle_StartExitRestartStop(t *testing.T) {
+	t.Parallel()
+
+	sourceProvider := &mockPTPSourceState{state: event.PTP_LOCKED, offset: 10}
+	processState := &mockProcessState{running: map[string]bool{}}
+	bcObserver := &mockBCState{state: event.PTP_LOCKED}
+
+	plan := NewTBCStartupPlan(sourceProvider, processState, bcObserver, 100, 3)
+	orch := NewProcessOrchestrator(plan, WithPollInterval(5*time.Millisecond))
+
+	var mu sync.Mutex
+	startCount := map[string]int{}
+	stopCount := map[string]int{}
+
+	for _, name := range []string{orchPtp4lTR, phc2sysProcessName, ts2phcProcessName, orchPtp4lTT} {
+		n := name
+		orch.RegisterProcess(n,
+			func() error {
+				mu.Lock()
+				startCount[n]++
+				mu.Unlock()
+				processState.mu.Lock()
+				processState.running[n] = true
+				processState.mu.Unlock()
+				return nil
+			},
+			func() {
+				mu.Lock()
+				stopCount[n]++
+				mu.Unlock()
+				processState.mu.Lock()
+				processState.running[n] = false
+				processState.mu.Unlock()
+			},
+		)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	err := orch.Start(ctx)
+	require.NoError(t, err)
+
+	for _, name := range []string{orchPtp4lTR, phc2sysProcessName, ts2phcProcessName, orchPtp4lTT} {
+		assert.True(t, orch.IsRunning(name), "%s should be running after start", name)
+	}
+
+	exitTime := time.Now()
+	orch.OnProcessExit(phc2sysProcessName, exitTime)
+	assert.False(t, orch.IsRunning(phc2sysProcessName))
+
+	restartTime := exitTime.Add(2 * time.Second)
+	result := orch.OnProcessRestart(phc2sysProcessName, restartTime)
+	assert.True(t, orch.IsRunning(phc2sysProcessName), "phc2sys should be running after restart")
+	assert.Equal(t, 2*time.Second, result.Downtime)
+	assert.False(t, result.ThresholdExceeded)
+
+	orch.Stop()
+
+	for _, name := range []string{orchPtp4lTR, phc2sysProcessName, ts2phcProcessName, orchPtp4lTT} {
+		assert.False(t, orch.IsRunning(name), "%s should be stopped", name)
+	}
+
+	mu.Lock()
+	for _, name := range []string{orchPtp4lTR, phc2sysProcessName, ts2phcProcessName, orchPtp4lTT} {
+		assert.Equal(t, 1, startCount[name], "%s start count", name)
+		assert.Equal(t, 1, stopCount[name], "%s stop count", name)
+	}
+	mu.Unlock()
+}
+
+func TestIntegration_TBCPreconditionGating(t *testing.T) {
+	t.Parallel()
+
+	sourceProvider := &mockPTPSourceState{state: event.PTP_FREERUN, offset: 500}
+	processState := &mockProcessState{running: map[string]bool{}}
+	bcObserver := &mockBCState{state: event.PTP_FREERUN}
+
+	plan := NewTBCStartupPlan(sourceProvider, processState, bcObserver, 100, 3)
+	orch := NewProcessOrchestrator(plan, WithPollInterval(5*time.Millisecond))
+
+	var mu sync.Mutex
+	var startOrder []string
+	for _, name := range []string{orchPtp4lTR, phc2sysProcessName, ts2phcProcessName, orchPtp4lTT} {
+		n := name
+		orch.RegisterProcess(n,
+			func() error {
+				mu.Lock()
+				startOrder = append(startOrder, n)
+				mu.Unlock()
+				processState.mu.Lock()
+				processState.running[n] = true
+				processState.mu.Unlock()
+				return nil
+			},
+			func() {},
+		)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	err := orch.Start(ctx)
+	assert.Error(t, err, "should timeout because PTP source is not qualified")
+
+	mu.Lock()
+	assert.Equal(t, []string{orchPtp4lTR}, startOrder,
+		"only ptp4l-tr should start; phc2sys blocked by precondition")
+	mu.Unlock()
+}
+
+func TestIntegration_DowntimeThresholdExceeded(t *testing.T) {
+	t.Parallel()
+
+	sourceProvider := &mockPTPSourceState{state: event.PTP_LOCKED, offset: 10}
+	processState := &mockProcessState{running: map[string]bool{}}
+	bcObserver := &mockBCState{state: event.PTP_LOCKED}
+
+	plan := NewTBCStartupPlan(sourceProvider, processState, bcObserver, 100, 3)
+	orch := NewProcessOrchestrator(plan, WithPollInterval(5*time.Millisecond))
+
+	for _, name := range []string{orchPtp4lTR, phc2sysProcessName, ts2phcProcessName, orchPtp4lTT} {
+		n := name
+		orch.RegisterProcess(n,
+			func() error {
+				processState.mu.Lock()
+				processState.running[n] = true
+				processState.mu.Unlock()
+				return nil
+			},
+			func() {},
+		)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	err := orch.Start(ctx)
+	require.NoError(t, err)
+
+	exitTime := time.Now()
+	orch.OnProcessExit(orchPtp4lTR, exitTime)
+
+	restartTime := exitTime.Add(10 * time.Second)
+	result := orch.OnProcessRestart(orchPtp4lTR, restartTime)
+
+	assert.True(t, result.ThresholdExceeded,
+		"10s downtime should exceed the 5s default threshold")
+	assert.Equal(t, 10*time.Second, result.Downtime)
+}
+
+func TestIntegration_EventSuppressionWithOrchestrator(t *testing.T) {
+	t.Parallel()
+
+	sourceProvider := &mockPTPSourceState{state: event.PTP_LOCKED, offset: 10}
+	processState := &mockProcessState{running: map[string]bool{}}
+	bcObserver := &mockBCState{state: event.PTP_LOCKED}
+
+	plan := NewTBCStartupPlan(sourceProvider, processState, bcObserver, 100, 3)
+	orch := NewProcessOrchestrator(plan, WithPollInterval(5*time.Millisecond))
+
+	gate := NewEventSuppressionGate(orch.DowntimeTracker(), plan.FailureSemantics)
+
+	assert.True(t, gate.ShouldSuppressEvent(orchPtp4lTR, EventTypeOSClockSyncState),
+		"ptp4l-tr should always suppress E3 per failure semantics")
+
+	assert.False(t, gate.ShouldSuppressEvent(orchPtp4lTT, EventTypePTPStateChange),
+		"ptp4l-tt should never suppress E1 (EmitE1Always)")
+
+	assert.False(t, gate.ShouldSuppressEvent(phc2sysProcessName, EventTypePTPStateChange),
+		"phc2sys should not suppress E1 when not in suppressed state")
+
+	gate.SetSuppressed(phc2sysProcessName, true)
+	assert.True(t, gate.ShouldSuppressEvent(phc2sysProcessName, EventTypePTPStateChange),
+		"phc2sys should suppress events when in silent restart suppression")
+}
+
+// --- Mock implementations for integration tests ---
+
+type mockPTPSourceState struct {
+	mu     sync.Mutex
+	state  event.PTPState
+	offset float64
+}
+
+func (m *mockPTPSourceState) ServoState() event.PTPState {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.state
+}
+
+func (m *mockPTPSourceState) CurrentOffset() float64 {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.offset
+}
+
+type mockProcessState struct {
+	mu      sync.Mutex
+	running map[string]bool
+}
+
+func (m *mockProcessState) IsRunning(name string) bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.running[name]
+}
+
+type mockBCState struct {
+	mu    sync.Mutex
+	state event.PTPState
+}
+
+func (m *mockBCState) CurrentState() event.PTPState {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.state
+}

--- a/pkg/daemon/orchestrator_test.go
+++ b/pkg/daemon/orchestrator_test.go
@@ -1,0 +1,405 @@
+package daemon
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+)
+
+const testClockType = "test"
+
+type fakeTicker struct {
+	ch   chan time.Time
+	done chan struct{}
+}
+
+func (f *fakeTicker) C() <-chan time.Time { return f.ch }
+func (f *fakeTicker) Stop()               { close(f.done) }
+
+type fakeClock struct {
+	mu      sync.Mutex
+	now     time.Time
+	tickers []*fakeTicker
+}
+
+func newFakeClock(now time.Time) *fakeClock {
+	return &fakeClock{now: now}
+}
+
+func (c *fakeClock) Now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.now
+}
+
+func (c *fakeClock) NewTicker(_ time.Duration) Ticker {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	ft := &fakeTicker{
+		ch:   make(chan time.Time, 10),
+		done: make(chan struct{}),
+	}
+	c.tickers = append(c.tickers, ft)
+	return ft
+}
+
+func (c *fakeClock) Tick() {
+	c.mu.Lock()
+	tickers := append([]*fakeTicker(nil), c.tickers...)
+	c.mu.Unlock()
+	for _, t := range tickers {
+		select {
+		case t.ch <- c.Now():
+		default:
+		}
+	}
+}
+
+type startRecord struct {
+	mu    sync.Mutex
+	order []string
+}
+
+func (r *startRecord) append(name string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.order = append(r.order, name)
+}
+
+func (r *startRecord) get() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]string, len(r.order))
+	copy(out, r.order)
+	return out
+}
+
+type controllablePrecondition struct {
+	mu        sync.Mutex
+	satisfied bool
+}
+
+func (c *controllablePrecondition) Satisfied() bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.satisfied
+}
+
+func (c *controllablePrecondition) Name() string { return "controllable" }
+
+func (c *controllablePrecondition) setSatisfied(v bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.satisfied = v
+}
+
+func TestOrchestrator_PhasedStartup(t *testing.T) {
+	t.Parallel()
+	clock := newFakeClock(time.Now())
+	record := &startRecord{}
+
+	preCond2 := &controllablePrecondition{satisfied: false}
+	preCond3 := &controllablePrecondition{satisfied: false}
+
+	plan := &StartupPlan{
+		ClockType: testClockType,
+		Phases: []StartupPhase{
+			{Name: "phase-1", ProcessNames: []string{"proc-a"}, Precondition: &NoPrecondition{}},
+			{Name: "phase-2", ProcessNames: []string{"proc-b"}, Precondition: preCond2},
+			{Name: "phase-3", ProcessNames: []string{"proc-c"}, Precondition: preCond3},
+		},
+		FailureSemantics:  map[string]ProcessFailureSemantics{},
+		DefaultThresholds: map[string]time.Duration{},
+	}
+
+	orch := NewProcessOrchestrator(plan, WithClock(clock), WithPollInterval(10*time.Millisecond))
+
+	for _, name := range []string{"proc-a", "proc-b", "proc-c"} {
+		n := name
+		orch.RegisterProcess(n, func() error {
+			record.append(n)
+			return nil
+		}, func() {})
+	}
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- orch.Start(context.Background())
+	}()
+
+	// Phase 1 completes immediately (NoPrecondition)
+	time.Sleep(20 * time.Millisecond)
+	clock.Tick()
+	time.Sleep(20 * time.Millisecond)
+
+	got := record.get()
+	if len(got) < 1 || got[0] != "proc-a" {
+		t.Fatalf("expected proc-a started first, got %v", got)
+	}
+	if len(got) > 1 {
+		t.Fatalf("proc-b should not have started yet, got %v", got)
+	}
+
+	// Satisfy phase 2
+	preCond2.setSatisfied(true)
+	clock.Tick()
+	time.Sleep(30 * time.Millisecond)
+
+	got = record.get()
+	if len(got) < 2 || got[1] != "proc-b" {
+		t.Fatalf("expected proc-b started second, got %v", got)
+	}
+
+	// Satisfy phase 3
+	preCond3.setSatisfied(true)
+	clock.Tick()
+	time.Sleep(30 * time.Millisecond)
+
+	got = record.get()
+	if len(got) != 3 || got[2] != "proc-c" {
+		t.Fatalf("expected proc-c third, got %v", got)
+	}
+
+	if err := <-errCh; err != nil {
+		t.Fatalf("Start() returned error: %v", err)
+	}
+}
+
+func TestOrchestrator_StopReverseOrder(t *testing.T) {
+	t.Parallel()
+	var stopped []string
+	var mu sync.Mutex
+
+	plan := &StartupPlan{
+		ClockType: testClockType,
+		Phases: []StartupPhase{
+			{Name: "p1", ProcessNames: []string{"a"}, Precondition: &NoPrecondition{}},
+			{Name: "p2", ProcessNames: []string{"b"}, Precondition: &NoPrecondition{}},
+			{Name: "p3", ProcessNames: []string{"c"}, Precondition: &NoPrecondition{}},
+		},
+		FailureSemantics:  map[string]ProcessFailureSemantics{},
+		DefaultThresholds: map[string]time.Duration{},
+	}
+
+	orch := NewProcessOrchestrator(plan, WithPollInterval(1*time.Millisecond))
+
+	for _, name := range []string{"a", "b", "c"} {
+		n := name
+		orch.RegisterProcess(n, func() error { return nil }, func() {
+			mu.Lock()
+			stopped = append(stopped, n)
+			mu.Unlock()
+		})
+	}
+
+	go func() {
+		_ = orch.Start(context.Background())
+	}()
+	time.Sleep(50 * time.Millisecond)
+	orch.Stop()
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(stopped) != 3 {
+		t.Fatalf("expected 3 stops, got %v", stopped)
+	}
+	expected := []string{"c", "b", "a"}
+	for i, want := range expected {
+		if stopped[i] != want {
+			t.Errorf("stop order[%d] = %q, want %q", i, stopped[i], want)
+		}
+	}
+}
+
+func TestOrchestrator_ContextCancellation(t *testing.T) {
+	t.Parallel()
+	clock := newFakeClock(time.Now())
+	blocked := &controllablePrecondition{satisfied: false}
+
+	plan := &StartupPlan{
+		ClockType: testClockType,
+		Phases: []StartupPhase{
+			{Name: "p1", ProcessNames: []string{"a"}, Precondition: blocked},
+		},
+		FailureSemantics:  map[string]ProcessFailureSemantics{},
+		DefaultThresholds: map[string]time.Duration{},
+	}
+
+	orch := NewProcessOrchestrator(plan, WithClock(clock), WithPollInterval(10*time.Millisecond))
+	orch.RegisterProcess("a", func() error { return nil }, func() {})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- orch.Start(ctx)
+	}()
+
+	time.Sleep(20 * time.Millisecond)
+	cancel()
+	clock.Tick()
+
+	select {
+	case err := <-errCh:
+		if err == nil {
+			t.Fatal("expected error from cancelled context")
+		}
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("orchestrator did not stop after context cancellation")
+	}
+}
+
+func TestOrchestrator_RestartBypassesPrecondition(t *testing.T) {
+	t.Parallel()
+	orch := NewProcessOrchestrator(&StartupPlan{
+		ClockType:         "test",
+		Phases:            []StartupPhase{},
+		FailureSemantics:  map[string]ProcessFailureSemantics{},
+		DefaultThresholds: map[string]time.Duration{"proc-x": 5 * time.Second},
+	})
+
+	orch.RegisterProcess("proc-x", func() error { return nil }, func() {})
+
+	now := time.Now()
+	orch.OnProcessExit("proc-x", now)
+	if orch.IsRunning("proc-x") {
+		t.Fatal("process should not be running after exit")
+	}
+
+	result := orch.OnProcessRestart("proc-x", now.Add(2*time.Second))
+	if !orch.IsRunning("proc-x") {
+		t.Fatal("process should be running after restart")
+	}
+	if result.Downtime != 2*time.Second {
+		t.Errorf("downtime = %v, want 2s", result.Downtime)
+	}
+}
+
+func TestOrchestrator_OnProcessExitReturnsSemantics(t *testing.T) {
+	t.Parallel()
+	plan := &StartupPlan{
+		ClockType: testClockType,
+		Phases:    []StartupPhase{},
+		FailureSemantics: map[string]ProcessFailureSemantics{
+			orchPtp4lTR: {EnterHoldover: true, FlipSyncDirection: true},
+		},
+		DefaultThresholds: map[string]time.Duration{},
+	}
+
+	orch := NewProcessOrchestrator(plan)
+	sem := orch.OnProcessExit(orchPtp4lTR, time.Now())
+	if !sem.EnterHoldover || !sem.FlipSyncDirection {
+		t.Errorf("unexpected semantics: %+v", sem)
+	}
+
+	unknown := orch.OnProcessExit("unknown", time.Now())
+	if unknown.EnterHoldover || unknown.FlipSyncDirection {
+		t.Errorf("unknown process should have zero semantics: %+v", unknown)
+	}
+}
+
+func TestOrchestrator_IsRunningImplementsInterface(t *testing.T) {
+	t.Parallel()
+	orch := NewProcessOrchestrator(&StartupPlan{
+		ClockType:         "test",
+		Phases:            []StartupPhase{},
+		FailureSemantics:  map[string]ProcessFailureSemantics{},
+		DefaultThresholds: map[string]time.Duration{},
+	})
+
+	var provider ProcessStateProvider = orch
+	if provider.IsRunning("any") {
+		t.Fatal("should not be running")
+	}
+}
+
+func TestOrchestrator_ParallelProcessesInPhase(t *testing.T) {
+	t.Parallel()
+	record := &startRecord{}
+
+	plan := &StartupPlan{
+		ClockType: testClockType,
+		Phases: []StartupPhase{
+			{
+				Name:         "parallel",
+				ProcessNames: []string{"a", "b", "c"},
+				Precondition: &NoPrecondition{},
+			},
+		},
+		FailureSemantics:  map[string]ProcessFailureSemantics{},
+		DefaultThresholds: map[string]time.Duration{},
+	}
+
+	orch := NewProcessOrchestrator(plan, WithPollInterval(1*time.Millisecond))
+	for _, name := range []string{"a", "b", "c"} {
+		n := name
+		orch.RegisterProcess(n, func() error {
+			record.append(n)
+			return nil
+		}, func() {})
+	}
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- orch.Start(context.Background())
+	}()
+
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Fatalf("Start() error: %v", err)
+		}
+	case <-time.After(1 * time.Second):
+		t.Fatal("Start() did not complete")
+	}
+
+	got := record.get()
+	if len(got) != 3 {
+		t.Fatalf("expected 3 processes started, got %d: %v", len(got), got)
+	}
+}
+
+func TestOrchestrator_DoubleStartError(t *testing.T) {
+	t.Parallel()
+	plan := &StartupPlan{
+		ClockType: testClockType,
+		Phases: []StartupPhase{
+			{Name: "p1", ProcessNames: []string{"a"}, Precondition: &NoPrecondition{}},
+		},
+		FailureSemantics:  map[string]ProcessFailureSemantics{},
+		DefaultThresholds: map[string]time.Duration{},
+	}
+	orch := NewProcessOrchestrator(plan, WithPollInterval(1*time.Millisecond))
+	orch.RegisterProcess("a", func() error { return nil }, func() {})
+
+	go func() {
+		_ = orch.Start(context.Background())
+	}()
+	time.Sleep(30 * time.Millisecond)
+
+	if err := orch.Start(context.Background()); err == nil {
+		t.Fatal("expected error on double start")
+	}
+}
+
+func TestOrchestrator_StartFailure(t *testing.T) {
+	t.Parallel()
+	plan := &StartupPlan{
+		ClockType: testClockType,
+		Phases: []StartupPhase{
+			{Name: "p1", ProcessNames: []string{"a"}, Precondition: &NoPrecondition{}},
+		},
+		FailureSemantics:  map[string]ProcessFailureSemantics{},
+		DefaultThresholds: map[string]time.Duration{},
+	}
+	orch := NewProcessOrchestrator(plan, WithPollInterval(1*time.Millisecond))
+	orch.RegisterProcess("a", func() error {
+		return fmt.Errorf("simulated failure")
+	}, func() {})
+
+	err := orch.Start(context.Background())
+	if err == nil {
+		t.Fatal("expected error from failed process start")
+	}
+}

--- a/pkg/daemon/pmc.go
+++ b/pkg/daemon/pmc.go
@@ -99,6 +99,9 @@ func (pmc *PMCProcess) getAndSetStopped(val bool) bool {
 // CmdStop signals the process to stop.
 func (pmc *PMCProcess) CmdStop() {
 	pmc.getAndSetStopped(true)
+	if pmc.exitCh == nil {
+		return
+	}
 	select {
 	case <-pmc.exitCh:
 	default:

--- a/pkg/daemon/precondition.go
+++ b/pkg/daemon/precondition.go
@@ -1,0 +1,217 @@
+package daemon
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/event"
+)
+
+// StartupPrecondition gates process startup in the T-BC orchestrator.
+// Implementations determine when a process is allowed to start.
+type StartupPrecondition interface {
+	Satisfied() bool
+	Name() string
+}
+
+// BCStateObserver provides the current T-BC FSM state for precondition evaluation.
+type BCStateObserver interface {
+	CurrentState() event.PTPState
+}
+
+// ProcessStateProvider reports whether a named process is currently running.
+type ProcessStateProvider interface {
+	IsRunning(name string) bool
+}
+
+// PTPSourceStateProvider provides servo state and offset data
+// from the ptp4l[TR] process for PTPSourceQualified evaluation.
+type PTPSourceStateProvider interface {
+	ServoState() event.PTPState
+	CurrentOffset() float64
+}
+
+// NoPrecondition always returns true. Used for ptp4l[TR] which has no gate.
+type NoPrecondition struct{}
+
+// Satisfied implements StartupPrecondition.
+func (n *NoPrecondition) Satisfied() bool { return true }
+
+// Name implements StartupPrecondition.
+func (n *NoPrecondition) Name() string { return "none" }
+
+// PTPSourceQualifiedPrecondition evaluates whether the PTP source
+// is qualified: servo locked (s2) and offset below threshold for
+// a configurable number of consecutive samples.
+type PTPSourceQualifiedPrecondition struct {
+	mu               sync.Mutex
+	stateProvider    PTPSourceStateProvider
+	offsetThreshold  float64
+	requiredSamples  int
+	consecutiveCount int
+}
+
+// NewPTPSourceQualifiedPrecondition creates a PTPSourceQualified precondition.
+// offsetThreshold is in nanoseconds; requiredSamples is how many consecutive
+// good readings are needed before qualification.
+func NewPTPSourceQualifiedPrecondition(
+	provider PTPSourceStateProvider,
+	offsetThreshold float64,
+	requiredSamples int,
+) *PTPSourceQualifiedPrecondition {
+	return &PTPSourceQualifiedPrecondition{
+		stateProvider:   provider,
+		offsetThreshold: offsetThreshold,
+		requiredSamples: requiredSamples,
+	}
+}
+
+// Satisfied implements StartupPrecondition.
+func (p *PTPSourceQualifiedPrecondition) Satisfied() bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if p.stateProvider.ServoState() != event.PTP_LOCKED {
+		p.consecutiveCount = 0
+		return false
+	}
+
+	offset := p.stateProvider.CurrentOffset()
+	if offset < 0 {
+		offset = -offset
+	}
+	if offset > p.offsetThreshold {
+		p.consecutiveCount = 0
+		return false
+	}
+
+	p.consecutiveCount++
+	return p.consecutiveCount >= p.requiredSamples
+}
+
+// Name implements StartupPrecondition.
+func (p *PTPSourceQualifiedPrecondition) Name() string {
+	return fmt.Sprintf("PTPSourceQualified(threshold=%.0fns, samples=%d)", p.offsetThreshold, p.requiredSamples)
+}
+
+// ResetCount resets the consecutive sample counter. Used when state regresses.
+func (p *PTPSourceQualifiedPrecondition) ResetCount() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.consecutiveCount = 0
+}
+
+// ProcessRunningPrecondition checks that a named process is in Running state.
+type ProcessRunningPrecondition struct {
+	processName   string
+	stateProvider ProcessStateProvider
+}
+
+// NewProcessRunningPrecondition creates a precondition that checks if a process is running.
+func NewProcessRunningPrecondition(processName string, provider ProcessStateProvider) *ProcessRunningPrecondition {
+	return &ProcessRunningPrecondition{
+		processName:   processName,
+		stateProvider: provider,
+	}
+}
+
+// Satisfied implements StartupPrecondition.
+func (p *ProcessRunningPrecondition) Satisfied() bool {
+	return p.stateProvider.IsRunning(p.processName)
+}
+
+// Name implements StartupPrecondition.
+func (p *ProcessRunningPrecondition) Name() string {
+	return fmt.Sprintf("ProcessRunning(%s)", p.processName)
+}
+
+// BCStatePrecondition is satisfied when the T-BC FSM reaches PTP_LOCKED (S2).
+type BCStatePrecondition struct {
+	observer BCStateObserver
+}
+
+// NewBCStatePrecondition creates a precondition gated on T-BC FSM reaching LOCKED (S2).
+func NewBCStatePrecondition(observer BCStateObserver) *BCStatePrecondition {
+	return &BCStatePrecondition{observer: observer}
+}
+
+// Satisfied implements StartupPrecondition.
+func (b *BCStatePrecondition) Satisfied() bool {
+	return b.observer.CurrentState() == event.PTP_LOCKED
+}
+
+// Name implements StartupPrecondition.
+func (b *BCStatePrecondition) Name() string {
+	return "BCState(S2/LOCKED)"
+}
+
+// CompositePrecondition requires ALL sub-preconditions to be satisfied (AND logic).
+type CompositePrecondition struct {
+	preconditions []StartupPrecondition
+}
+
+// NewCompositePrecondition creates a precondition requiring ALL sub-preconditions (AND logic).
+func NewCompositePrecondition(preconditions ...StartupPrecondition) *CompositePrecondition {
+	return &CompositePrecondition{preconditions: preconditions}
+}
+
+// Satisfied implements StartupPrecondition.
+func (c *CompositePrecondition) Satisfied() bool {
+	for _, p := range c.preconditions {
+		if !p.Satisfied() {
+			return false
+		}
+	}
+	return true
+}
+
+// Name implements StartupPrecondition.
+func (c *CompositePrecondition) Name() string {
+	names := make([]string, len(c.preconditions))
+	for i, p := range c.preconditions {
+		names[i] = p.Name()
+	}
+	return fmt.Sprintf("Composite(%v)", names)
+}
+
+// TimedPrecondition wraps a precondition with a timeout. After the timeout
+// elapses, Satisfied() returns true regardless of the inner precondition state.
+// This prevents indefinite blocking during startup.
+type TimedPrecondition struct {
+	inner     StartupPrecondition
+	timeout   time.Duration
+	startTime time.Time
+	started   bool
+}
+
+// NewTimedPrecondition creates a precondition that falls through after timeout.
+func NewTimedPrecondition(inner StartupPrecondition, timeout time.Duration) *TimedPrecondition {
+	return &TimedPrecondition{
+		inner:   inner,
+		timeout: timeout,
+	}
+}
+
+// Satisfied implements StartupPrecondition.
+func (t *TimedPrecondition) Satisfied() bool {
+	if !t.started {
+		t.startTime = time.Now()
+		t.started = true
+	}
+	if t.inner.Satisfied() {
+		return true
+	}
+	return time.Since(t.startTime) >= t.timeout
+}
+
+// Name implements StartupPrecondition.
+func (t *TimedPrecondition) Name() string {
+	return fmt.Sprintf("Timed(%s, timeout=%s)", t.inner.Name(), t.timeout)
+}
+
+// TimedOut returns true if the precondition was satisfied by timeout rather than
+// the inner condition becoming true.
+func (t *TimedPrecondition) TimedOut() bool {
+	return t.started && !t.inner.Satisfied() && time.Since(t.startTime) >= t.timeout
+}

--- a/pkg/daemon/precondition_test.go
+++ b/pkg/daemon/precondition_test.go
@@ -1,0 +1,270 @@
+package daemon
+
+import (
+	"testing"
+	"time"
+
+	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/event"
+)
+
+type testPTPSourceState struct {
+	servo  event.PTPState
+	offset float64
+}
+
+func (m *testPTPSourceState) ServoState() event.PTPState { return m.servo }
+func (m *testPTPSourceState) CurrentOffset() float64     { return m.offset }
+
+type testProcessState struct {
+	running map[string]bool
+}
+
+func (m *testProcessState) IsRunning(name string) bool { return m.running[name] }
+
+type testBCStateObserver struct {
+	state event.PTPState
+}
+
+func (m *testBCStateObserver) CurrentState() event.PTPState { return m.state }
+
+func TestPrecondition_NoPrecondition(t *testing.T) {
+	t.Parallel()
+	p := &NoPrecondition{}
+	if !p.Satisfied() {
+		t.Fatal("NoPrecondition should always be satisfied")
+	}
+	if p.Name() != "none" {
+		t.Fatalf("expected name 'none', got %q", p.Name())
+	}
+}
+
+func TestPrecondition_PTPSourceQualified(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name            string
+		servo           event.PTPState
+		offsets         []float64
+		threshold       float64
+		requiredSamples int
+		wantSatisfied   bool
+	}{
+		{
+			name:            "not locked",
+			servo:           event.PTP_FREERUN,
+			offsets:         []float64{10, 10, 10},
+			threshold:       100,
+			requiredSamples: 3,
+			wantSatisfied:   false,
+		},
+		{
+			name:            "locked but offset exceeds threshold",
+			servo:           event.PTP_LOCKED,
+			offsets:         []float64{200, 200, 200},
+			threshold:       100,
+			requiredSamples: 3,
+			wantSatisfied:   false,
+		},
+		{
+			name:            "locked, offset ok, enough samples",
+			servo:           event.PTP_LOCKED,
+			offsets:         []float64{50, 50, 50},
+			threshold:       100,
+			requiredSamples: 3,
+			wantSatisfied:   true,
+		},
+		{
+			name:            "locked, offset ok, insufficient samples",
+			servo:           event.PTP_LOCKED,
+			offsets:         []float64{50, 50},
+			threshold:       100,
+			requiredSamples: 3,
+			wantSatisfied:   false,
+		},
+		{
+			name:            "negative offset within threshold",
+			servo:           event.PTP_LOCKED,
+			offsets:         []float64{-50, -50, -50},
+			threshold:       100,
+			requiredSamples: 3,
+			wantSatisfied:   true,
+		},
+		{
+			name:            "offset crosses threshold mid-sequence resets count",
+			servo:           event.PTP_LOCKED,
+			offsets:         []float64{50, 50, 200, 50, 50, 50},
+			threshold:       100,
+			requiredSamples: 3,
+			wantSatisfied:   true,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			provider := &testPTPSourceState{servo: tc.servo}
+			p := NewPTPSourceQualifiedPrecondition(provider, tc.threshold, tc.requiredSamples)
+
+			var result bool
+			for _, offset := range tc.offsets {
+				provider.offset = offset
+				result = p.Satisfied()
+			}
+			if result != tc.wantSatisfied {
+				t.Errorf("Satisfied() = %v, want %v", result, tc.wantSatisfied)
+			}
+		})
+	}
+}
+
+func TestPrecondition_PTPSourceQualified_ResetCount(t *testing.T) {
+	t.Parallel()
+	provider := &testPTPSourceState{servo: event.PTP_LOCKED, offset: 10}
+	p := NewPTPSourceQualifiedPrecondition(provider, 100, 3)
+
+	p.Satisfied()
+	p.Satisfied()
+	p.ResetCount()
+	if p.Satisfied() {
+		t.Fatal("should not be satisfied after reset with only 1 sample")
+	}
+}
+
+func TestPrecondition_ProcessRunning(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		process string
+		running map[string]bool
+		want    bool
+	}{
+		{
+			name:    "process is running",
+			process: phc2sysProcessName,
+			running: map[string]bool{phc2sysProcessName: true},
+			want:    true,
+		},
+		{
+			name:    "process is not running",
+			process: phc2sysProcessName,
+			running: map[string]bool{phc2sysProcessName: false},
+			want:    false,
+		},
+		{
+			name:    "process not in map",
+			process: ts2phcProcessName,
+			running: map[string]bool{},
+			want:    false,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			provider := &testProcessState{running: tc.running}
+			p := NewProcessRunningPrecondition(tc.process, provider)
+			if got := p.Satisfied(); got != tc.want {
+				t.Errorf("Satisfied() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestPrecondition_BCState(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name  string
+		state event.PTPState
+		want  bool
+	}{
+		{"locked satisfies", event.PTP_LOCKED, true},
+		{"freerun does not satisfy", event.PTP_FREERUN, false},
+		{"holdover does not satisfy", event.PTP_HOLDOVER, false},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			obs := &testBCStateObserver{state: tc.state}
+			p := NewBCStatePrecondition(obs)
+			if got := p.Satisfied(); got != tc.want {
+				t.Errorf("Satisfied() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestPrecondition_Composite(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name          string
+		preconditions []StartupPrecondition
+		wantSatisfied bool
+	}{
+		{
+			name:          "all satisfied",
+			preconditions: []StartupPrecondition{&NoPrecondition{}, &NoPrecondition{}},
+			wantSatisfied: true,
+		},
+		{
+			name: "one unsatisfied",
+			preconditions: []StartupPrecondition{
+				&NoPrecondition{},
+				NewProcessRunningPrecondition("x", &testProcessState{running: map[string]bool{}}),
+			},
+			wantSatisfied: false,
+		},
+		{
+			name:          "empty composite",
+			preconditions: []StartupPrecondition{},
+			wantSatisfied: true,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			p := NewCompositePrecondition(tc.preconditions...)
+			if got := p.Satisfied(); got != tc.wantSatisfied {
+				t.Errorf("Satisfied() = %v, want %v", got, tc.wantSatisfied)
+			}
+		})
+	}
+}
+
+func TestPrecondition_Timed(t *testing.T) {
+	t.Parallel()
+
+	t.Run("inner satisfied before timeout", func(t *testing.T) {
+		t.Parallel()
+		inner := &NoPrecondition{}
+		p := NewTimedPrecondition(inner, 1*time.Second)
+		if !p.Satisfied() {
+			t.Fatal("should be satisfied immediately when inner is satisfied")
+		}
+		if p.TimedOut() {
+			t.Fatal("should not be timed out")
+		}
+	})
+
+	t.Run("timeout triggers when inner unsatisfied", func(t *testing.T) {
+		t.Parallel()
+		provider := &testProcessState{running: map[string]bool{}}
+		inner := NewProcessRunningPrecondition("x", provider)
+		p := NewTimedPrecondition(inner, 10*time.Millisecond)
+
+		if p.Satisfied() {
+			t.Fatal("should not be satisfied initially")
+		}
+		time.Sleep(20 * time.Millisecond)
+		if !p.Satisfied() {
+			t.Fatal("should be satisfied after timeout")
+		}
+		if !p.TimedOut() {
+			t.Fatal("should report timed out")
+		}
+	})
+}

--- a/pkg/daemon/ptpdev.go
+++ b/pkg/daemon/ptpdev.go
@@ -107,7 +107,7 @@ func GetDevStatusUpdate(nodePTPDev *ptpv1.NodePtpDevice) (*ptpv1.NodePtpDevice, 
 		if dev.Name == nicDefaultPort[nicBase] {
 			ptpnetwork.LogStructuredHardwareInfo(dev.Name, dev.HardwareInfo)
 		} else {
-			glog.Infof("PTP Device: %s (PCI: %s, same NIC as %s)", dev.Name, dev.HardwareInfo.PCIAddress, nicDefaultPort[nicBase])
+			glog.V(14).Infof("PTP Device: %s (PCI: %s, same NIC as %s)", dev.Name, dev.HardwareInfo.PCIAddress, nicDefaultPort[nicBase])
 		}
 	}
 

--- a/pkg/daemon/ready.go
+++ b/pkg/daemon/ready.go
@@ -104,6 +104,13 @@ func (h metricHandler) ServeHTTP(w http.ResponseWriter, _ *http.Request) {
 		}
 		return
 	}
+
+	if h.tracker.processManager.ShouldSuppressEvent("ts2phc", EventTypeClockClassChange) {
+		glog.V(14).Info("/emit-logs: skipping replay during process suppression window")
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+
 	w.WriteHeader(http.StatusOK)
 
 	// Emit replay data synchronously so the live gate is only opened after

--- a/pkg/daemon/startup_plans.go
+++ b/pkg/daemon/startup_plans.go
@@ -1,0 +1,130 @@
+package daemon
+
+import "time"
+
+const (
+	orchPtp4lTR      = "ptp4l-tr"
+	orchPtp4lTT      = "ptp4l-tt"
+	orchPhasePhc2sys = "phc2sys-start"
+	orchPhaseTs2phc  = "ts2phc-start"
+)
+
+// NewTBCStartupPlan returns the startup plan for Telecom Boundary Clock mode.
+// T-BC order: ptp4l[TR] → phc2sys → ts2phc → ptp4l[TT]
+func NewTBCStartupPlan(
+	ptpSourceProvider PTPSourceStateProvider,
+	processStateProvider ProcessStateProvider,
+	bcStateObserver BCStateObserver,
+	offsetThreshold float64,
+	requiredSamples int,
+) *StartupPlan {
+	return &StartupPlan{
+		ClockType: "T-BC",
+		Phases: []StartupPhase{
+			{
+				Name:         orchPtp4lTR + "-start",
+				ProcessNames: []string{orchPtp4lTR},
+				Precondition: &NoPrecondition{},
+			},
+			{
+				Name:         orchPhasePhc2sys,
+				ProcessNames: []string{phc2sysProcessName},
+				Precondition: NewPTPSourceQualifiedPrecondition(ptpSourceProvider, offsetThreshold, requiredSamples),
+			},
+			{
+				Name:         orchPhaseTs2phc,
+				ProcessNames: []string{ts2phcProcessName},
+				Precondition: NewCompositePrecondition(
+					NewPTPSourceQualifiedPrecondition(ptpSourceProvider, offsetThreshold, requiredSamples),
+					NewProcessRunningPrecondition(phc2sysProcessName, processStateProvider),
+				),
+			},
+			{
+				Name:         orchPtp4lTT + "-start",
+				ProcessNames: []string{orchPtp4lTT},
+				Precondition: NewBCStatePrecondition(bcStateObserver),
+			},
+		},
+		FailureSemantics: map[string]ProcessFailureSemantics{
+			orchPtp4lTR: {
+				EnterHoldover:     true,
+				FlipSyncDirection: true,
+				SuppressE3Always:  true,
+			},
+			orchPtp4lTT: {
+				EmitE1Always: true,
+			},
+			ts2phcProcessName: {
+				SilentRestart: true,
+			},
+			phc2sysProcessName: {
+				SilentRestart:    true,
+				SuppressE3Always: true,
+			},
+		},
+		DefaultThresholds: map[string]time.Duration{
+			orchPtp4lTR:        5 * time.Second,
+			orchPtp4lTT:        5 * time.Second,
+			phc2sysProcessName: 5 * time.Second,
+			ts2phcProcessName:  5 * time.Second,
+		},
+	}
+}
+
+// NewTGMStartupPlan returns the startup plan for Telecom Grandmaster mode.
+// T-GM order: ts2phc → ptp4l → phc2sys → synce4l
+// GNSS monitor (gpsd/gpspipe) and DPLL monitors are depProcesses of ts2phc,
+// started automatically by the existing depProcess mechanism.
+func NewTGMStartupPlan(
+	ts2phcStateProvider PTPSourceStateProvider,
+	processStateProvider ProcessStateProvider,
+	offsetThreshold float64,
+	requiredSamples int,
+) *StartupPlan {
+	return &StartupPlan{
+		ClockType: "T-GM",
+		Phases: []StartupPhase{
+			{
+				Name:         orchPhaseTs2phc,
+				ProcessNames: []string{ts2phcProcessName},
+				Precondition: &NoPrecondition{},
+			},
+			{
+				Name:         ptp4lProcessName + "-start",
+				ProcessNames: []string{ptp4lProcessName},
+				Precondition: NewProcessRunningPrecondition(ts2phcProcessName, processStateProvider),
+			},
+			{
+				Name:         orchPhasePhc2sys,
+				ProcessNames: []string{phc2sysProcessName},
+				Precondition: NewPTPSourceQualifiedPrecondition(ts2phcStateProvider, offsetThreshold, requiredSamples),
+			},
+			{
+				Name:         syncEProcessName + "-start",
+				ProcessNames: []string{syncEProcessName},
+				Precondition: &NoPrecondition{},
+			},
+		},
+		FailureSemantics: map[string]ProcessFailureSemantics{
+			ts2phcProcessName: {
+				EnterHoldover: true,
+			},
+			ptp4lProcessName: {
+				EmitE1Always: true,
+			},
+			phc2sysProcessName: {
+				SilentRestart:    true,
+				SuppressE3Always: true,
+			},
+			syncEProcessName: {
+				SilentRestart: true,
+			},
+		},
+		DefaultThresholds: map[string]time.Duration{
+			ts2phcProcessName:  5 * time.Second,
+			ptp4lProcessName:   5 * time.Second,
+			phc2sysProcessName: 5 * time.Second,
+			syncEProcessName:   5 * time.Second,
+		},
+	}
+}

--- a/pkg/daemon/startup_plans_test.go
+++ b/pkg/daemon/startup_plans_test.go
@@ -1,0 +1,195 @@
+package daemon
+
+import (
+	"testing"
+	"time"
+)
+
+func TestStartupPlan_TBC(t *testing.T) {
+	t.Parallel()
+	ptpSource := &testPTPSourceState{}
+	processState := &testProcessState{running: map[string]bool{}}
+	bcObserver := &testBCStateObserver{}
+
+	plan := NewTBCStartupPlan(ptpSource, processState, bcObserver, 100, 3)
+
+	t.Run("clock type", func(t *testing.T) {
+		t.Parallel()
+		if plan.ClockType != "T-BC" {
+			t.Errorf("ClockType = %q, want T-BC", plan.ClockType)
+		}
+	})
+
+	t.Run("phase count", func(t *testing.T) {
+		t.Parallel()
+		if len(plan.Phases) != 4 {
+			t.Fatalf("expected 4 phases, got %d", len(plan.Phases))
+		}
+	})
+
+	t.Run("phase order", func(t *testing.T) {
+		t.Parallel()
+		expected := []struct {
+			name  string
+			procs []string
+		}{
+			{orchPtp4lTR + "-start", []string{orchPtp4lTR}},
+			{orchPhasePhc2sys, []string{phc2sysProcessName}},
+			{orchPhaseTs2phc, []string{ts2phcProcessName}},
+			{orchPtp4lTT + "-start", []string{orchPtp4lTT}},
+		}
+		for i, exp := range expected {
+			phase := plan.Phases[i]
+			if phase.Name != exp.name {
+				t.Errorf("phase[%d].Name = %q, want %q", i, phase.Name, exp.name)
+			}
+			if len(phase.ProcessNames) != len(exp.procs) {
+				t.Errorf("phase[%d].ProcessNames = %v, want %v", i, phase.ProcessNames, exp.procs)
+				continue
+			}
+			for j, p := range exp.procs {
+				if phase.ProcessNames[j] != p {
+					t.Errorf("phase[%d].ProcessNames[%d] = %q, want %q", i, j, phase.ProcessNames[j], p)
+				}
+			}
+		}
+	})
+
+	t.Run("failure semantics", func(t *testing.T) {
+		t.Parallel()
+		tests := []struct {
+			proc string
+			want ProcessFailureSemantics
+		}{
+			{orchPtp4lTR, ProcessFailureSemantics{EnterHoldover: true, FlipSyncDirection: true, SuppressE3Always: true}},
+			{orchPtp4lTT, ProcessFailureSemantics{EmitE1Always: true}},
+			{ts2phcProcessName, ProcessFailureSemantics{SilentRestart: true}},
+			{phc2sysProcessName, ProcessFailureSemantics{SilentRestart: true, SuppressE3Always: true}},
+		}
+		for _, tc := range tests {
+			tc := tc
+			t.Run(tc.proc, func(t *testing.T) {
+				t.Parallel()
+				got, exists := plan.FailureSemantics[tc.proc]
+				if !exists {
+					t.Fatalf("no failure semantics for %q", tc.proc)
+				}
+				if got != tc.want {
+					t.Errorf("FailureSemantics[%q] = %+v, want %+v", tc.proc, got, tc.want)
+				}
+			})
+		}
+	})
+
+	t.Run("default thresholds", func(t *testing.T) {
+		t.Parallel()
+		for _, proc := range []string{orchPtp4lTR, orchPtp4lTT, phc2sysProcessName, ts2phcProcessName} {
+			if plan.DefaultThresholds[proc] != 5*time.Second {
+				t.Errorf("DefaultThresholds[%q] = %v, want 5s", proc, plan.DefaultThresholds[proc])
+			}
+		}
+	})
+
+	t.Run("phase 1 has NoPrecondition", func(t *testing.T) {
+		t.Parallel()
+		if !plan.Phases[0].Precondition.Satisfied() {
+			t.Error("phase 1 precondition should always be satisfied")
+		}
+	})
+}
+
+func TestStartupPlan_TGM(t *testing.T) {
+	t.Parallel()
+	ts2phcState := &testPTPSourceState{}
+	processState := &testProcessState{running: map[string]bool{}}
+
+	plan := NewTGMStartupPlan(ts2phcState, processState, 100, 3)
+
+	t.Run("clock type", func(t *testing.T) {
+		t.Parallel()
+		if plan.ClockType != "T-GM" {
+			t.Errorf("ClockType = %q, want T-GM", plan.ClockType)
+		}
+	})
+
+	t.Run("phase count", func(t *testing.T) {
+		t.Parallel()
+		if len(plan.Phases) != 4 {
+			t.Fatalf("expected 4 phases, got %d", len(plan.Phases))
+		}
+	})
+
+	t.Run("phase order", func(t *testing.T) {
+		t.Parallel()
+		expected := []struct {
+			name  string
+			procs []string
+		}{
+			{orchPhaseTs2phc, []string{ts2phcProcessName}},
+			{ptp4lProcessName + "-start", []string{ptp4lProcessName}},
+			{orchPhasePhc2sys, []string{phc2sysProcessName}},
+			{syncEProcessName + "-start", []string{syncEProcessName}},
+		}
+		for i, exp := range expected {
+			phase := plan.Phases[i]
+			if phase.Name != exp.name {
+				t.Errorf("phase[%d].Name = %q, want %q", i, phase.Name, exp.name)
+			}
+			if len(phase.ProcessNames) != len(exp.procs) {
+				t.Errorf("phase[%d].ProcessNames = %v, want %v", i, phase.ProcessNames, exp.procs)
+				continue
+			}
+			for j, p := range exp.procs {
+				if phase.ProcessNames[j] != p {
+					t.Errorf("phase[%d].ProcessNames[%d] = %q, want %q", i, j, phase.ProcessNames[j], p)
+				}
+			}
+		}
+	})
+
+	t.Run("failure semantics", func(t *testing.T) {
+		t.Parallel()
+		tests := []struct {
+			proc string
+			want ProcessFailureSemantics
+		}{
+			{ts2phcProcessName, ProcessFailureSemantics{EnterHoldover: true}},
+			{ptp4lProcessName, ProcessFailureSemantics{EmitE1Always: true}},
+			{phc2sysProcessName, ProcessFailureSemantics{SilentRestart: true, SuppressE3Always: true}},
+			{syncEProcessName, ProcessFailureSemantics{SilentRestart: true}},
+		}
+		for _, tc := range tests {
+			tc := tc
+			t.Run(tc.proc, func(t *testing.T) {
+				t.Parallel()
+				got, exists := plan.FailureSemantics[tc.proc]
+				if !exists {
+					t.Fatalf("no failure semantics for %q", tc.proc)
+				}
+				if got != tc.want {
+					t.Errorf("FailureSemantics[%q] = %+v, want %+v", tc.proc, got, tc.want)
+				}
+			})
+		}
+	})
+
+	t.Run("default thresholds", func(t *testing.T) {
+		t.Parallel()
+		for _, proc := range []string{ts2phcProcessName, ptp4lProcessName, phc2sysProcessName, syncEProcessName} {
+			if plan.DefaultThresholds[proc] != 5*time.Second {
+				t.Errorf("DefaultThresholds[%q] = %v, want 5s", proc, plan.DefaultThresholds[proc])
+			}
+		}
+	})
+
+	t.Run("phase 1 ts2phc no precondition", func(t *testing.T) {
+		t.Parallel()
+		phase := plan.Phases[0]
+		if len(phase.ProcessNames) != 1 || phase.ProcessNames[0] != ts2phcProcessName {
+			t.Fatalf("phase 1 should be ts2phc, got %v", phase.ProcessNames)
+		}
+		if !phase.Precondition.Satisfied() {
+			t.Error("phase 1 precondition should always be satisfied")
+		}
+	})
+}

--- a/pkg/dpll-netlink/dpll-uapi.go
+++ b/pkg/dpll-netlink/dpll-uapi.go
@@ -400,7 +400,7 @@ type PinInfoHR struct {
 	EsyncPulse                   int64               `json:"esyncPulse,omitempty"`
 	ReferenceSync                []ReferenceSync     `json:"referenceSync,omitempty"`
 	PhaseAdjustGran              uint32              `json:"phaseAdjustGran,omitempty"`
-	FractionalFrequencyOffsetPPT int                 `json:"fractionalFrequencyOffsetPPT,omitempty"`
+	FractionalFrequencyOffsetPPT int64               `json:"fractionalFrequencyOffsetPPT,omitempty"`
 	MeasuredFrequencyHz          float64             `json:"measuredFrequencyHz,omitempty"`
 	Operstate                    string              `json:"operstate,omitempty"`
 }
@@ -414,7 +414,7 @@ type PinParentDeviceHR struct {
 	PhaseOffsetPs                float64 `json:"phaseOffsetPs"`
 	Operstate                    string  `json:"operstate,omitempty"`
 	FractionalFrequencyOffset    int     `json:"fractionalFrequencyOffset,omitempty"`
-	FractionalFrequencyOffsetPPT int     `json:"fractionalFrequencyOffsetPPT,omitempty"`
+	FractionalFrequencyOffsetPPT int64   `json:"fractionalFrequencyOffsetPPT,omitempty"`
 }
 
 // PinParentPin contains nested netlink attributes.

--- a/pkg/dpll-netlink/dpll.go
+++ b/pkg/dpll-netlink/dpll.go
@@ -4,12 +4,28 @@ package dpll_netlink
 
 import (
 	"errors"
+	"fmt"
 	"log"
 	"math"
 
 	"github.com/mdlayher/genetlink"
 	"github.com/mdlayher/netlink"
 )
+
+// decodeSint decodes a netlink NLA_SINT attribute. The kernel's nla_put_sint
+// encodes signed values as either 4 or 8 bytes depending on magnitude, so
+// fixed-width Int32/Int64 decoders reject valid payloads.
+func decodeSint(ad *netlink.AttributeDecoder) (int64, error) {
+	b := ad.Bytes()
+	switch len(b) {
+	case 4:
+		return int64(int32(ad.ByteOrder.Uint32(b))), nil
+	case 8:
+		return int64(ad.ByteOrder.Uint64(b)), nil
+	default:
+		return 0, fmt.Errorf("netlink: attribute %d is not a sint; length: %d", ad.Type(), len(b))
+	}
+}
 
 // A Conn is a connection to netlink family "dpll".
 type Conn struct {
@@ -331,9 +347,17 @@ func ParsePinReplies(msgs []genetlink.Message) ([]*PinInfo, error) {
 						case DpllPinOperstate:
 							temp.Operstate = ad.Uint32()
 						case DpllPinFractionalFrequencyOffset:
-							temp.FractionalFrequencyOffset = int(ad.Int32())
+							v, err := decodeSint(ad)
+							if err != nil {
+								return err
+							}
+							temp.FractionalFrequencyOffset = int(v)
 						case DpllPinFractionalFrequencyOffsetPPT:
-							temp.FractionalFrequencyOffsetPPT = int(ad.Int32())
+							v, err := decodeSint(ad)
+							if err != nil {
+								return err
+							}
+							temp.FractionalFrequencyOffsetPPT = v
 						}
 
 					}
@@ -363,7 +387,11 @@ func ParsePinReplies(msgs []genetlink.Message) ([]*PinInfo, error) {
 			case DpllPinPhaseOffset:
 				reply.PhaseOffset = ad.Int64()
 			case DpllPinFractionalFrequencyOffset:
-				reply.FractionalFrequencyOffset = int(ad.Int32())
+				v, err := decodeSint(ad)
+				if err != nil {
+					return nil, err
+				}
+				reply.FractionalFrequencyOffset = int(v)
 			case DpllPinEsyncFrequency:
 				reply.EsyncFrequency = ad.Int64()
 			case DpllPinEsyncFrequencySupported:
@@ -397,7 +425,11 @@ func ParsePinReplies(msgs []genetlink.Message) ([]*PinInfo, error) {
 			case DpllPinPhaseAdjustGran:
 				reply.PhaseAdjustGran = ad.Uint32()
 			case DpllPinFractionalFrequencyOffsetPPT:
-				reply.FractionalFrequencyOffsetPPT = int(ad.Int32())
+				v, err := decodeSint(ad)
+				if err != nil {
+					return nil, err
+				}
+				reply.FractionalFrequencyOffsetPPT = v
 			case DpllPinMeasuredFrequency:
 				reply.MeasuredFrequency = ad.Uint64()
 			case DpllPinOperstate:
@@ -498,7 +530,7 @@ type PinInfo struct {
 	PhaseAdjust                  int32
 	PhaseOffset                  int64
 	FractionalFrequencyOffset    int
-	FractionalFrequencyOffsetPPT int
+	FractionalFrequencyOffsetPPT int64
 	EsyncFrequency               int64
 	EsyncFrequencySupported      []FrequencyRange
 	EsyncPulse                   uint32
@@ -529,7 +561,7 @@ type PinParentDevice struct {
 	PhaseOffset                  int64
 	Operstate                    uint32
 	FractionalFrequencyOffset    int
-	FractionalFrequencyOffsetPPT int
+	FractionalFrequencyOffsetPPT int64
 }
 
 // PinParentPin contains nested netlink attributes.

--- a/pkg/dpll-netlink/dpll_test.go
+++ b/pkg/dpll-netlink/dpll_test.go
@@ -92,20 +92,54 @@ func Test_EncodePinControl(t *testing.T) {
 // TestParsePinReplies_DpllPinFractionalFrequencyOffsetPPT verifies that
 // ParsePinReplies correctly decodes the DpllPinFractionalFrequencyOffsetPPT
 // attribute (FFO in parts per trillion) into PinInfo.FractionalFrequencyOffsetPPT.
+// Kernel nla_put_sint may encode as 4 or 8 bytes; both must decode.
 func TestParsePinReplies_DpllPinFractionalFrequencyOffsetPPT(t *testing.T) {
 	tests := []struct {
-		name   string
-		ffoPPT int32
+		name    string
+		encode  func(*netlink.AttributeEncoder)
+		wantPPT int64
 	}{
-		{"positive value", 12345},
-		{"zero", 0},
-		{"negative value", -999},
+		{
+			name: "int32-width positive",
+			encode: func(ae *netlink.AttributeEncoder) {
+				ae.Int32(DpllPinFractionalFrequencyOffsetPPT, 12345)
+			},
+			wantPPT: 12345,
+		},
+		{
+			name: "int32-width zero",
+			encode: func(ae *netlink.AttributeEncoder) {
+				ae.Int32(DpllPinFractionalFrequencyOffsetPPT, 0)
+			},
+			wantPPT: 0,
+		},
+		{
+			name: "int32-width negative",
+			encode: func(ae *netlink.AttributeEncoder) {
+				ae.Int32(DpllPinFractionalFrequencyOffsetPPT, -999)
+			},
+			wantPPT: -999,
+		},
+		{
+			name: "int64-width value beyond int32",
+			encode: func(ae *netlink.AttributeEncoder) {
+				ae.Int64(DpllPinFractionalFrequencyOffsetPPT, 3_000_000_000)
+			},
+			wantPPT: 3_000_000_000,
+		},
+		{
+			name: "int64-width negative",
+			encode: func(ae *netlink.AttributeEncoder) {
+				ae.Int64(DpllPinFractionalFrequencyOffsetPPT, -3_000_000_000)
+			},
+			wantPPT: -3_000_000_000,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ae := netlink.NewAttributeEncoder()
 			ae.Uint32(DpllPinID, 1)
-			ae.Int32(DpllPinFractionalFrequencyOffsetPPT, tt.ffoPPT)
+			tt.encode(ae)
 			payload, err := ae.Encode()
 			assert.NoError(t, err, "encode attributes")
 
@@ -113,7 +147,7 @@ func TestParsePinReplies_DpllPinFractionalFrequencyOffsetPPT(t *testing.T) {
 			replies, err := ParsePinReplies(msgs)
 			assert.NoError(t, err)
 			assert.Len(t, replies, 1)
-			assert.Equal(t, int(tt.ffoPPT), replies[0].FractionalFrequencyOffsetPPT,
+			assert.Equal(t, tt.wantPPT, replies[0].FractionalFrequencyOffsetPPT,
 				"FractionalFrequencyOffsetPPT should match encoded value")
 		})
 	}
@@ -249,7 +283,7 @@ func TestParsePinReplies_ParentDeviceNewFields(t *testing.T) {
 	const parentID = uint32(7)
 	const operstate = uint32(PinOperstateActive)
 	const ffo = int32(-42)
-	const ffoPPT = int32(12345)
+	const ffoPPT = int64(3_000_000_000)
 
 	ae := netlink.NewAttributeEncoder()
 	ae.Uint32(DpllPinID, 1)
@@ -257,7 +291,7 @@ func TestParsePinReplies_ParentDeviceNewFields(t *testing.T) {
 		nae.Uint32(DpllPinParentID, parentID)
 		nae.Uint32(DpllPinOperstate, operstate)
 		nae.Int32(DpllPinFractionalFrequencyOffset, ffo)
-		nae.Int32(DpllPinFractionalFrequencyOffsetPPT, ffoPPT)
+		nae.Int64(DpllPinFractionalFrequencyOffsetPPT, ffoPPT)
 		return nil
 	})
 	payload, err := ae.Encode()
@@ -272,5 +306,5 @@ func TestParsePinReplies_ParentDeviceNewFields(t *testing.T) {
 	assert.Equal(t, parentID, pd.ParentID)
 	assert.Equal(t, operstate, pd.Operstate)
 	assert.Equal(t, int(ffo), pd.FractionalFrequencyOffset)
-	assert.Equal(t, int(ffoPPT), pd.FractionalFrequencyOffsetPPT)
+	assert.Equal(t, ffoPPT, pd.FractionalFrequencyOffsetPPT)
 }

--- a/pkg/dpll/dpll.go
+++ b/pkg/dpll/dpll.go
@@ -377,7 +377,7 @@ func (d *DpllConfig) ActivePhaseOffsetPin(pin *nl.PinInfo) (int, bool) {
 		// New behavior: An input pin is the device synchronization source when its OperState is "active".
 		// Note: In this scenario, the administrative state never exceeds "selectable".
 		if (p.State != nl.PinStateConnected && p.Operstate != nl.PinOperstateActive) || p.Direction != nl.PinDirectionInput {
-			glog.Infof("pin id %d parentID=%d skipped: direction=%s adminState=%s operstate=%s",
+			glog.V(14).Infof("pin id %d parentID=%d skipped: direction=%s adminState=%s operstate=%s",
 				pin.ID, p.ParentID, nl.GetPinDirection(p.Direction), nl.GetPinState(p.State), nl.GetPinOperstate(p.Operstate))
 			continue
 		}

--- a/pkg/dpll/dpll.go
+++ b/pkg/dpll/dpll.go
@@ -402,20 +402,29 @@ func (d *DpllConfig) nlUpdateState(devices []*nl.DoDeviceGetReply, pins []*nl.Pi
 				continue
 			}
 			glog.Info(string(replyHr), " ", d.iface)
-			switch nl.GetDpllType(reply.Type) {
+			dpllType := nl.GetDpllType(reply.Type)
+			lockChanged := false
+			switch dpllType {
 			case "eec":
+				lockChanged = d.frequencyStatus != int64(reply.LockStatus)
 				d.frequencyStatus = int64(reply.LockStatus)
 				glog.Infof("%s (%#x) updating eec to %s (%d)", d.iface, d.clockId, stateName(d.frequencyStatus), d.frequencyStatus)
 				valid = true
 			case "pps":
+				lockChanged = d.phaseStatus != int64(reply.LockStatus)
 				d.phaseStatus = int64(reply.LockStatus)
 				glog.Infof("%s (%#x) updating pps to %s (%d)", d.iface, d.clockId, stateName(d.phaseStatus), d.phaseStatus)
 				valid = true
 			default:
-				glog.Infof("discarding irrelevant dpll type: %s, id %#x", nl.GetDpllType(reply.Type), d.clockId)
+				glog.Infof("discarding irrelevant dpll type: %s, id %#x", dpllType, d.clockId)
 			}
-			nl.LogPinTable(fmt.Sprintf("%s %s->%s", d.iface, nl.GetDpllType(reply.Type), stateName(int64(reply.LockStatus))),
-				reply.ClockID, reply.ID, reply.LockStatus)
+			// Log only the parents of the DPLL that changed (reply.ID), and only
+			// when lock status actually changes. Otherwise SyncInitialState and
+			// MonitorDpllNetlink's initial dump reprint the same EEC+PPS tables.
+			if lockChanged {
+				nl.LogPinTable(fmt.Sprintf("%s %s->%s", d.iface, dpllType, stateName(int64(reply.LockStatus))),
+					reply.ClockID, reply.ID, reply.LockStatus)
+			}
 		}
 	}
 	for _, pin := range pins {

--- a/pkg/event/event.go
+++ b/pkg/event/event.go
@@ -158,27 +158,28 @@ type clockSyncState struct {
 // EventHandler ... event handler to process events
 type EventHandler struct {
 	sync.Mutex
-	nodeName           string
-	stdoutSocket       string
-	stdoutToSocket     bool
-	processChannel     <-chan Event
-	closeCh            chan bool
-	conn               net.Conn   // event socket connection, guarded by connMu
-	connMu             sync.Mutex // separate mutex for conn to avoid deadlocks with embedded sync.Mutex
-	reconnectMu        sync.Mutex // serializes reconnection attempts to prevent leaked connections
-	data               map[string][]*Data
-	offsetMetric       *prometheus.GaugeVec
-	clockMetric        *prometheus.GaugeVec
-	clockClassMetric   *prometheus.GaugeVec
-	clockClass         fbprotocol.ClockClass
-	clockAccuracy      fbprotocol.ClockAccuracy
-	clkSyncState       map[string]*clockSyncState
-	downstreamCancel   map[string]context.CancelFunc // cancels in-flight downstream update goroutines per config
-	outOfSpec          bool                          // is offset out of spec, used for Lost Source,In Spec and OPut of Spec state transitions
-	frequencyTraceable bool                          // will be tru if synce is traceable
-	ReduceLog          bool                          // reduce logs for every announce
-	LeadingClockData   *LeadingClockParams
-	portRole           map[string]map[string]*parser.PTPEvent
+	nodeName               string
+	stdoutSocket           string
+	stdoutToSocket         bool
+	processChannel         <-chan Event
+	closeCh                chan bool
+	conn                   net.Conn   // event socket connection, guarded by connMu
+	connMu                 sync.Mutex // separate mutex for conn to avoid deadlocks with embedded sync.Mutex
+	reconnectMu            sync.Mutex // serializes reconnection attempts to prevent leaked connections
+	data                   map[string][]*Data
+	offsetMetric           *prometheus.GaugeVec
+	clockMetric            *prometheus.GaugeVec
+	clockClassMetric       *prometheus.GaugeVec
+	clockClass             fbprotocol.ClockClass
+	clockAccuracy          fbprotocol.ClockAccuracy
+	clkSyncState           map[string]*clockSyncState
+	downstreamCancel       map[string]context.CancelFunc // cancels in-flight downstream update goroutines per config
+	outOfSpec              bool                          // is offset out of spec, used for Lost Source,In Spec and OPut of Spec state transitions
+	frequencyTraceable     bool                          // will be tru if synce is traceable
+	ReduceLog              bool                          // reduce logs for every announce
+	LeadingClockData       *LeadingClockParams
+	portRole               map[string]map[string]*parser.PTPEvent
+	ShouldSuppressHoldover func(ptpLost, dpllLost bool) bool // set by daemon when orchestrator is active; suppresses LOCKED->HOLDOVER only for ts2phc-related stale data
 }
 
 // getConn returns the current event socket connection under lock.

--- a/pkg/event/event_internal_test.go
+++ b/pkg/event/event_internal_test.go
@@ -776,7 +776,9 @@ func TestIsSourceLostBC_StaleDetailFixed(t *testing.T) {
 			},
 		}
 
-		assert.False(t, e.isSourceLostBC("cfg"), "before source-lost event, ptpLost should be false")
+		// Before source-lost event: PTP source should NOT be lost
+		lost, _, _ := e.isSourceLostBC("cfg")
+		assert.False(t, lost, "before source-lost event, ptpLost should be false")
 
 		ptp4lData.AddEvent(Event{
 			Source: PTP4l,
@@ -788,7 +790,8 @@ func TestIsSourceLostBC_StaleDetailFixed(t *testing.T) {
 		// Without cross-hardware propagation, the stale LOCKED detail on
 		// eno8903 is not overwritten, so isSourceLostBC still sees a LOCKED
 		// port and returns false.
-		assert.False(t, e.isSourceLostBC("cfg"), "stale LOCKED detail on other iface prevents ptpLost")
+		lost2, _, _ := e.isSourceLostBC("cfg")
+		assert.False(t, lost2, "stale LOCKED detail on other iface prevents ptpLost")
 	})
 
 	t.Run("single LOCKED detail keeps source as not lost", func(t *testing.T) {
@@ -810,7 +813,8 @@ func TestIsSourceLostBC_StaleDetailFixed(t *testing.T) {
 				"cfg": {ptp4lData, dpllData},
 			},
 		}
-		assert.False(t, e.isSourceLostBC("cfg"))
+		lost, _, _ := e.isSourceLostBC("cfg")
+		assert.False(t, lost)
 	})
 }
 

--- a/pkg/event/event_tbc.go
+++ b/pkg/event/event_tbc.go
@@ -136,7 +136,7 @@ func (e *EventHandler) updateBCState(event Event) (clockSyncState, bool, bool) {
 
 	isTTSC := (e.LeadingClockData.clockID != "" && e.LeadingClockData.controlledPortsConfig == "")
 
-	glog.Info("current BC state: ", e.clkSyncState[cfgName].state)
+	glog.V(14).Info("current BC state: ", e.clkSyncState[cfgName].state)
 	switch e.clkSyncState[cfgName].state {
 	case PTP_NOTSET, PTP_FREERUN:
 		if !e.isSourceLostBC(cfgName) && e.inSyncCondition(cfgName) {
@@ -512,9 +512,9 @@ func (e *EventHandler) isSourceLostBC(cfgName string) bool {
 				}
 			}
 			if d.ProcessName == DPLL {
-				glog.Infof("isSourceLostBC[%s]", cfgName)
+				glog.V(14).Infof("isSourceLostBC[%s]", cfgName)
 				for _, dd := range d.Details {
-					glog.Infof("  DPLL detail: iface=%s state=%s signalSource=%s sourceLost=%t offset=%d time=%d metrics=%+v", dd.IFace, dd.State, dd.signalSource, dd.sourceLost, dd.Offset, dd.time, dd.Metrics)
+					glog.V(14).Infof("  DPLL detail: iface=%s state=%s signalSource=%s sourceLost=%t offset=%d time=%d metrics=%+v", dd.IFace, dd.State, dd.signalSource, dd.sourceLost, dd.Offset, dd.time, dd.Metrics)
 					if dd.State != PTP_LOCKED {
 						dpllLost = true
 						dpllLostIface = dd.IFace
@@ -647,7 +647,7 @@ func (e *EventHandler) convergeConfig(event Event) Event {
 	if event.Source == PTP4lProcessName {
 		iface := event.IFace
 		ifacePhc := alias.GetPhcGroup(iface)
-		glog.Infof("convergeConfig: ptp4l iface=%s phcGroup=%q original cfgName=%s", iface, ifacePhc, event.CfgName)
+		glog.V(14).Infof("convergeConfig: ptp4l iface=%s phcGroup=%q original cfgName=%s", iface, ifacePhc, event.CfgName)
 		for cfg, dd := range e.data {
 			for _, item := range dd {
 				if item.ProcessName != DPLL {
@@ -657,12 +657,12 @@ func (e *EventHandler) convergeConfig(event Event) Event {
 					dpPhc := alias.GetPhcGroup(dp.IFace)
 					aliasMatch := alias.GetAlias(dp.IFace) == alias.GetAlias(iface)
 					samePhc := dpPhc != "" && dpPhc == ifacePhc
-					glog.Infof("convergeConfig: checking DPLL iface=%s phcGroup=%q alias=%q vs ptp4l alias=%q aliasMatch=%v samePhc=%v",
+					glog.V(14).Infof("convergeConfig: checking DPLL iface=%s phcGroup=%q alias=%q vs ptp4l alias=%q aliasMatch=%v samePhc=%v",
 						dp.IFace, dpPhc, alias.GetAlias(dp.IFace), alias.GetAlias(iface), aliasMatch, samePhc)
 					if aliasMatch || samePhc {
 						// We want to process ptp4l having a separate config with ts2phc and dpll events having ts2phc config
 						// so in the rare occurrence of ptp4l state change we modify the event.CfgName
-						glog.Infof("convergeConfig: remapping ptp4l event cfgName %s -> %s (iface %s matched DPLL iface %s)",
+						glog.V(14).Infof("convergeConfig: remapping ptp4l event cfgName %s -> %s (iface %s matched DPLL iface %s)",
 							event.CfgName, cfg, iface, dp.IFace)
 						event.CfgName = cfg
 					}

--- a/pkg/event/event_tbc.go
+++ b/pkg/event/event_tbc.go
@@ -139,7 +139,7 @@ func (e *EventHandler) updateBCState(event Event) (clockSyncState, bool, bool) {
 	glog.V(14).Info("current BC state: ", e.clkSyncState[cfgName].state)
 	switch e.clkSyncState[cfgName].state {
 	case PTP_NOTSET, PTP_FREERUN:
-		if !e.isSourceLostBC(cfgName) && e.inSyncCondition(cfgName) {
+		if sourceLost, _, _ := e.isSourceLostBC(cfgName); !sourceLost && e.inSyncCondition(cfgName) {
 			e.clkSyncState[cfgName].state = PTP_LOCKED
 			glog.Info("BC FSM: FREERUN to LOCKED")
 			e.LeadingClockData.lastInSpec = true
@@ -151,12 +151,16 @@ func (e *EventHandler) updateBCState(event Event) (clockSyncState, bool, bool) {
 			e.clkSyncState[cfgName].clockClass = protocol.ClockClassFreerun
 			glog.Info("BC FSM: LOCKED to FREERUN")
 			updateDownstreamData = true
-		} else if e.isSourceLostBC(cfgName) {
-			e.clkSyncState[cfgName].state = PTP_HOLDOVER
-			e.clkSyncState[cfgName].clockClass = fbprotocol.ClockClass(135)
-			glog.Info("BC FSM: LOCKED to HOLDOVER")
-			e.LeadingClockData.lastInSpec = true
-			updateDownstreamData = true
+		} else if sourceLost, ptpLost, dpllLost := e.isSourceLostBC(cfgName); sourceLost {
+			if e.ShouldSuppressHoldover != nil && e.ShouldSuppressHoldover(ptpLost, dpllLost) {
+				glog.Info("BC FSM: suppressing LOCKED->HOLDOVER (process restart within threshold)")
+			} else {
+				e.clkSyncState[cfgName].state = PTP_HOLDOVER
+				e.clkSyncState[cfgName].clockClass = fbprotocol.ClockClass(135)
+				glog.Info("BC FSM: LOCKED to HOLDOVER")
+				e.LeadingClockData.lastInSpec = true
+				updateDownstreamData = true
+			}
 		} else {
 			if *e.LeadingClockData.upstreamTimeProperties != *e.LeadingClockData.downstreamTimeProperties {
 				e.LeadingClockData.downstreamTimeProperties = e.LeadingClockData.upstreamTimeProperties
@@ -181,7 +185,7 @@ func (e *EventHandler) updateBCState(event Event) (clockSyncState, bool, bool) {
 			e.clkSyncState[cfgName].clockClass = protocol.ClockClassFreerun
 			glog.Info("BC FSM: HOLDOVER to FREERUN")
 			updateDownstreamData = true
-		case e.inSyncCondition(cfgName) && !e.isSourceLostBC(cfgName):
+		case func() bool { lost, _, _ := e.isSourceLostBC(cfgName); return e.inSyncCondition(cfgName) && !lost }():
 			e.clkSyncState[cfgName].state = PTP_LOCKED
 			glog.Info("BC FSM: HOLDOVER to LOCKED")
 			updateDownstreamData = true
@@ -498,9 +502,9 @@ func (e *EventHandler) inSyncCondition(cfgName string) bool {
 	return false
 }
 
-func (e *EventHandler) isSourceLostBC(cfgName string) bool {
-	ptpLost := true
-	dpllLost := false
+func (e *EventHandler) isSourceLostBC(cfgName string) (lost bool, ptpLost bool, dpllLost bool) {
+	ptpLost = true
+	dpllLost = false
 	dpllLostIface := ""
 	if data, ok := e.data[cfgName]; ok {
 		for _, d := range data {
@@ -524,14 +528,15 @@ func (e *EventHandler) isSourceLostBC(cfgName string) bool {
 			}
 		}
 	}
+	lost = ptpLost || dpllLost
 	glog.Infof("Source %s: ptpLost %t, dpllLost %t %s",
 		func() string {
-			if dpllLost || ptpLost {
+			if lost {
 				return "LOST"
 			}
 			return "NOT LOST"
 		}(), ptpLost, dpllLost, dpllLostIface)
-	return ptpLost || dpllLost
+	return
 }
 
 func (e *EventHandler) getLargestOffset(cfgName string) int64 {

--- a/pkg/hardwareconfig/hardware-vendor/dell/XR8720t/delays.yaml
+++ b/pkg/hardwareconfig/hardware-vendor/dell/XR8720t/delays.yaml
@@ -52,10 +52,10 @@ connections:
   # NAC to Timing Module routing/wiring
   - from: "NAC0 phase out 1kHz"
     to: "DPLL phase in 1kHz"
-    delayPs: -5000
+    delayPs: -8600
   - from: "NAC0 phase out 1Hz"
     to: "DPLL phase in 1Hz"
-    delayPs: -5000
+    delayPs: -8600
 
 
   # DPLL to NAC (during holdover)


### PR DESCRIPTION
Implements a generic, clock-type-agnostic process orchestrator for the linuxptp daemon supervisor. For T-BC mode, it enforces precondition-gated startup order: ptp4l[TR] → phc2sys → ts2phc → ptp4l[TT], where each phase waits for its precondition (PTPSourceQualified, ProcessRunning, BCState S2) before starting the next process.

Key capabilities:
- Phased startup with configurable preconditions per clock type
- Per-process downtime thresholds (from PtpClockThreshold CRD)
- Silent restart for ts2phc/phc2sys: no holdover, no faulty offset, no CEP noise when restart completes within threshold
- Suppression only applies to stale-data artifacts; genuine source loss (DPLL lost or ptp4l port lost) proceeds to holdover normally
- Event data windows preserved during suppression (no Reset sent)
- PTP_PROCESS_STATUS:0 suppressed, :1 always emitted (restart counter stays accurate in CEP metrics)
- /emit-logs replay skipped during suppression window
- T-GM orchestration infrastructure in place but disabled at runtime

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added phased startup support for telecom timing profiles, including ordered process startup and shutdown handling.
  * Introduced smarter event suppression so some status logs are withheld during brief restart windows.
  * Improved readiness handling to avoid replaying certain logs when suppression is active.

* **Bug Fixes**
  * Fixed downtime tracking so restart decisions use configured thresholds consistently.
  * Prevented a nil-channel close issue in process stop handling.

* **Tests**
  * Added broad coverage for startup plans, preconditions, orchestration, and suppression behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->