### PR TITLE
CNF-25385: Add automatic interface name resolution for RHEL 10 npN suffix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	golang.org/x/sync v0.20.0
 	gonum.org/v1/gonum v0.16.0
 	k8s.io/api v0.35.2
+	k8s.io/apiextensions-apiserver v0.35.2
 	k8s.io/apimachinery v0.35.2
 	k8s.io/client-go v0.35.2
 	k8s.io/klog/v2 v2.130.1
@@ -87,7 +88,6 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	howett.net/plist v1.0.0 // indirect
-	k8s.io/apiextensions-apiserver v0.35.2 // indirect
 	k8s.io/kube-openapi v0.0.0-20250910181357-589584f1c912 // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect

--- a/pkg/daemon/config.go
+++ b/pkg/daemon/config.go
@@ -324,6 +324,26 @@ func (conf *Ptp4lConf) AddInterfaceSection(iface string) {
 	conf.setPtp4lConfOption(ifaceSectionName, "", "", false)
 }
 
+// ResolveInterfaceNames resolves interface section names using the given
+// resolver. Non-interface sections (global, nmea, unicast_master_table,
+// synce device sections) are left unchanged.
+func (conf *Ptp4lConf) ResolveInterfaceNames(resolver *network.InterfaceResolver) {
+	for i, section := range conf.sections {
+		name := section.sectionName
+		if name == GlobalSectionName || name == NmeaSectionName || name == UnicastSectionName {
+			continue
+		}
+		inner := getSectionName(name)
+		if strings.HasPrefix(inner, "<") || strings.HasPrefix(inner, "{") {
+			continue
+		}
+		resolved, remapped := resolver.Resolve(inner)
+		if remapped {
+			conf.sections[i].sectionName = fmt.Sprintf("[%s]", resolved)
+		}
+	}
+}
+
 func getSource(isTs2phcMaster string) event.EventSource {
 	if ts2phcMaster, err := strconv.ParseBool(strings.TrimSpace(isTs2phcMaster)); err == nil {
 		if ts2phcMaster {

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -465,6 +465,8 @@ type Daemon struct {
 
 	delayedPhc2sys   atomic.Bool
 	delayedPhc2sysMu sync.Mutex // protects skipInitialStartup on phc2sys processes
+
+	interfaceResolver *ptpnetwork.InterfaceResolver
 }
 
 type initialStateSyncer interface{ SyncInitialState() }
@@ -626,24 +628,25 @@ func New(
 	}
 
 	dn := &Daemon{
-		nodeName:              nodeName,
-		namespace:             namespace,
-		stdoutToSocket:        stdoutToSocket,
-		kubeClient:            kubeClient,
-		ptpClient:             ptpClient,
-		ptpUpdate:             ptpUpdate,
-		pluginManager:         pluginManager,
-		unknownPlugins:        unknownPlugins,
-		hwconfigs:             hwconfigs,
-		hardwareConfigManager: hardwareconfig.NewHardwareConfigManager(kubeClient, namespace),
-		refreshNodePtpDevice:  refreshNodePtpDevice,
-		pmcPollInterval:       pmcPollInterval,
-		processManager:        pm,
-		readyTracker:          tracker,
-		stopCh:                stopCh,
-		saFileWatcher:         saFileWatch,
-		liveGate:              &liveGate{},
+		nodeName:             nodeName,
+		namespace:            namespace,
+		stdoutToSocket:       stdoutToSocket,
+		kubeClient:           kubeClient,
+		ptpClient:            ptpClient,
+		ptpUpdate:            ptpUpdate,
+		pluginManager:        pluginManager,
+		unknownPlugins:       unknownPlugins,
+		hwconfigs:            hwconfigs,
+		interfaceResolver:    ptpnetwork.NewInterfaceResolver(),
+		refreshNodePtpDevice: refreshNodePtpDevice,
+		pmcPollInterval:      pmcPollInterval,
+		processManager:       pm,
+		readyTracker:         tracker,
+		stopCh:               stopCh,
+		saFileWatcher:        saFileWatch,
+		liveGate:             &liveGate{},
 	}
+	dn.hardwareConfigManager = hardwareconfig.NewHardwareConfigManager(kubeClient, namespace, dn.interfaceResolver)
 	pm.daemon = dn
 	return dn
 }
@@ -833,6 +836,11 @@ func (dn *Daemon) applyNodePTPProfiles() error {
 		dn.hardwareConfigManager.SetPtpConfig(ptpConfig)
 		glog.Infof("Updated PtpConfig in hardware config manager with %d profiles (after sorting and reconciliation)", len(dn.ptpUpdate.NodeProfiles))
 	}
+	// Refresh interface resolver so RHEL 10 npN name mapping uses current system state
+	if err := dn.interfaceResolver.Refresh(); err != nil {
+		glog.Warningf("Failed to refresh interface resolver, name resolution may use stale data: %v", err)
+	}
+
 	// TODO: resolve clock IDs, clockType, leadingInterface and upstreamPort from hardware config
 	// (needed to keep code compatibility elsewhere and allow it to work both with hardware config and plugins)
 	for _, profile := range dn.ptpUpdate.NodeProfiles {
@@ -859,6 +867,8 @@ func (dn *Daemon) applyNodePTPProfiles() error {
 		if controlledID, ok := relations[*profile.Name]; ok {
 			profile.PtpSettings["controlledId"] = strconv.Itoa(controlledID)
 		}
+
+		dn.interfaceResolver.ResolveProfileInterfaces(&profile)
 
 		glog.Infof("Calling applyNodePtpProfile for profile %s with runID %d", *profile.Name, runID)
 		err := dn.applyNodePtpProfile(runID, &profile)
@@ -1144,6 +1154,7 @@ func (dn *Daemon) applyNodePtpProfile(runID int, nodeProfile *ptpv1.PtpProfile) 
 			printNodeProfile(nodeProfile)
 			return err
 		}
+		output.ResolveInterfaceNames(dn.interfaceResolver)
 
 		if configOpts == nil || *configOpts == "" {
 			glog.Infof("configOpts empty for profile %s, skipping process: %s", *nodeProfile.Name, pProcess)

--- a/pkg/daemon/daemon_internal_test.go
+++ b/pkg/daemon/daemon_internal_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/event"
 	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/hardwareconfig"
 	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/leap"
+	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/network"
 	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/utils"
 	ptpv1 "github.com/k8snetworkplumbingwg/ptp-operator/api/v1"
 	ptpv2alpha1 "github.com/k8snetworkplumbingwg/ptp-operator/api/v2alpha1"
@@ -51,7 +52,7 @@ func NewDaemonForTests(tracker *ReadyTracker, processManager *ProcessManager) *D
 	return &Daemon{
 		readyTracker:          tracker,
 		processManager:        processManager,
-		hardwareConfigManager: hardwareconfig.NewHardwareConfigManager(fakeClient, "default"),
+		hardwareConfigManager: hardwareconfig.NewHardwareConfigManager(fakeClient, "default", nil),
 		liveGate:              &liveGate{},
 	}
 }
@@ -680,7 +681,7 @@ func TestTBCTransitionCheck_HardwareConfigPath(t *testing.T) {
 
 		// Create a mock Daemon with hardwareConfigManager and set up hardware config
 		fakeClient := fake.NewClientset()
-		hcm := hardwareconfig.NewHardwareConfigManager(fakeClient, "default")
+		hcm := hardwareconfig.NewHardwareConfigManager(fakeClient, "default", nil)
 		err := setupHardwareConfigForTest(hcm, "test-profile", "ens4f0")
 		assert.NoError(t, err, "Should be able to set up hardware config")
 		mockDaemon := &Daemon{
@@ -763,7 +764,7 @@ func TestTBCTransitionCheck_HardwareConfigPath(t *testing.T) {
 
 		// Create a mock Daemon with hardwareConfigManager and set up hardware config
 		fakeClient := fake.NewClientset()
-		hcm := hardwareconfig.NewHardwareConfigManager(fakeClient, "default")
+		hcm := hardwareconfig.NewHardwareConfigManager(fakeClient, "default", nil)
 		err := setupHardwareConfigForTest(hcm, "test-profile", "ens4f0")
 		assert.NoError(t, err, "Should be able to set up hardware config")
 		mockDaemon := &Daemon{
@@ -1011,7 +1012,7 @@ func setupHardwareConfigForTest(hcm *hardwareconfig.HardwareConfigManager, profi
 func createMockPTPStateDetectorForHardwareConfig() *hardwareconfig.PTPStateDetector {
 	// Create a detector using the normal constructor - this properly initializes ptp4lExtractor
 	fakeClient := fake.NewClientset()
-	hcm := hardwareconfig.NewHardwareConfigManager(fakeClient, "default")
+	hcm := hardwareconfig.NewHardwareConfigManager(fakeClient, "default", nil)
 	_ = setupHardwareConfigForTest(hcm, "test-profile", "ens4f0")
 
 	// Create detector - it will automatically populate monitoredPorts from the hardware config
@@ -1070,7 +1071,7 @@ func TestProcessTBCTransitionHardwareConfig_HardwareConfigIntegration(t *testing
 
 	// Create hardware config manager and verify it works with our config
 	fakeClient := fake.NewClientset()
-	hcm := hardwareconfig.NewHardwareConfigManager(fakeClient, "default")
+	hcm := hardwareconfig.NewHardwareConfigManager(fakeClient, "default", nil)
 	err = hcm.UpdateHardwareConfig([]ptpv2alpha1.HardwareConfig{hwConfig})
 	assert.NoError(t, err, "Should be able to update hardware config")
 
@@ -1144,7 +1145,7 @@ func TestProcessTBCTransitionHardwareConfig_ProcessLogFile(t *testing.T) {
 
 	// Create hardware config manager and initialize it
 	fakeClient := fake.NewClientset()
-	hcm := hardwareconfig.NewHardwareConfigManager(fakeClient, "default")
+	hcm := hardwareconfig.NewHardwareConfigManager(fakeClient, "default", nil)
 	err = hcm.UpdateHardwareConfig([]ptpv2alpha1.HardwareConfig{hwConfig})
 	assert.NoError(t, err, "Should be able to update hardware config")
 
@@ -1457,7 +1458,7 @@ func TestTBCDualUpstream_PortALost_PortBTakesOver(t *testing.T) {
 	defer func() { vTbcHasHardwareConfig = oldValue }()
 
 	fakeClient := fake.NewClientset()
-	hcm := hardwareconfig.NewHardwareConfigManager(fakeClient, "default")
+	hcm := hardwareconfig.NewHardwareConfigManager(fakeClient, "default", nil)
 	err := setupDualUpstreamHardwareConfig(hcm, "test-profile", "eno2", "eno3")
 	assert.NoError(t, err)
 	mockDaemon := &Daemon{hardwareConfigManager: hcm}
@@ -1522,7 +1523,7 @@ func TestTBCDualUpstream_BothPortsLost(t *testing.T) {
 	defer func() { vTbcHasHardwareConfig = oldValue }()
 
 	fakeClient := fake.NewClientset()
-	hcm := hardwareconfig.NewHardwareConfigManager(fakeClient, "default")
+	hcm := hardwareconfig.NewHardwareConfigManager(fakeClient, "default", nil)
 	err := setupDualUpstreamHardwareConfig(hcm, "test-profile", "eno2", "eno3")
 	assert.NoError(t, err)
 	mockDaemon := &Daemon{hardwareConfigManager: hcm}
@@ -1573,7 +1574,7 @@ func TestTBCDualUpstream_RecoveryAfterBothLost(t *testing.T) {
 	defer func() { vTbcHasHardwareConfig = oldValue }()
 
 	fakeClient := fake.NewClientset()
-	hcm := hardwareconfig.NewHardwareConfigManager(fakeClient, "default")
+	hcm := hardwareconfig.NewHardwareConfigManager(fakeClient, "default", nil)
 	err := setupDualUpstreamHardwareConfig(hcm, "test-profile", "eno2", "eno3")
 	assert.NoError(t, err)
 	mockDaemon := &Daemon{hardwareConfigManager: hcm}
@@ -3672,4 +3673,63 @@ func TestFindProcessesByName(t *testing.T) {
 
 	procs = pm.findProcessesByName("nonexistent")
 	assert.Equal(t, 0, len(procs))
+}
+
+func TestPtp4lConf_ResolveInterfaceNames(t *testing.T) {
+	resolver := network.NewInterfaceResolverWithInterfaces([]string{"ens5f0np0", "ens5f1np1"})
+
+	t.Run("resolves interface sections", func(t *testing.T) {
+		conf := &Ptp4lConf{}
+		config := "[global]\ndomainNumber 24\n[ens5f0]\nmasterOnly 1\n[ens5f1]\nmasterOnly 0"
+		err := conf.PopulatePtp4lConf(&config, nil)
+		assert.NoError(t, err)
+
+		conf.ResolveInterfaceNames(resolver)
+
+		for _, section := range conf.sections {
+			if section.sectionName == "[ens5f0]" || section.sectionName == "[ens5f1]" {
+				t.Errorf("section %s should have been resolved", section.sectionName)
+			}
+		}
+		// Verify resolved names exist
+		found := map[string]bool{}
+		for _, section := range conf.sections {
+			found[section.sectionName] = true
+		}
+		assert.True(t, found["[ens5f0np0]"], "should have [ens5f0np0] section")
+		assert.True(t, found["[ens5f1np1]"], "should have [ens5f1np1] section")
+		assert.True(t, found[GlobalSectionName], "should keep [global] section")
+	})
+
+	t.Run("skips known sections", func(t *testing.T) {
+		conf := &Ptp4lConf{}
+		config := "[global]\ndomainNumber 24\n[nmea]\nts2phc.master 1"
+		err := conf.PopulatePtp4lConf(&config, nil)
+		assert.NoError(t, err)
+
+		conf.ResolveInterfaceNames(resolver)
+
+		found := map[string]bool{}
+		for _, section := range conf.sections {
+			found[section.sectionName] = true
+		}
+		assert.True(t, found[GlobalSectionName], "should keep [global]")
+		assert.True(t, found[NmeaSectionName], "should keep [nmea]")
+	})
+
+	t.Run("no-op when names exist", func(t *testing.T) {
+		noChangeResolver := network.NewInterfaceResolverWithInterfaces([]string{"ens5f0", "ens5f1"})
+		conf := &Ptp4lConf{}
+		config := "[global]\n[ens5f0]\nmasterOnly 1"
+		err := conf.PopulatePtp4lConf(&config, nil)
+		assert.NoError(t, err)
+
+		conf.ResolveInterfaceNames(noChangeResolver)
+
+		found := map[string]bool{}
+		for _, section := range conf.sections {
+			found[section.sectionName] = true
+		}
+		assert.True(t, found["[ens5f0]"], "should keep [ens5f0] unchanged")
+	})
 }

--- a/pkg/hardwareconfig/clockchain_resolution_test.go
+++ b/pkg/hardwareconfig/clockchain_resolution_test.go
@@ -202,7 +202,7 @@ func TestClockChainResolution(t *testing.T) {
 			defer ResetLeadingInterfaceResolver()
 
 			// Resolve clock chain (this is what we're testing)
-			hcm := NewHardwareConfigManager(fakeClient, "default")
+			hcm := NewHardwareConfigManager(fakeClient, "default", nil)
 			resolvedConfig, err := hcm.ResolveClockChain(hwConfig, ptpConfig)
 			assert.NoError(t, err)
 			assert.NotNil(t, resolvedConfig)
@@ -346,7 +346,7 @@ func TestClockChainResolution_DualUpstream(t *testing.T) {
 	defer ResetLeadingInterfaceResolver()
 
 	fakeClient := fake.NewClientset()
-	hcm := NewHardwareConfigManager(fakeClient, "default")
+	hcm := NewHardwareConfigManager(fakeClient, "default", nil)
 	resolvedConfig, err := hcm.ResolveClockChain(hwConfig, ptpConfig)
 	assert.NoError(t, err)
 	if !assert.NotNil(t, resolvedConfig) {
@@ -516,7 +516,7 @@ func TestClockChainResolutionWithE830(t *testing.T) {
 	defer ResetLeadingInterfaceResolver()
 
 	fakeClient := fake.NewClientset()
-	hcm := NewHardwareConfigManager(fakeClient, "default")
+	hcm := NewHardwareConfigManager(fakeClient, "default", nil)
 
 	resolvedConfig, err := hcm.ResolveClockChain(hwConfig, ptpConfig)
 	require.NoError(t, err, "ResolveClockChain should succeed with E830 subsystems")

--- a/pkg/hardwareconfig/hardwareconfig.go
+++ b/pkg/hardwareconfig/hardwareconfig.go
@@ -13,6 +13,7 @@ import (
 	"github.com/golang/glog"
 	dpllcfg "github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/dpll"
 	dpll "github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/dpll-netlink"
+	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/network"
 	"k8s.io/client-go/kubernetes"
 
 	// loader is part of this package (vendor_loader.go)
@@ -217,14 +218,15 @@ type HardwareConfigManager struct {
 	// current PtpConfig used for resolving clock chains (optional)
 	ptpConfig *ptpv1.PtpConfig
 	// ConfigMap loader for board label remapping (optional, can be nil)
-	configMapLoader *BoardLabelMapLoader
-	mu              sync.RWMutex
-	cond            *sync.Cond
-	ready           bool
+	configMapLoader   *BoardLabelMapLoader
+	interfaceResolver *network.InterfaceResolver
+	mu                sync.RWMutex
+	cond              *sync.Cond
+	ready             bool
 }
 
 // NewHardwareConfigManager creates a new hardware config manager.
-func NewHardwareConfigManager(kubeClient kubernetes.Interface, namespace string) *HardwareConfigManager {
+func NewHardwareConfigManager(kubeClient kubernetes.Interface, namespace string, resolver *network.InterfaceResolver) *HardwareConfigManager {
 	hcm := &HardwareConfigManager{
 		hardwareConfigs: make([]enrichedHardwareConfig, 0),
 		pinApplier:      func(cmds []dpll.PinParentDeviceCtl) error { return BatchPinSet(cmds) },
@@ -238,6 +240,7 @@ func NewHardwareConfigManager(kubeClient kubernetes.Interface, namespace string)
 			return os.WriteFile(path, []byte(value), 0o644)
 		},
 	}
+	hcm.interfaceResolver = resolver
 	hcm.cond = sync.NewCond(&hcm.mu)
 
 	// Set up ConfigMap loader for board label remapping
@@ -285,6 +288,14 @@ func (hcm *HardwareConfigManager) UpdateHardwareConfig(hwConfigs []ptpv2alpha1.H
 
 	// Clear clock ID cache for new hardware config processing
 	hcm.clockIDCache = make(map[string]uint64)
+
+	// Resolve RHEL 10 npN interface name changes in hardware configs
+	if hcm.interfaceResolver != nil {
+		if err := hcm.interfaceResolver.Refresh(); err != nil {
+			glog.Warningf("Failed to refresh interface resolver for hardware config, name resolution may use stale data: %v", err)
+		}
+		hcm.interfaceResolver.ResolveHardwareConfigInterfaces(hwConfigs)
+	}
 
 	// Detect removed hardwareconfigs before updating
 	removedConfigs := hcm.detectRemovedHardwareConfigs(hwConfigs)

--- a/pkg/hardwareconfig/hardwareconfig_test.go
+++ b/pkg/hardwareconfig/hardwareconfig_test.go
@@ -24,7 +24,7 @@ import (
 // newHardwareConfigManagerForTests creates a HardwareConfigManager with a fake ConfigMap loader for tests
 func newHardwareConfigManagerForTests() *HardwareConfigManager {
 	fakeClient := fake.NewClientset()
-	return NewHardwareConfigManager(fakeClient, "default")
+	return NewHardwareConfigManager(fakeClient, "default", nil)
 }
 
 func TestApplyHardwareConfigsForProfile(t *testing.T) {

--- a/pkg/network/resolve.go
+++ b/pkg/network/resolve.go
@@ -1,0 +1,342 @@
+package network
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/golang/glog"
+	ptpv1 "github.com/k8snetworkplumbingwg/ptp-operator/api/v1"
+	ptpv2alpha1 "github.com/k8snetworkplumbingwg/ptp-operator/api/v2alpha1"
+)
+
+var (
+	dpllKeyRegex    = regexp.MustCompile(`^dpll\.(.+)\.(ignore|flags)$`)
+	clockIDKeyRegex = regexp.MustCompile(`^(clockId|clockIdFormat)\[(.+)\]$`)
+)
+
+// InterfaceResolver maps configured interface names to actual system interface
+// names, handling the RHEL 10 npN suffix change transparently.
+type InterfaceResolver struct {
+	knownInterfaces map[string]bool
+	remapCache      map[string]string
+}
+
+// NewInterfaceResolver creates a resolver that scans /sys/class/net/ for current interfaces.
+func NewInterfaceResolver() *InterfaceResolver {
+	r := &InterfaceResolver{
+		knownInterfaces: make(map[string]bool),
+		remapCache:      make(map[string]string),
+	}
+	if err := r.Refresh(); err != nil {
+		glog.Warningf("InterfaceResolver: initial scan of /sys/class/net failed: %v", err)
+	}
+	return r
+}
+
+// NewInterfaceResolverWithInterfaces creates a resolver pre-populated with the
+// given interface names. Intended for unit tests.
+func NewInterfaceResolverWithInterfaces(interfaces []string) *InterfaceResolver {
+	r := &InterfaceResolver{
+		knownInterfaces: make(map[string]bool, len(interfaces)),
+		remapCache:      make(map[string]string),
+	}
+	for _, iface := range interfaces {
+		r.knownInterfaces[iface] = true
+	}
+	return r
+}
+
+// npSuffix returns the integer N from an interface name ending in "npN".
+// Returns -1 if no suffix is found.
+func npSuffix(iface string) int {
+	idx := strings.LastIndex(iface, "np")
+	if idx < 0 || idx+2 >= len(iface) {
+		return -1
+	}
+	n, err := strconv.Atoi(iface[idx+2:])
+	if err != nil {
+		return -1
+	}
+	return n
+}
+
+// Refresh re-scans /sys/class/net/ and clears the remap cache.
+func (r *InterfaceResolver) Refresh() error {
+	entries, err := os.ReadDir("/sys/class/net")
+	if err != nil {
+		return fmt.Errorf("failed to read /sys/class/net: %w", err)
+	}
+	r.knownInterfaces = make(map[string]bool, len(entries))
+	for _, entry := range entries {
+		r.knownInterfaces[entry.Name()] = true
+	}
+	r.remapCache = make(map[string]string)
+	return nil
+}
+
+// Resolve returns the actual system interface name for a configured name.
+// If the configured name exists, it is returned unchanged.
+// Otherwise the resolver tries appending npN (N=0..7).
+func (r *InterfaceResolver) Resolve(configuredName string) (string, bool) {
+	if configuredName == "" {
+		return configuredName, false
+	}
+
+	if cached, ok := r.remapCache[configuredName]; ok {
+		return cached, cached != configuredName
+	}
+
+	if r.knownInterfaces[configuredName] {
+		r.remapCache[configuredName] = configuredName
+		return configuredName, false
+	}
+
+	// Match any interface named configuredName + "np" + digits
+	npPattern := regexp.MustCompile(`^` + regexp.QuoteMeta(configuredName) + `np\d+$`)
+	var candidates []string
+	for iface := range r.knownInterfaces {
+		if npPattern.MatchString(iface) {
+			candidates = append(candidates, iface)
+		}
+	}
+	// Map iteration order is randomized; sort by numeric npN suffix so the
+	// lowest-numbered interface (e.g. np0 before np1/np10) is always chosen.
+	sort.Slice(candidates, func(i, j int) bool {
+		return npSuffix(candidates[i]) < npSuffix(candidates[j])
+	})
+
+	if len(candidates) == 1 {
+		resolved := candidates[0]
+		glog.Infof("Interface name resolved: %q -> %q (RHEL 10 npN suffix detected)", configuredName, resolved)
+		r.remapCache[configuredName] = resolved
+		return resolved, true
+	}
+
+	if len(candidates) > 1 {
+		resolved := candidates[0]
+		glog.Warningf("Multiple npN candidates found for %q: %v; using lowest-numbered match %q",
+			configuredName, candidates, resolved)
+		r.remapCache[configuredName] = resolved
+		return resolved, true
+	}
+
+	glog.Warningf("Interface %q not found on system and no npN variant exists", configuredName)
+	r.remapCache[configuredName] = configuredName
+	return configuredName, false
+}
+
+// ResolveProfileInterfaces resolves all interface name references in a PtpProfile.
+func (r *InterfaceResolver) ResolveProfileInterfaces(profile *ptpv1.PtpProfile) {
+	profileName := "<unknown>"
+	if profile.Name != nil {
+		profileName = *profile.Name
+	}
+
+	if profile.Interface != nil && *profile.Interface != "" {
+		if resolved, remapped := r.Resolve(*profile.Interface); remapped {
+			glog.Infof("Profile %s: Interface field remapped %q -> %q", profileName, *profile.Interface, resolved)
+			*profile.Interface = resolved
+		}
+	}
+
+	// Config section headers ([interface]) are resolved by Ptp4lConf.ResolveInterfaceNames
+	// after parsing, inside applyNodePtpProfile — not here.
+
+	if profile.PtpSettings != nil {
+		resolvePtpSettings(r, profile.PtpSettings, profileName)
+	}
+
+	resolvePluginDevices(r, profile, profileName)
+}
+
+func resolvePtpSettings(r *InterfaceResolver, settings map[string]string, profileName string) {
+	// Resolve simple value settings
+	for _, key := range []string{"leadingInterface"} {
+		if val, ok := settings[key]; ok && val != "" {
+			if resolved, remapped := r.Resolve(val); remapped {
+				glog.Infof("Profile %s: PtpSettings[%s] remapped %q -> %q", profileName, key, val, resolved)
+				settings[key] = resolved
+			}
+		}
+	}
+
+	// upstreamPort can be comma-separated
+	if val, ok := settings["upstreamPort"]; ok && val != "" {
+		ports := strings.Split(val, ",")
+		changed := false
+		for i, port := range ports {
+			port = strings.TrimSpace(port)
+			if resolved, remapped := r.Resolve(port); remapped {
+				glog.Infof("Profile %s: PtpSettings[upstreamPort] port %q -> %q", profileName, port, resolved)
+				ports[i] = resolved
+				changed = true
+			}
+		}
+		if changed {
+			settings["upstreamPort"] = strings.Join(ports, ",")
+		}
+	}
+
+	// Resolve keys that embed interface names
+	renames := make(map[string]string)
+	for key := range settings {
+		newKey := resolveDpllKey(r, key)
+		if newKey == "" {
+			newKey = resolveClockIDKey(r, key)
+		}
+		if newKey != "" {
+			renames[key] = newKey
+			glog.Infof("Profile %s: PtpSettings key %q -> %q", profileName, key, newKey)
+		}
+	}
+	for oldKey, newKey := range renames {
+		if _, exists := settings[newKey]; exists {
+			glog.Warningf("Profile %s: PtpSettings key rename %q -> %q skipped: target key already exists",
+				profileName, oldKey, newKey)
+			continue
+		}
+		settings[newKey] = settings[oldKey]
+		delete(settings, oldKey)
+	}
+}
+
+func resolveDpllKey(r *InterfaceResolver, key string) string {
+	m := dpllKeyRegex.FindStringSubmatch(key)
+	if m == nil {
+		return ""
+	}
+	resolved, remapped := r.Resolve(m[1])
+	if !remapped {
+		return ""
+	}
+	return fmt.Sprintf("dpll.%s.%s", resolved, m[2])
+}
+
+func resolveClockIDKey(r *InterfaceResolver, key string) string {
+	m := clockIDKeyRegex.FindStringSubmatch(key)
+	if m == nil {
+		return ""
+	}
+	resolved, remapped := r.Resolve(m[2])
+	if !remapped {
+		return ""
+	}
+	return fmt.Sprintf("%s[%s]", m[1], resolved)
+}
+
+func resolvePluginDevices(r *InterfaceResolver, profile *ptpv1.PtpProfile, profileName string) {
+	if profile.Plugins == nil {
+		return
+	}
+
+	for pluginName, opts := range profile.Plugins {
+		if opts == nil {
+			continue
+		}
+		var rawOpts map[string]any
+		if err := json.Unmarshal(opts.Raw, &rawOpts); err != nil {
+			continue
+		}
+
+		changed := false
+
+		// Resolve "devices" array
+		if devices, ok := rawOpts["devices"].([]any); ok {
+			for i, d := range devices {
+				name, isStr := d.(string)
+				if !isStr {
+					glog.Warningf("Profile %s: plugin %s devices[%d] is not a string, skipping", profileName, pluginName, i)
+					continue
+				}
+				if resolved, remapped := r.Resolve(name); remapped {
+					devices[i] = resolved
+					changed = true
+					glog.Infof("Profile %s: plugin %s device %q -> %q", profileName, pluginName, name, resolved)
+				}
+			}
+		}
+
+		// Resolve map keys in pins, frequencies, phaseOffsetPins
+		for _, mapKey := range []string{"pins", "frequencies", "phaseOffsetPins"} {
+			if m, ok := rawOpts[mapKey].(map[string]any); ok {
+				renames := make(map[string]string)
+				for deviceName := range m {
+					if resolved, remapped := r.Resolve(deviceName); remapped {
+						renames[deviceName] = resolved
+						changed = true
+						glog.Infof("Profile %s: plugin %s %s key %q -> %q", profileName, pluginName, mapKey, deviceName, resolved)
+					}
+				}
+				for oldKey, newKey := range renames {
+					if _, exists := m[newKey]; exists {
+						glog.Warningf("Profile %s: plugin %s %s key rename %q -> %q skipped: target key already exists",
+							profileName, pluginName, mapKey, oldKey, newKey)
+						continue
+					}
+					m[newKey] = m[oldKey]
+					delete(m, oldKey)
+				}
+			}
+		}
+
+		if changed {
+			newRaw, err := json.Marshal(rawOpts)
+			if err != nil {
+				glog.Errorf("Profile %s: failed to re-marshal plugin %s opts: %v", profileName, pluginName, err)
+				continue
+			}
+			opts.Raw = newRaw
+		}
+	}
+}
+
+// ResolveHardwareConfigInterfaces resolves interface names in HardwareConfig CRs.
+func (r *InterfaceResolver) ResolveHardwareConfigInterfaces(hwConfigs []ptpv2alpha1.HardwareConfig) {
+	for i := range hwConfigs {
+		cc := hwConfigs[i].Spec.Profile.ClockChain
+		if cc == nil {
+			continue
+		}
+		configName := hwConfigs[i].Name
+
+		// Resolve Structure subsystem interface names
+		for si := range cc.Structure {
+			sub := &cc.Structure[si]
+			if sub.DPLL.NetworkInterface != "" {
+				if resolved, remapped := r.Resolve(sub.DPLL.NetworkInterface); remapped {
+					glog.Infof("HardwareConfig %s: subsystem %s DPLL.NetworkInterface %q -> %q",
+						configName, sub.Name, sub.DPLL.NetworkInterface, resolved)
+					sub.DPLL.NetworkInterface = resolved
+				}
+			}
+			for ei := range sub.Ethernet {
+				for pi := range sub.Ethernet[ei].Ports {
+					if resolved, remapped := r.Resolve(sub.Ethernet[ei].Ports[pi]); remapped {
+						glog.Infof("HardwareConfig %s: subsystem %s Ethernet port %q -> %q",
+							configName, sub.Name, sub.Ethernet[ei].Ports[pi], resolved)
+						sub.Ethernet[ei].Ports[pi] = resolved
+					}
+				}
+			}
+		}
+
+		// Resolve Behavior source PTPTimeReceivers
+		if cc.Behavior != nil {
+			for si := range cc.Behavior.Sources {
+				src := &cc.Behavior.Sources[si]
+				for pi := range src.PTPTimeReceivers {
+					if resolved, remapped := r.Resolve(src.PTPTimeReceivers[pi]); remapped {
+						glog.Infof("HardwareConfig %s: source %s PTPTimeReceiver %q -> %q",
+							configName, src.Name, src.PTPTimeReceivers[pi], resolved)
+						src.PTPTimeReceivers[pi] = resolved
+					}
+				}
+			}
+		}
+	}
+}

--- a/pkg/network/resolve_test.go
+++ b/pkg/network/resolve_test.go
@@ -1,0 +1,272 @@
+package network
+
+import (
+	"encoding/json"
+	"testing"
+
+	ptpv1 "github.com/k8snetworkplumbingwg/ptp-operator/api/v1"
+	ptpv2alpha1 "github.com/k8snetworkplumbingwg/ptp-operator/api/v2alpha1"
+	apiextensions "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	testIfOld   = "ens5f0"
+	testIfNew   = "ens5f0np0"
+	testIf2Old  = "ens5f1"
+	testIf2New  = "ens5f1np1"
+	testProfile = "test"
+)
+
+func TestResolve_NameExistsAsIs(t *testing.T) {
+	r := NewInterfaceResolverWithInterfaces([]string{testIfOld, testIf2Old})
+	resolved, remapped := r.Resolve(testIfOld)
+	if remapped {
+		t.Error("expected no remap when name exists")
+	}
+	if resolved != testIfOld {
+		t.Errorf("expected %s, got %s", testIfOld, resolved)
+	}
+}
+
+func TestResolve_NpNSuffix(t *testing.T) {
+	r := NewInterfaceResolverWithInterfaces([]string{testIfNew, testIf2New})
+	resolved, remapped := r.Resolve(testIfOld)
+	if !remapped {
+		t.Error("expected remap")
+	}
+	if resolved != testIfNew {
+		t.Errorf("expected %s, got %s", testIfNew, resolved)
+	}
+}
+
+func TestResolve_MultipleCandidates(t *testing.T) {
+	// Insert higher-numbered suffix first so map insertion order cannot
+	// accidentally match the expected lowest-numbered result.
+	r := NewInterfaceResolverWithInterfaces([]string{"ens5f0np1", "ens5f0np10", testIfNew})
+	resolved, remapped := r.Resolve(testIfOld)
+	if !remapped {
+		t.Error("expected remap")
+	}
+	if resolved != testIfNew {
+		t.Errorf("expected lowest-numbered candidate %s, got %s", testIfNew, resolved)
+	}
+}
+
+func TestResolve_NoMatch(t *testing.T) {
+	r := NewInterfaceResolverWithInterfaces([]string{"eth0", "eth1"})
+	resolved, remapped := r.Resolve(testIfOld)
+	if remapped {
+		t.Error("expected no remap when no match")
+	}
+	if resolved != testIfOld {
+		t.Errorf("expected original %s, got %s", testIfOld, resolved)
+	}
+}
+
+func TestResolve_Empty(t *testing.T) {
+	r := NewInterfaceResolverWithInterfaces([]string{testIfNew})
+	resolved, remapped := r.Resolve("")
+	if remapped {
+		t.Error("expected no remap for empty")
+	}
+	if resolved != "" {
+		t.Errorf("expected empty, got %s", resolved)
+	}
+}
+
+func TestResolve_Caching(t *testing.T) {
+	r := NewInterfaceResolverWithInterfaces([]string{testIfNew})
+
+	r1, _ := r.Resolve(testIfOld)
+	r2, _ := r.Resolve(testIfOld)
+	if r1 != r2 {
+		t.Errorf("cache inconsistency: %s vs %s", r1, r2)
+	}
+}
+
+func TestResolveProfileInterfaces_InterfaceField(t *testing.T) {
+	r := NewInterfaceResolverWithInterfaces([]string{testIfNew})
+	iface := testIfOld
+	name := testProfile
+	profile := &ptpv1.PtpProfile{
+		Name:      &name,
+		Interface: &iface,
+	}
+	r.ResolveProfileInterfaces(profile)
+	if *profile.Interface != testIfNew {
+		t.Errorf("expected %s, got %s", testIfNew, *profile.Interface)
+	}
+}
+
+func TestResolveProfileInterfaces_PtpSettingsValues(t *testing.T) {
+	r := NewInterfaceResolverWithInterfaces([]string{testIfNew, testIf2New})
+	name := testProfile
+	profile := &ptpv1.PtpProfile{
+		Name: &name,
+		PtpSettings: map[string]string{
+			"leadingInterface": testIfOld,
+			"upstreamPort":     "ens5f0,ens5f1",
+		},
+	}
+	r.ResolveProfileInterfaces(profile)
+
+	if profile.PtpSettings["leadingInterface"] != testIfNew {
+		t.Errorf("leadingInterface: expected %s, got %s", testIfNew, profile.PtpSettings["leadingInterface"])
+	}
+	if profile.PtpSettings["upstreamPort"] != "ens5f0np0,ens5f1np1" {
+		t.Errorf("upstreamPort: expected ens5f0np0,ens5f1np1, got %s", profile.PtpSettings["upstreamPort"])
+	}
+}
+
+func TestResolveProfileInterfaces_PtpSettingsKeys(t *testing.T) {
+	r := NewInterfaceResolverWithInterfaces([]string{testIfNew})
+	name := testProfile
+	profile := &ptpv1.PtpProfile{
+		Name: &name,
+		PtpSettings: map[string]string{
+			"dpll.ens5f0.ignore": "true",
+			"dpll.ens5f0.flags":  "0x1",
+			"clockId[ens5f0]":    "0x1234",
+			"someOtherSetting":   "value",
+		},
+	}
+	r.ResolveProfileInterfaces(profile)
+
+	if _, ok := profile.PtpSettings["dpll.ens5f0np0.ignore"]; !ok {
+		t.Error("dpll.ens5f0.ignore should be renamed to dpll.ens5f0np0.ignore")
+	}
+	if _, ok := profile.PtpSettings["dpll.ens5f0np0.flags"]; !ok {
+		t.Error("dpll.ens5f0.flags should be renamed to dpll.ens5f0np0.flags")
+	}
+	if _, ok := profile.PtpSettings["clockId[ens5f0np0]"]; !ok {
+		t.Error("clockId[ens5f0] should be renamed to clockId[ens5f0np0]")
+	}
+	if v := profile.PtpSettings["someOtherSetting"]; v != "value" {
+		t.Errorf("unrelated setting should be unchanged, got %s", v)
+	}
+}
+
+func TestResolveProfileInterfaces_PluginDevices(t *testing.T) {
+	r := NewInterfaceResolverWithInterfaces([]string{testIfNew})
+	name := testProfile
+
+	pluginOpts := map[string]any{
+		"devices": []any{testIfOld},
+		"pins": map[string]any{
+			testIfOld: []any{map[string]any{"name": "SMA1"}},
+		},
+	}
+	raw, _ := json.Marshal(pluginOpts)
+	profile := &ptpv1.PtpProfile{
+		Name: &name,
+		Plugins: map[string]*apiextensions.JSON{
+			"e810": {Raw: raw},
+		},
+	}
+	r.ResolveProfileInterfaces(profile)
+
+	var result map[string]any
+	_ = json.Unmarshal(profile.Plugins["e810"].Raw, &result)
+
+	devices := result["devices"].([]any)
+	if devices[0].(string) != testIfNew {
+		t.Errorf("plugin device: expected %s, got %s", testIfNew, devices[0])
+	}
+
+	pins := result["pins"].(map[string]any)
+	if _, ok := pins[testIfNew]; !ok {
+		t.Error("plugin pins key should be renamed to ens5f0np0")
+	}
+	if _, ok := pins[testIfOld]; ok {
+		t.Error("old plugin pins key ens5f0 should be removed")
+	}
+}
+
+func TestResolveProfileInterfaces_NoChangeWhenNamesExist(t *testing.T) {
+	r := NewInterfaceResolverWithInterfaces([]string{testIfOld, testIf2Old})
+	name := testProfile
+	iface := testIfOld
+	conf := "[global]\ndomainNumber 24\n[ens5f0]\nmasterOnly 1"
+	originalConf := conf
+	profile := &ptpv1.PtpProfile{
+		Name:      &name,
+		Interface: &iface,
+		Ptp4lConf: &conf,
+		PtpSettings: map[string]string{
+			"leadingInterface": testIfOld,
+		},
+	}
+	r.ResolveProfileInterfaces(profile)
+
+	if *profile.Interface != testIfOld {
+		t.Errorf("interface should be unchanged, got %s", *profile.Interface)
+	}
+	if *profile.Ptp4lConf != originalConf {
+		t.Errorf("ptp4lConf should be unchanged")
+	}
+	if profile.PtpSettings["leadingInterface"] != testIfOld {
+		t.Errorf("leadingInterface should be unchanged")
+	}
+}
+
+func TestResolveProfileInterfaces_NilFields(_ *testing.T) {
+	r := NewInterfaceResolverWithInterfaces([]string{testIfNew})
+	name := testProfile
+	profile := &ptpv1.PtpProfile{
+		Name: &name,
+	}
+	r.ResolveProfileInterfaces(profile)
+}
+
+func TestResolveHardwareConfigInterfaces(t *testing.T) {
+	r := NewInterfaceResolverWithInterfaces([]string{testIfNew, testIf2New})
+
+	hwConfigs := []ptpv2alpha1.HardwareConfig{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-hw"},
+			Spec: ptpv2alpha1.HardwareConfigSpec{
+				Profile: ptpv2alpha1.HardwareProfile{
+					ClockChain: &ptpv2alpha1.ClockChain{
+						Structure: []ptpv2alpha1.Subsystem{
+							{
+								Name: "sub1",
+								DPLL: ptpv2alpha1.DPLL{NetworkInterface: testIfOld},
+								Ethernet: []ptpv2alpha1.Ethernet{
+									{Ports: []string{testIfOld, testIf2Old}},
+								},
+							},
+						},
+						Behavior: &ptpv2alpha1.Behavior{
+							Sources: []ptpv2alpha1.SourceConfig{
+								{
+									Name:             "ptp",
+									SourceType:       "ptpTimeReceiver",
+									PTPTimeReceivers: []string{testIf2Old},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	r.ResolveHardwareConfigInterfaces(hwConfigs)
+
+	sub := hwConfigs[0].Spec.Profile.ClockChain.Structure[0]
+	if sub.DPLL.NetworkInterface != testIfNew {
+		t.Errorf("DPLL.NetworkInterface: expected %s, got %s", testIfNew, sub.DPLL.NetworkInterface)
+	}
+	if sub.Ethernet[0].Ports[0] != testIfNew {
+		t.Errorf("Ethernet.Ports[0]: expected %s, got %s", testIfNew, sub.Ethernet[0].Ports[0])
+	}
+	if sub.Ethernet[0].Ports[1] != testIf2New {
+		t.Errorf("Ethernet.Ports[1]: expected %s, got %s", testIf2New, sub.Ethernet[0].Ports[1])
+	}
+
+	src := hwConfigs[0].Spec.Profile.ClockChain.Behavior.Sources[0]
+	if src.PTPTimeReceivers[0] != testIf2New {
+		t.Errorf("PTPTimeReceivers[0]: expected %s, got %s", testIf2New, src.PTPTimeReceivers[0])
+	}
+}


### PR DESCRIPTION
## Summary

RHEL 10 (systemd v252+) adds an `npN` suffix to multi-port NIC interface names (e.g., `ens5f0` → `ens5f0np0`). After upgrading from OCP 4.22 (RHEL 9) to 5.0 (RHEL 10), PtpConfig and HardwareConfig CRs referencing old names break because the kernel names change.

This adds an `InterfaceResolver` in `pkg/network/resolve.go` that transparently maps old names to new `npN`-suffixed names at config application time:

- Scans `/sys/class/net/` each config cycle to discover current interface names
- If a configured name doesn't exist, matches it against known interfaces using a regex pattern (`configuredName + np\d+`)
- Sorts candidates by numeric npN suffix for deterministic selection
- Resolves **PtpProfile** fields:
  - `Interface` field
  - `PtpSettings` values (`leadingInterface`, `upstreamPort`)
  - `PtpSettings` keys (`dpll.<ifname>.*`, `clockId[<ifname>]`)
  - Plugin device lists and map keys (`devices`, `pins`, `frequencies`, `phaseOffsetPins`)
- Resolves **config section headers** via `Ptp4lConf.ResolveInterfaceNames()` after parsing, reusing the existing parsed structure from `PopulatePtp4lConf`
- Resolves **HardwareConfig** fields in `UpdateHardwareConfig()` before processing:
  - `Subsystem.DPLL.NetworkInterface`
  - `Subsystem.Ethernet[].Ports[]`
  - `SourceConfig.PTPTimeReceivers[]`
- Detects key-rename collisions and skips with a warning instead of silently overwriting
- No-op when names already match (forward-compatible with RHEL 10 native configs)
- Logs all remappings at Info level; warns on refresh failures and non-string plugin device entries

**Affected NICs:** Intel E810/E825 (ice driver), WPC, GNR-D. Mellanox ConnectX already uses `npN` on RHEL 9 (unaffected).

## Test plan

- [x] 13 unit tests in `pkg/network/resolve_test.go` — name exists, npN resolution, multiple candidates, no match, empty name, caching, profile resolution (Interface, PtpSettings keys/values, plugins), HardwareConfig resolution, nil fields
- [x] 3 unit tests in `pkg/daemon/daemon_internal_test.go` — `Ptp4lConf.ResolveInterfaceNames` (resolves sections, skips known sections, no-op when names exist)
- [x] `golangci-lint run ./pkg/network/ ./pkg/daemon/ ./pkg/hardwareconfig/` — 0 issues
- [x] Integration test on OCP 5.0 node (cnfdg14) — PtpConfig with `eno12399` (no `np0` suffix) resolved to `eno12399np0` in rendered ptp4l config; ptp4l ran successfully with resolved interface
- [x] Upgrade scenario test on OCP 4.22 node (cnfdg32) — PtpConfig with `ens6f0` (old-style name) resolved to `ens6f0np0` (actual system interface); ptp4l bound to correct interface. Existing T-GM config with `ens7f0`/`ens7f1` passed through unchanged (resolver no-op). Original T-GM sync restored after cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic network interface name resolution for PTP profiles, hardware configurations, and generated PTP configuration.
  * Supports remapping interface references across clock-chain settings and plugin configurations.
  * Selects matching system interfaces deterministically and refreshes mappings when configurations are applied.

* **Bug Fixes**
  * Prevents configuration failures when configured interface names differ from the system’s actual names.

* **Tests**
  * Added coverage for interface mapping across profiles, hardware configurations, plugins, and PTP configuration sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->