### PR TITLE
Ublox refactoring

### DIFF
--- a/addons/intel/e810.go
+++ b/addons/intel/e810.go
@@ -197,7 +197,7 @@ func AfterRunPTPCommandE810(data *interface{}, nodeProfile *ptpv1.PtpProfile, co
 			case "gpspipe":
 				glog.Infof("AfterRunPTPCommandE810 doing ublx config for command: %s", command)
 				// Execute user-supplied UblxCmds first:
-				pluginData.hwplugins = append(pluginData.hwplugins, e810Opts.UblxCmds.runAll(true)...)
+				pluginData.hwplugins = append(pluginData.hwplugins, e810Opts.UblxCmds.RunAll(true)...)
 			case "tbc-ho-exit":
 				err = clockChain.EnterNormalTBC()
 				if err != nil {

--- a/addons/intel/e810_test.go
+++ b/addons/intel/e810_test.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"slices"
 	"testing"
 
 	dpll "github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/dpll-netlink"
@@ -31,13 +30,12 @@ func Test_AfterRunPTPCommandE810(t *testing.T) {
 	err = p.AfterRunPTPCommand(d, profile, "bad command")
 	assert.NoError(t, err)
 
-	mockExec, execRestore := setupExecMock()
-	defer execRestore()
-	mockExec.setDefaults("output", nil)
+	mock, cmdRestore := setupCommandMock()
+	defer cmdRestore()
 	err = p.AfterRunPTPCommand(d, profile, "gpspipe")
 	assert.NoError(t, err)
-	// Ensure all 9 required calls are the last 9:
-	requiredUblxCmds := []string{
+	// Verify all required ublox commands were executed
+	requiredPatterns := []string{
 		"CFG-HW-ANT_CFG_VOLTCTRL,1",
 		"GPS",
 		"Galileo",
@@ -49,15 +47,10 @@ func Test_AfterRunPTPCommandE810(t *testing.T) {
 		"CFG-MSG,1,38,248",
 		"SAVE",
 	}
-	found := make([]string, 0, len(requiredUblxCmds))
-	for _, call := range mockExec.actualCalls {
-		for _, arg := range call.args {
-			if slices.Contains(requiredUblxCmds, arg) {
-				found = append(found, arg)
-			}
-		}
+	for _, pattern := range requiredPatterns {
+		assert.True(t, mock.containsCommand(pattern),
+			"expected command containing %q", pattern)
 	}
-	assert.Equal(t, requiredUblxCmds, found)
 	// And expect 3 of them to have produced output (as specified in the profile)
 	assert.Equal(t, 3, len(data.hwplugins))
 }

--- a/addons/intel/e825.go
+++ b/addons/intel/e825.go
@@ -351,7 +351,7 @@ func AfterRunPTPCommandE825(data *interface{}, nodeProfile *ptpv1.PtpProfile, co
 			case "gpspipe":
 				glog.Infof("AfterRunPTPCommandE825 doing ublx config for command: %s", command)
 				// Execute user-supplied UblxCmds first:
-				pluginData.hwplugins = append(pluginData.hwplugins, e825Opts.UblxCmds.runAll(true)...)
+				pluginData.hwplugins = append(pluginData.hwplugins, e825Opts.UblxCmds.RunAll(true)...)
 			// "tbc-ho-exit" is called when ptp4l sync is achieved on the T-BC upstreamPort
 			case "tbc-ho-exit":
 				if tbcConfigured(nodeProfile) {

--- a/addons/intel/e825_test.go
+++ b/addons/intel/e825_test.go
@@ -2,7 +2,6 @@ package intel
 
 import (
 	"fmt"
-	"slices"
 	"testing"
 
 	dpll "github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/dpll-netlink"
@@ -51,13 +50,12 @@ func Test_AfterRunPTPCommandE825(t *testing.T) {
 	err = p.AfterRunPTPCommand(d, profile, "bad command")
 	assert.NoError(t, err)
 
-	mockExec, execRestore := setupExecMock()
-	defer execRestore()
-	mockExec.setDefaults("output", nil)
+	mock, cmdRestore := setupCommandMock()
+	defer cmdRestore()
 	err = p.AfterRunPTPCommand(d, profile, "gpspipe")
 	assert.NoError(t, err)
-	// Ensure all 9 required calls are present:
-	requiredUblxCmds := []string{
+	// Verify all required ublox commands were executed
+	requiredPatterns := []string{
 		"CFG-HW-ANT_CFG_VOLTCTRL,1",
 		"GPS",
 		"Galileo",
@@ -69,15 +67,10 @@ func Test_AfterRunPTPCommandE825(t *testing.T) {
 		"CFG-MSG,1,38,248",
 		"SAVE",
 	}
-	found := make([]string, 0, len(requiredUblxCmds))
-	for _, call := range mockExec.actualCalls {
-		for _, arg := range call.args {
-			if slices.Contains(requiredUblxCmds, arg) {
-				found = append(found, arg)
-			}
-		}
+	for _, pattern := range requiredPatterns {
+		assert.True(t, mock.containsCommand(pattern),
+			"expected command containing %q", pattern)
 	}
-	assert.Equal(t, requiredUblxCmds, found)
 	// And expect 3 of them to have produced output (as specified in the profile)
 	assert.Equal(t, 3, len(data.hwplugins))
 }

--- a/addons/intel/gnss_detect.go
+++ b/addons/intel/gnss_detect.go
@@ -6,13 +6,13 @@ import (
 
 	"github.com/bigkevmcd/go-configparser"
 	"github.com/golang/glog"
+	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/ublox"
 	ptpv1 "github.com/k8snetworkplumbingwg/ptp-operator/api/v1"
 )
 
 const (
-	nmeaSerialPortKey       = "ts2phc.nmea_serialport"
-	ts2phcMasterKey         = "ts2phc.master"
-	gnssDeviceSysfsTemplate = "/sys/class/net/%s/device/gnss"
+	nmeaSerialPortKey = "ts2phc.nmea_serialport"
+	ts2phcMasterKey   = "ts2phc.master"
 )
 
 var knownNonInterfaceSections = map[string]bool{
@@ -69,23 +69,6 @@ func findLeadingInterface(ts2phcConf string) (string, bool) {
 	return candidates[0], true
 }
 
-// gnssDeviceFromInterface resolves the GNSS device path for a given network interface
-// by reading the sysfs directory /sys/class/net/<iface>/device/gnss/.
-func gnssDeviceFromInterface(iface string) (string, error) {
-	gnssDir := fmt.Sprintf(gnssDeviceSysfsTemplate, iface)
-	entries, err := filesystem.ReadDir(gnssDir)
-	if err != nil {
-		return "", fmt.Errorf("no GNSS device found for interface %s: %w", iface, err)
-	}
-	if len(entries) == 0 {
-		return "", fmt.Errorf("GNSS sysfs directory %s is empty", gnssDir)
-	}
-	if len(entries) > 1 {
-		glog.Warningf("multiple GNSS devices found for %s, using %s", iface, entries[0].Name())
-	}
-	return fmt.Sprintf("/dev/%s", entries[0].Name()), nil
-}
-
 // autoDetectGNSSSerialPort attempts to auto-detect the GNSS serial port
 // from the ts2phcConf and patch it into the node profile if needed.
 func autoDetectGNSSSerialPort(nodeProfile *ptpv1.PtpProfile) {
@@ -96,7 +79,7 @@ func autoDetectGNSSSerialPort(nodeProfile *ptpv1.PtpProfile) {
 	if !found {
 		return
 	}
-	gnssPath, err := gnssDeviceFromInterface(leadingIface)
+	gnssPath, err := ublox.GNSSDeviceFromInterface(leadingIface)
 	if err != nil {
 		glog.Warningf("could not auto-detect GNSS device for %s: %v", leadingIface, err)
 		return

--- a/addons/intel/gnss_detect_test.go
+++ b/addons/intel/gnss_detect_test.go
@@ -2,10 +2,12 @@ package intel
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"strings"
 	"testing"
 
+	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/ublox"
 	ptpv1 "github.com/k8snetworkplumbingwg/ptp-operator/api/v1"
 	"github.com/stretchr/testify/assert"
 )
@@ -146,76 +148,73 @@ ts2phc.extts_polarity rising`,
 	}
 }
 
-func TestGnssDeviceFromInterface(t *testing.T) {
-	tests := []struct {
-		name        string
-		iface       string
-		setupMock   func(*MockFileSystem)
-		expected    string
-		expectError bool
-	}{
-		{
-			name:  "single GNSS device found",
-			iface: "ens7f0",
-			setupMock: func(m *MockFileSystem) {
-				m.ExpectReadDir("/sys/class/net/ens7f0/device/gnss",
-					[]os.DirEntry{MockDirEntry{name: "gnss0"}}, nil)
-			},
-			expected:    "/dev/gnss0",
-			expectError: false,
-		},
-		{
-			name:  "multiple GNSS devices, returns first",
-			iface: "ens7f0",
-			setupMock: func(m *MockFileSystem) {
-				m.ExpectReadDir("/sys/class/net/ens7f0/device/gnss",
-					[]os.DirEntry{
-						MockDirEntry{name: "gnss0"},
-						MockDirEntry{name: "gnss1"},
-					}, nil)
-			},
-			expected:    "/dev/gnss0",
-			expectError: false,
-		},
-		{
-			name:  "sysfs directory does not exist",
-			iface: "ens7f0",
-			setupMock: func(m *MockFileSystem) {
-				m.ExpectReadDir("/sys/class/net/ens7f0/device/gnss",
-					nil, errors.New("no such file or directory"))
-			},
-			expected:    "",
-			expectError: true,
-		},
-		{
-			name:  "sysfs directory is empty",
-			iface: "ens7f0",
-			setupMock: func(m *MockFileSystem) {
-				m.ExpectReadDir("/sys/class/net/ens7f0/device/gnss",
-					[]os.DirEntry{}, nil)
-			},
-			expected:    "",
-			expectError: true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			mockFS, restoreFs := setupMockFS()
-			defer restoreFs()
-			tt.setupMock(mockFS)
-
-			result, err := gnssDeviceFromInterface(tt.iface)
-			if tt.expectError {
-				assert.Error(t, err)
-				assert.Empty(t, result)
-			} else {
-				assert.NoError(t, err)
-				assert.Equal(t, tt.expected, result)
+func setupUbloxReadDirMock(entries map[string][]os.DirEntry, errs map[string]error) func() {
+	orig := ublox.ReadDir
+	ublox.ReadDir = func(name string) ([]os.DirEntry, error) {
+		if errs != nil {
+			if err, ok := errs[name]; ok {
+				return nil, err
 			}
-			mockFS.VerifyAllCalls(t)
-		})
+		}
+		if entries != nil {
+			if e, ok := entries[name]; ok {
+				return e, nil
+			}
+		}
+		return nil, errors.New("not found")
 	}
+	return func() { ublox.ReadDir = orig }
+}
+
+func TestGNSSDeviceFromInterface(t *testing.T) {
+	t.Run("single GNSS device found", func(t *testing.T) {
+		restore := setupUbloxReadDirMock(
+			map[string][]os.DirEntry{
+				fmt.Sprintf(ublox.GNSSDeviceSysfsTemplate, "ens7f0"): {MockDirEntry{name: "gnss0"}},
+			}, nil)
+		defer restore()
+
+		result, err := ublox.GNSSDeviceFromInterface("ens7f0")
+		assert.NoError(t, err)
+		assert.Equal(t, "/dev/gnss0", result)
+	})
+
+	t.Run("multiple GNSS devices, returns first sorted", func(t *testing.T) {
+		restore := setupUbloxReadDirMock(
+			map[string][]os.DirEntry{
+				fmt.Sprintf(ublox.GNSSDeviceSysfsTemplate, "ens7f0"): {
+					MockDirEntry{name: "gnss1"},
+					MockDirEntry{name: "gnss0"},
+				},
+			}, nil)
+		defer restore()
+
+		result, err := ublox.GNSSDeviceFromInterface("ens7f0")
+		assert.NoError(t, err)
+		assert.Equal(t, "/dev/gnss0", result)
+	})
+
+	t.Run("sysfs directory does not exist", func(t *testing.T) {
+		restore := setupUbloxReadDirMock(nil,
+			map[string]error{
+				fmt.Sprintf(ublox.GNSSDeviceSysfsTemplate, "ens7f0"): errors.New("no such file or directory"),
+			})
+		defer restore()
+
+		_, err := ublox.GNSSDeviceFromInterface("ens7f0")
+		assert.Error(t, err)
+	})
+
+	t.Run("sysfs directory is empty", func(t *testing.T) {
+		restore := setupUbloxReadDirMock(
+			map[string][]os.DirEntry{
+				fmt.Sprintf(ublox.GNSSDeviceSysfsTemplate, "ens7f0"): {},
+			}, nil)
+		defer restore()
+
+		_, err := ublox.GNSSDeviceFromInterface("ens7f0")
+		assert.Error(t, err)
+	})
 }
 
 func TestAutoDetectGNSSSerialPort(t *testing.T) {
@@ -228,10 +227,11 @@ verbose 1
 ts2phc.extts_polarity rising`
 
 	t.Run("patches config when GNSS device found", func(t *testing.T) {
-		mockFS, restoreFs := setupMockFS()
-		defer restoreFs()
-		mockFS.ExpectReadDir("/sys/class/net/ens7f0/device/gnss",
-			[]os.DirEntry{MockDirEntry{name: "gnss0"}}, nil)
+		restore := setupUbloxReadDirMock(
+			map[string][]os.DirEntry{
+				fmt.Sprintf(ublox.GNSSDeviceSysfsTemplate, "ens7f0"): {MockDirEntry{name: "gnss0"}},
+			}, nil)
+		defer restore()
 
 		conf := ts2phcConf
 		profile := &ptpv1.PtpProfile{Ts2PhcConf: &conf}
@@ -245,7 +245,6 @@ ts2phc.extts_polarity rising`
 				break
 			}
 		}
-		mockFS.VerifyAllCalls(t)
 	})
 
 	t.Run("skips when nmea_serialport already set", func(t *testing.T) {
@@ -269,16 +268,16 @@ ts2phc.extts_polarity rising`
 	})
 
 	t.Run("skips when sysfs lookup fails", func(t *testing.T) {
-		mockFS, restoreFs := setupMockFS()
-		defer restoreFs()
-		mockFS.ExpectReadDir("/sys/class/net/ens7f0/device/gnss",
-			nil, errors.New("no such file or directory"))
+		restore := setupUbloxReadDirMock(nil,
+			map[string]error{
+				fmt.Sprintf(ublox.GNSSDeviceSysfsTemplate, "ens7f0"): errors.New("no such file or directory"),
+			})
+		defer restore()
 
 		conf := ts2phcConf
 		profile := &ptpv1.PtpProfile{Ts2PhcConf: &conf}
 		autoDetectGNSSSerialPort(profile)
 
 		assert.NotContains(t, *profile.Ts2PhcConf, "ts2phc.nmea_serialport")
-		mockFS.VerifyAllCalls(t)
 	})
 }

--- a/addons/intel/ublx.go
+++ b/addons/intel/ublx.go
@@ -1,70 +1,15 @@
 package intel
 
 import (
-	"os/exec"
-	"slices"
-	"strings"
-
-	"github.com/golang/glog"
 	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/ublox"
 )
 
-// UblxCmdList is a list of UblxCmd items
-type UblxCmdList []UblxCmd
+// UblxCmdList is a list of UblxCmd items.
+// This is a type alias for ublox.CommandList, preserving JSON compatibility
+// with existing plugin configurations.
+type UblxCmdList = ublox.CommandList
 
-// UblxCmd represents a single ublox command
-type UblxCmd struct {
-	ReportOutput bool     `json:"reportOutput"`
-	Args         []string `json:"args"`
-}
-
-// ublxSaveCommand saves the current configuration
-var ublxSaveCommand = UblxCmd{
-	ReportOutput: false,
-	Args:         []string{"-p", "SAVE"},
-}
-
-// A named anonymous function for ease of mocking
-var execCombined = func(name string, arg ...string) ([]byte, error) {
-	return exec.Command(name, arg...).CombinedOutput()
-}
-
-// run a single UblxCmd and return the result
-func (cmd UblxCmd) run() (string, error) {
-	args := cmd.Args
-	if !slices.Contains(cmd.Args, "-w") {
-		// Default wait time is 2s per command; prefer 0.1s
-		args = append([]string{"-w", "0.1"}, args...)
-	}
-	glog.Infof("Running ubxtool with: %s", strings.Join(args, ", "))
-	stdout, err := execCombined(ublox.UBXCommand, args...)
-	return string(stdout), err
-}
-
-// run a set of UblxCmds, returning the output of any that have 'ReportOutput' set.
-func (cmdList UblxCmdList) runAll(withSave bool) []string {
-	results := []string{}
-	for _, cmd := range cmdList {
-		result, err := cmd.run()
-		if err != nil {
-			glog.Warningf("ubxtool error: %s", err)
-		}
-		if cmd.ReportOutput {
-			if err != nil {
-				results = append(results, err.Error())
-			} else {
-				glog.Infof("Saving status to hwconfig: %s", result)
-				results = append(results, result)
-			}
-		} else if err != nil {
-			glog.Infof("Not saving status to hwconfig: %s", result)
-		}
-	}
-	if withSave {
-		_, err := ublxSaveCommand.run()
-		if err != nil {
-			glog.Warningf("ubxtool SAVE error: %s", err)
-		}
-	}
-	return results
-}
+// UblxCmd represents a single ublox command.
+// This is a type alias for ublox.Command, preserving JSON compatibility
+// with existing plugin configurations.
+type UblxCmd = ublox.Command

--- a/addons/intel/ublx_test.go
+++ b/addons/intel/ublx_test.go
@@ -2,112 +2,117 @@ package intel
 
 import (
 	"errors"
-	"slices"
+	"strings"
 	"testing"
 
+	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/ublox"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-type mockExecutor struct {
-	actualCalls   []actualCall
-	expectedCalls []expectedCall
-	defaultResult execResult
+// mockRunner implements ublox.Runner, recording all commands passed to it
+// without executing anything. Tests verify command content at the Command
+// level, not the raw exec level.
+type mockRunner struct {
+	commands      []ublox.Command
+	defaultOutput string
+	defaultErr    error
 }
 
-type actualCall struct {
-	name string
-	args []string
+func (m *mockRunner) Run(cmd ublox.Command) (string, error) {
+	m.commands = append(m.commands, cmd)
+	return m.defaultOutput, m.defaultErr
 }
 
-type expectedCall struct {
-	args       []string
-	returnData []byte
-	returnErr  error
-}
-
-type execResult struct {
-	data []byte
-	err  error
-}
-
-func (m *mockExecutor) run(name string, arg ...string) ([]byte, error) {
-	m.actualCalls = append(m.actualCalls, actualCall{name, arg})
-	for _, expected := range m.expectedCalls {
-		if slices.Equal(expected.args, arg) {
-			return expected.returnData, expected.returnErr
+func (m *mockRunner) RunAll(cmds ublox.CommandList, withSave bool) []string {
+	var results []string
+	for _, cmd := range cmds {
+		output, err := m.Run(cmd)
+		if cmd.ReportOutput {
+			if err != nil {
+				results = append(results, err.Error())
+			} else {
+				results = append(results, output)
+			}
 		}
 	}
-	return m.defaultResult.data, m.defaultResult.err
+	if withSave {
+		m.Run(ublox.SaveCommand) //nolint:errcheck // mock always succeeds for SAVE
+	}
+	return results
 }
 
-func (m *mockExecutor) setDefaults(data string, err error) {
-	m.defaultResult.data = []byte(data)
-	m.defaultResult.err = err
+func (m *mockRunner) Save() error {
+	_, err := m.Run(ublox.SaveCommand)
+	return err
 }
 
-func (m *mockExecutor) expect(args []string, data string, err error) {
-	m.expectedCalls = append(m.expectedCalls, expectedCall{
-		args:       args,
-		returnData: []byte(data),
-		returnErr:  err,
-	})
+// containsCommand returns true if any recorded command's Args contain
+// all the given substrings.
+func (m *mockRunner) containsCommand(substrs ...string) bool {
+	for _, cmd := range m.commands {
+		joined := strings.Join(cmd.Args, " ")
+		allFound := true
+		for _, s := range substrs {
+			if !strings.Contains(joined, s) {
+				allFound = false
+				break
+			}
+		}
+		if allFound {
+			return true
+		}
+	}
+	return false
 }
 
-// setupExecMock sets up a mock executor (returns the executor and the restoration function)
-func setupExecMock() (*mockExecutor, func()) {
-	originalExec := execCombined
-	execMockData := &mockExecutor{}
-	execCombined = execMockData.run
-	return execMockData, func() { execCombined = originalExec }
-}
-
-func Test_UbxCmdRun(t *testing.T) {
-	execMock, execRestore := setupExecMock()
-	defer execRestore()
-	execMock.setDefaults("result", nil)
-
-	cmd := UblxCmd{Args: []string{"arg"}}
-	stdout, err := cmd.run()
-	assert.NoError(t, err)
-	assert.Equal(t, "result", stdout)
-	assert.Equal(t, 1, len(execMock.actualCalls))
-	assert.Equal(t, []string{"-w", "0.1", "arg"}, execMock.actualCalls[0].args)
-
-	execMock.setDefaults("", errors.New("Error"))
-	_, err = cmd.run()
-	assert.Error(t, err)
-	assert.Equal(t, 2, len(execMock.actualCalls))
+// setupCommandMock replaces NewCommandRunnerFn with a mock runner.
+// No ExecCommand stubbing is needed.
+func setupCommandMock() (*mockRunner, func()) {
+	orig := ublox.NewCommandRunnerFn
+	mock := &mockRunner{defaultOutput: "output"}
+	ublox.NewCommandRunnerFn = func() (ublox.Runner, error) {
+		return mock, nil
+	}
+	return mock, func() { ublox.NewCommandRunnerFn = orig }
 }
 
 func Test_UbxCmdListRunAll(t *testing.T) {
-	execMock, execRestore := setupExecMock()
-	defer execRestore()
-	execMock.setDefaults("", errors.New("Unexpected call"))
-	execMock.expect([]string{"-w", "0.1", "arg1"}, "result1", nil)
-	execMock.expect([]string{"-w", "2", "arg2"}, "result2", nil)
-	execMock.expect([]string{"-w", "0.1", "arg3"}, "", errors.New("error3"))
-	execMock.expect([]string{"-w", "0.1", "arg4"}, "", errors.New("error4"))
-	execMock.expect([]string{"-w", "0.1", "-p", "SAVE"}, "", nil)
+	mock, restore := setupCommandMock()
+	defer restore()
 
 	cmdList := UblxCmdList{
-		UblxCmd{
-			ReportOutput: false,
-			Args:         []string{"arg1"},
-		},
-		UblxCmd{
-			ReportOutput: true,
-			Args:         []string{"-w", "2", "arg2"},
-		},
-		UblxCmd{
-			ReportOutput: false,
-			Args:         []string{"arg3"},
-		},
-		UblxCmd{
-			ReportOutput: true,
-			Args:         []string{"arg4"},
-		},
+		{ReportOutput: false, Args: []string{"arg1"}},
+		{ReportOutput: true, Args: []string{"-w", "2", "arg2"}},
+		{ReportOutput: false, Args: []string{"arg3"}},
+		{ReportOutput: true, Args: []string{"arg4"}},
 	}
 
-	results := cmdList.runAll(true)
-	assert.Equal(t, []string{"result2", "error4"}, results)
+	results := cmdList.RunAll(true)
+
+	// Should have 2 reportable results
+	require.Equal(t, 2, len(results))
+	assert.Equal(t, "output", results[0])
+	assert.Equal(t, "output", results[1])
+
+	// Verify all commands were executed
+	assert.True(t, mock.containsCommand("arg1"))
+	assert.True(t, mock.containsCommand("arg2"))
+	assert.True(t, mock.containsCommand("arg3"))
+	assert.True(t, mock.containsCommand("arg4"))
+	assert.True(t, mock.containsCommand("SAVE"))
+}
+
+func Test_UbxCmdListRunAll_Error(t *testing.T) {
+	mock, restore := setupCommandMock()
+	defer restore()
+	mock.defaultErr = errors.New("exec failed")
+
+	cmdList := UblxCmdList{
+		{ReportOutput: true, Args: []string{"will-fail"}},
+	}
+
+	results := cmdList.RunAll(false)
+	require.Equal(t, 1, len(results))
+	assert.Contains(t, results[0], "exec failed")
 }

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -1249,9 +1249,11 @@ func (dn *Daemon) applyNodePtpProfile(runID int, nodeProfile *ptpv1.PtpProfile) 
 		} else if pProcess == ts2phcProcessName { //& if the x plugin is enabled
 			if clockType == event.GM {
 				if output.gnss_serial_port == "" {
-					output.gnss_serial_port = GPSPIPE_SERIALPORT
+					output.gnss_serial_port = GPSDDefaultGNSSSerialPort
+					glog.Warningf("Setting GNSS serial port to %s", output.gnss_serial_port)
 				}
 				gmInterface := dprocess.ifaces.GetLeadingInterface().Name
+				glog.Infof("Working with GNSS serial port %s, leading iface %s", output.gnss_serial_port, gmInterface)
 
 				// Record ublox init results (MON-HW, etc.) to NodePtpDevice status.
 				// Replaces any previous "gnss" entries to avoid duplicates on re-init.
@@ -1968,7 +1970,7 @@ func (p *ptpProcess) cmdSetEnabled(enabled bool) {
 				cmd := p.cmd
 				newCmd := exec.Command(cmd.Args[0], cmd.Args[1:]...)
 				p.cmd = newCmd
-				go p.cmdRun(p.dn.stdoutToSocket, &(p.dn.pluginManager))
+				go p.cmdRun(p.dn.stdoutToSocket, &p.dn.pluginManager)
 			}
 		} else {
 			go p.cmdStop()

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -439,7 +439,8 @@ type Daemon struct {
 	processManager *ProcessManager
 	readyTracker   *ReadyTracker
 
-	hwconfigs *[]ptpv1.HwConfig
+	hwconfigs   *[]ptpv1.HwConfig
+	hwconfigsMu sync.Mutex // protects hwconfigs from concurrent GPSD goroutine writes
 
 	// Hardware config manager handles hardware configurations from HardwareConfig CRs
 	hardwareConfigManager *hardwareconfig.HardwareConfigManager
@@ -774,7 +775,9 @@ func (dn *Daemon) applyNodePTPProfiles() error {
 	// only apply when nodeProfile changes
 
 	// clear hwconfig before updating
+	dn.hwconfigsMu.Lock()
 	*dn.hwconfigs = []ptpv1.HwConfig{}
+	dn.hwconfigsMu.Unlock()
 
 	glog.Infof("updating NodePTPProfiles to:")
 	runID := 0
@@ -889,7 +892,9 @@ func (dn *Daemon) applyNodePTPProfiles() error {
 			break
 		}
 	}
+	dn.hwconfigsMu.Lock()
 	dn.pluginManager.PopulateHwConfig(dn.hwconfigs)
+	dn.hwconfigsMu.Unlock()
 	*dn.refreshNodePtpDevice = true
 	dn.readyTracker.setConfig(true)
 	return dn.sendSidecarRestart()
@@ -1246,19 +1251,41 @@ func (dn *Daemon) applyNodePtpProfile(runID int, nodeProfile *ptpv1.PtpProfile) 
 				if output.gnss_serial_port == "" {
 					output.gnss_serial_port = GPSPIPE_SERIALPORT
 				}
-				// TODO: move this to plugin or call it from hwplugin or leave it here and remove Hardcoded
 				gmInterface := dprocess.ifaces.GetLeadingInterface().Name
 
+				// Record ublox init results (MON-HW, etc.) to NodePtpDevice status.
+				// Replaces any previous "gnss" entries to avoid duplicates on re-init.
+				gnssResultsFn := func(results []string) {
+					dn.hwconfigsMu.Lock()
+					defer dn.hwconfigsMu.Unlock()
+					// Remove previous gnss entries
+					filtered := (*dn.hwconfigs)[:0]
+					for _, hw := range *dn.hwconfigs {
+						if hw.DeviceID != "gnss" {
+							filtered = append(filtered, hw)
+						}
+					}
+					// Add current results
+					for _, result := range results {
+						filtered = append(filtered, ptpv1.HwConfig{
+							DeviceID: "gnss",
+							Status:   result,
+						})
+					}
+					*dn.hwconfigs = filtered
+				}
+
 				gpsDaemon := &GPSD{
-					name:        GPSD_PROCESSNAME,
-					execMutex:   sync.Mutex{},
-					cmd:         nil,
-					serialPort:  output.gnss_serial_port,
-					exitCh:      make(chan struct{}),
-					gmInterface: gmInterface,
-					stopped:     false,
-					messageTag:  messageTag,
-					ublxTool:    nil,
+					name:          GPSD_PROCESSNAME,
+					execMutex:     sync.Mutex{},
+					cmd:           nil,
+					serialPort:    output.gnss_serial_port,
+					exitCh:        make(chan struct{}),
+					gmInterface:   gmInterface,
+					stopped:       false,
+					messageTag:    messageTag,
+					ublxTool:      nil,
+					gnssResultsFn: gnssResultsFn,
 				}
 				gpsDaemon.CmdInit()
 				gpsDaemon.cmdLine = addScheduling(nodeProfile, gpsDaemon.cmdLine)

--- a/pkg/daemon/gpsd.go
+++ b/pkg/daemon/gpsd.go
@@ -50,6 +50,8 @@ type GPSD struct {
 	gmInterface          string
 	messageTag           string
 	ublxTool             *ublox.UBlox
+	gnssInitCmds         ublox.CommandList      // optional HardwareConfig GNSS init commands
+	gnssResultsFn        func(results []string) // callback to store GNSS init results
 	gpsdSession          *gpsdlib.Session
 	gpsdDoneCh           chan bool
 	sourceLost           bool
@@ -217,7 +219,7 @@ func (g *GPSD) MonitorGNSSEventsWithUblox() {
 		ticker.Stop()
 	}
 	for {
-		ublx, err := ublox.NewUblox()
+		ublx, err := ublox.NewUblox(g.gnssInitCmds...)
 		if err != nil {
 			glog.Errorf("failed to initialize GNSS monitoring via ublox %s", err)
 			select {
@@ -229,6 +231,9 @@ func (g *GPSD) MonitorGNSSEventsWithUblox() {
 			}
 		}
 		g.ublxTool = ublx
+		if results := ublx.InitResults(); len(results) > 0 && g.gnssResultsFn != nil {
+			g.gnssResultsFn(results)
+		}
 		missedTickers := 0
 		for {
 			select {

--- a/pkg/ublox/command.go
+++ b/pkg/ublox/command.go
@@ -1,0 +1,180 @@
+package ublox
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"regexp"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/golang/glog"
+)
+
+const (
+	// DefaultWait is the default ubxtool wait time (seconds) used when -w is not specified.
+	DefaultWait = "0.1"
+
+	// QueryTimeout is a longer wait time (seconds) used for commands that expect output
+	// (e.g., MON-VER, MON-HW).
+	QueryTimeout = "0.5"
+
+	// execTimeout is the maximum time to wait for a single ubxtool invocation
+	// before killing the process. Prevents hung ubxtool from blocking forever.
+	execTimeout = 30 * time.Second
+)
+
+var (
+	// Query ublox version information
+	cmdProtoVersion = Command{Args: []string{"-p", "MON-VER"}}
+	// Extract ublox version information
+	regexProtoVersion = regexp.MustCompile(`PROTVER=(\d+\.\d+)`)
+
+	// execCommand is the low-level function used to execute ubxtool.
+	// Replace in tests to mock ubxtool execution.
+	execCommand = defaultExecCommand
+
+	// NewCommandRunnerFn creates a Runner. Replace in tests to mock
+	// command execution at the runner level instead of the exec level.
+	NewCommandRunnerFn = defaultNewCommandRunnerFn
+
+	// SaveCommand is the ubxtool command that persists the current configuration.
+	SaveCommand = Command{
+		Args: []string{"-p", "SAVE"},
+	}
+)
+
+func defaultExecCommand(args ...string) ([]byte, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), execTimeout)
+	defer cancel()
+	return exec.CommandContext(ctx, UBXCommand, args...).CombinedOutput()
+}
+
+// Command represents a single ubxtool command.
+type Command struct {
+	ReportOutput bool     `json:"reportOutput"`
+	Args         []string `json:"args"`
+}
+
+// CommandList is a list of Commands.
+type CommandList []Command
+
+// Runner is the interface for executing ubxtool commands.
+// CommandRunner is the production implementation; tests can substitute a mock.
+type Runner interface {
+	Run(cmd Command) (string, error)
+	RunAll(cmds CommandList, withSave bool) []string
+	Save() error
+}
+
+func defaultNewCommandRunnerFn() (Runner, error) {
+	return NewCommandRunner()
+}
+
+// RunAll creates a convenience CommandRunner wrapper and executes all commands
+// with protocol detection and '-P' injection as needed. If withSave is true, a
+// SAVE command is appended. Returns output from commands that have
+// ReportOutput set.
+func (cmds CommandList) RunAll(withSave bool) []string {
+	runner, err := NewCommandRunnerFn()
+	if err != nil {
+		glog.Warningf("ubxtool error: %v", err)
+		return []string{
+			err.Error(),
+		}
+	}
+	return runner.RunAll(cmds, withSave)
+}
+
+// CommandRunner executes ubxtool commands with automatic protocol version
+// and wait time handling.
+type CommandRunner struct {
+	protoVersion string
+}
+
+// NewCommandRunner detects the UBX protocol version and returns a runner.
+func NewCommandRunner() (*CommandRunner, error) {
+	runner := &CommandRunner{}
+	version, err := runner.Query(cmdProtoVersion, regexProtoVersion)
+	if err != nil {
+		return nil, fmt.Errorf("command runner init failed: %w", err)
+	}
+	runner.protoVersion = version
+	glog.Infof("ubxtool: command runner initialized with protocol version %s", version)
+	return runner, nil
+}
+
+// Run executes a single command. It prepends -P <version> if the runner has a
+// protocol version and the command doesn't already include -P. It also prepends
+// -w <DefaultWait> if -w is not already in the args.
+func (r *CommandRunner) Run(cmd Command) (string, error) {
+	args := r.buildArgs(cmd.Args)
+	glog.Infof("ubxtool: running %s", strings.Join(args, " "))
+	output, err := execCommand(args...)
+	if err != nil {
+		return string(output), fmt.Errorf("ubxtool %v failed: [%s] %w", args, string(output), err)
+	}
+	return string(output), nil
+}
+
+// RunAll executes a list of commands. If withSave is true, a SAVE command is
+// appended. Returns output from commands that have ReportOutput set.
+func (r *CommandRunner) RunAll(cmds CommandList, withSave bool) []string {
+	var results []string
+	for _, cmd := range cmds {
+		result, err := r.Run(cmd)
+		if err != nil {
+			glog.Warningf("ubxtool error: %v", err)
+			if cmd.ReportOutput {
+				results = append(results, err.Error())
+			}
+			continue
+		}
+		if cmd.ReportOutput {
+			glog.Infof("ubxtool: recording output: %s", result)
+			results = append(results, result)
+		}
+	}
+	if withSave {
+		if err := r.Save(); err != nil {
+			glog.Warningf("ubxtool SAVE error: %v", err)
+		}
+	}
+	return results
+}
+
+// Save persists the current ublox configuration.
+func (r *CommandRunner) Save() error {
+	_, err := r.Run(SaveCommand)
+	return err
+}
+
+// Query executes a command with QueryTimeout and matches the output against
+// the given regex. Returns the first capture group on success.
+func (r *CommandRunner) Query(cmd Command, promptRE *regexp.Regexp) (string, error) {
+	// Use QueryTimeout for commands expecting output
+	cmd.Args = append([]string{"-w", QueryTimeout}, cmd.Args...)
+	output, err := r.Run(cmd)
+	if err != nil {
+		return "", err
+	}
+	match := promptRE.FindStringSubmatch(output)
+	if len(match) > 0 {
+		return match[1], nil
+	}
+	return "", fmt.Errorf("ubxtool output did not match %s: %s", promptRE.String(), output)
+}
+
+// buildArgs constructs the full argument list for a ubxtool invocation.
+func (r *CommandRunner) buildArgs(args []string) []string {
+	var fullArgs []string
+	if r.protoVersion != "" && !slices.Contains(args, "-P") {
+		fullArgs = append(fullArgs, "-P", r.protoVersion)
+	}
+	if !slices.Contains(args, "-w") {
+		fullArgs = append(fullArgs, "-w", DefaultWait)
+	}
+	fullArgs = append(fullArgs, args...)
+	return fullArgs
+}

--- a/pkg/ublox/command_test.go
+++ b/pkg/ublox/command_test.go
@@ -1,0 +1,198 @@
+package ublox
+
+import (
+	"errors"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Test constants to avoid goconst warnings
+const (
+	testProtoVersion  = "29.20"
+	testProtoVersion2 = "29.25"
+	testAntVoltCfg    = "CFG-HW-ANT_CFG_VOLTCTRL,1"
+	testGPS           = "GPS"
+)
+
+type execCall struct {
+	args []string
+}
+
+type execMock struct {
+	calls         []execCall
+	defaultOutput string
+	defaultErr    error
+	expectations  []execExpectation
+}
+
+type execExpectation struct {
+	matchArgs []string
+	output    string
+	err       error
+}
+
+func (m *execMock) run(args ...string) ([]byte, error) {
+	m.calls = append(m.calls, execCall{args: slices.Clone(args)})
+	for _, exp := range m.expectations {
+		needle := strings.Join(exp.matchArgs, "::")
+		haystack := strings.Join(args, "::")
+		if strings.Contains(haystack, needle) {
+			return []byte(exp.output), exp.err
+		}
+	}
+	return []byte(m.defaultOutput), m.defaultErr
+}
+
+func setupExecMock() (*execMock, func()) {
+	orig := execCommand
+	mock := &execMock{defaultOutput: "OK"}
+	execCommand = mock.run
+	return mock, func() { execCommand = orig }
+}
+
+func TestBuildArgs(t *testing.T) {
+	t.Run("injects protocol version and wait", func(t *testing.T) {
+		r := &CommandRunner{testProtoVersion}
+		args := r.buildArgs([]string{"-z", testAntVoltCfg})
+		assert.Equal(t, []string{"-P", testProtoVersion, "-w", DefaultWait, "-z", testAntVoltCfg}, args)
+	})
+
+	t.Run("skips -P when version is empty", func(t *testing.T) {
+		r := &CommandRunner{}
+		args := r.buildArgs([]string{"-z", testAntVoltCfg})
+		assert.Equal(t, []string{"-w", DefaultWait, "-z", testAntVoltCfg}, args)
+	})
+
+	t.Run("skips -P when already in args", func(t *testing.T) {
+		r := &CommandRunner{testProtoVersion}
+		args := r.buildArgs([]string{"-P", testProtoVersion2, "-z", testAntVoltCfg})
+		assert.Equal(t, []string{"-w", DefaultWait, "-P", testProtoVersion2, "-z", testAntVoltCfg}, args)
+	})
+
+	t.Run("skips -w when already in args", func(t *testing.T) {
+		r := &CommandRunner{testProtoVersion}
+		args := r.buildArgs([]string{"-w", "5", "-e", "SURVEYIN,600,50000"})
+		assert.Equal(t, []string{"-P", testProtoVersion, "-w", "5", "-e", "SURVEYIN,600,50000"}, args)
+	})
+
+	t.Run("empty version and user-supplied -w", func(t *testing.T) {
+		r := &CommandRunner{}
+		args := r.buildArgs([]string{"-P", testProtoVersion2, "-w", "2", "arg"})
+		assert.Equal(t, []string{"-P", testProtoVersion2, "-w", "2", "arg"}, args)
+	})
+}
+
+func TestCommandRunnerRun(t *testing.T) {
+	mock, restore := setupExecMock()
+	defer restore()
+
+	r := &CommandRunner{testProtoVersion}
+
+	t.Run("success", func(t *testing.T) {
+		result, err := r.Run(Command{Args: []string{"-e", testGPS}})
+		require.NoError(t, err)
+		assert.Equal(t, "OK", result)
+		assert.Equal(t, 1, len(mock.calls))
+		assert.Equal(t, []string{"-P", testProtoVersion, "-w", DefaultWait, "-e", testGPS}, mock.calls[0].args)
+	})
+
+	t.Run("error", func(t *testing.T) {
+		mock.calls = nil
+		mock.defaultErr = errors.New("failed")
+		_, err := r.Run(Command{Args: []string{"-e", testGPS}})
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "failed")
+		mock.defaultErr = nil
+	})
+}
+
+func TestCommandRunnerRunAll(t *testing.T) {
+	mock, restore := setupExecMock()
+	defer restore()
+	mock.expectations = []execExpectation{
+		{matchArgs: []string{"-w", DefaultWait, "fail"}, output: "error output", err: errors.New("cmd failed")},
+	}
+
+	r := &CommandRunner{}
+
+	cmds := CommandList{
+		{Args: []string{"cmd1"}, ReportOutput: false},
+		{Args: []string{"cmd2"}, ReportOutput: true},
+		{Args: []string{"fail"}, ReportOutput: true},
+		{Args: []string{"cmd4"}, ReportOutput: false},
+	}
+
+	results := r.RunAll(cmds, false)
+
+	// cmd2 reports "OK", fail reports error
+	require.Equal(t, 2, len(results))
+	assert.Equal(t, "OK", results[0])
+	assert.Contains(t, results[1], "cmd failed")
+	assert.Equal(t, 4, len(mock.calls))
+}
+
+func TestCommandRunnerRunAllWithSave(t *testing.T) {
+	mock, restore := setupExecMock()
+	defer restore()
+
+	r := &CommandRunner{testProtoVersion}
+
+	cmds := CommandList{
+		{Args: []string{"-e", testGPS}},
+	}
+
+	_ = r.RunAll(cmds, true)
+
+	// Should have 2 calls: the command + SAVE
+	require.Equal(t, 2, len(mock.calls))
+	lastArgs := mock.calls[1].args
+	assert.True(t, slices.Contains(lastArgs, "SAVE"), "last call should be SAVE, got: %v", lastArgs)
+}
+
+func TestCommandListRunAll(t *testing.T) {
+	mock, restore := setupExecMock()
+	defer restore()
+	mock.expectations = []execExpectation{
+		{matchArgs: cmdProtoVersion.Args, output: "PROTVER=29.20"},
+	}
+
+	cmds := CommandList{
+		{Args: []string{"-P", testProtoVersion2, "-z", testAntVoltCfg}, ReportOutput: false},
+		{Args: []string{"-P", testProtoVersion2, "-e", testGPS}, ReportOutput: true},
+	}
+
+	results := cmds.RunAll(true)
+
+	// cmd2 reports output, plus SAVE at end
+	require.Equal(t, 1, len(results))
+	assert.Equal(t, "OK", results[0])
+
+	// 3 calls: 2 commands + SAVE
+	assert.Equal(t, 4, len(mock.calls))
+
+	// No extra -P injection since commands already have -P
+	for _, call := range mock.calls[1:3] {
+		count := 0
+		for _, arg := range call.args {
+			if arg == "-P" {
+				count++
+			}
+		}
+		assert.Equal(t, 1, count, "should not double-inject -P: %v", call.args)
+	}
+}
+
+func TestNewCommandRunner(t *testing.T) {
+	mock, restore := setupExecMock()
+	defer restore()
+
+	mock.defaultOutput = "PROTVER=29.20"
+	runner, err := NewCommandRunner()
+	require.NoError(t, err)
+	assert.Equal(t, testProtoVersion, runner.protoVersion)
+	assert.Equal(t, 1, len(mock.calls))
+}

--- a/pkg/ublox/device.go
+++ b/pkg/ublox/device.go
@@ -1,0 +1,44 @@
+package ublox
+
+import (
+	"fmt"
+	"os"
+	"sort"
+
+	"github.com/golang/glog"
+)
+
+const (
+	// GNSSDeviceSysfsTemplate is the sysfs path template for finding GNSS
+	// devices attached to a network interface.
+	GNSSDeviceSysfsTemplate = "/sys/class/net/%s/device/gnss"
+)
+
+// ReadDir is the function used to read sysfs directories.
+// Replace in tests to mock filesystem access.
+var ReadDir = os.ReadDir
+
+// GNSSDeviceFromInterface resolves the GNSS TTY device path for a given
+// network interface by reading the sysfs directory
+// /sys/class/net/<iface>/device/gnss/.
+func GNSSDeviceFromInterface(iface string) (string, error) {
+	glog.Infof("Looking for GNSS device associated with iface %s", iface)
+	gnssDir := fmt.Sprintf(GNSSDeviceSysfsTemplate, iface)
+	entries, err := ReadDir(gnssDir)
+	if err != nil {
+		return "", fmt.Errorf("no GNSS device found for interface %s: %w", iface, err)
+	}
+	if len(entries) == 0 {
+		return "", fmt.Errorf("GNSS sysfs directory %s is empty", gnssDir)
+	}
+	if len(entries) > 1 {
+		// Sort for deterministic selection when multiple devices exist
+		sort.Slice(entries, func(i, j int) bool {
+			return entries[i].Name() < entries[j].Name()
+		})
+		glog.Warningf("multiple GNSS devices found for %s, using %s", iface, entries[0].Name())
+	}
+	result := fmt.Sprintf("/dev/%s", entries[0].Name())
+	glog.Infof("Detected GNSS device %s", result)
+	return result, nil
+}

--- a/pkg/ublox/device_test.go
+++ b/pkg/ublox/device_test.go
@@ -1,0 +1,107 @@
+package ublox
+
+import (
+	"errors"
+	"io/fs"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type mockDirEntry struct {
+	name  string
+	isDir bool
+}
+
+func (m mockDirEntry) Name() string               { return m.name }
+func (m mockDirEntry) IsDir() bool                { return m.isDir }
+func (m mockDirEntry) Type() fs.FileMode          { return 0 }
+func (m mockDirEntry) Info() (fs.FileInfo, error) { return mockFileInfo{name: m.name}, nil }
+
+type mockFileInfo struct{ name string }
+
+func (m mockFileInfo) Name() string       { return m.name }
+func (m mockFileInfo) Size() int64        { return 0 }
+func (m mockFileInfo) Mode() fs.FileMode  { return 0 }
+func (m mockFileInfo) ModTime() time.Time { return time.Time{} }
+func (m mockFileInfo) IsDir() bool        { return false }
+func (m mockFileInfo) Sys() interface{}   { return nil }
+
+const testSysfsPath = "/sys/class/net/ens7f0/device/gnss"
+
+func setupReadDirMock(entries map[string][]os.DirEntry, errs map[string]error) func() {
+	orig := ReadDir
+	ReadDir = func(name string) ([]os.DirEntry, error) {
+		if errs != nil {
+			if err, ok := errs[name]; ok {
+				return nil, err
+			}
+		}
+		if entries != nil {
+			if e, ok := entries[name]; ok {
+				return e, nil
+			}
+		}
+		return nil, errors.New("not found")
+	}
+	return func() { ReadDir = orig }
+}
+
+func TestGNSSDeviceFromInterface(t *testing.T) {
+	t.Run("single device", func(t *testing.T) {
+		restore := setupReadDirMock(
+			map[string][]os.DirEntry{
+				testSysfsPath: {mockDirEntry{name: "gnss0"}},
+			}, nil,
+		)
+		defer restore()
+
+		device, err := GNSSDeviceFromInterface("ens7f0")
+		assert.NoError(t, err)
+		assert.Equal(t, "/dev/gnss0", device)
+	})
+
+	t.Run("multiple devices returns first sorted", func(t *testing.T) {
+		restore := setupReadDirMock(
+			map[string][]os.DirEntry{
+				testSysfsPath: {
+					mockDirEntry{name: "gnss1"},
+					mockDirEntry{name: "gnss0"},
+				},
+			}, nil,
+		)
+		defer restore()
+
+		device, err := GNSSDeviceFromInterface("ens7f0")
+		assert.NoError(t, err)
+		assert.Equal(t, "/dev/gnss0", device)
+	})
+
+	t.Run("sysfs directory does not exist", func(t *testing.T) {
+		restore := setupReadDirMock(nil,
+			map[string]error{
+				testSysfsPath: errors.New("no such file or directory"),
+			},
+		)
+		defer restore()
+
+		_, err := GNSSDeviceFromInterface("ens7f0")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "no GNSS device found")
+	})
+
+	t.Run("sysfs directory is empty", func(t *testing.T) {
+		restore := setupReadDirMock(
+			map[string][]os.DirEntry{
+				testSysfsPath: {},
+			}, nil,
+		)
+		defer restore()
+
+		_, err := GNSSDeviceFromInterface("ens7f0")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "empty")
+	})
+}

--- a/pkg/ublox/ublox.go
+++ b/pkg/ublox/ublox.go
@@ -43,6 +43,11 @@ var (
 	ublxBusTypes = []string{
 		"I2C", "UART1", "UART2", "USB", "SPI",
 	}
+
+	monHW = Command{
+		Args:         []string{"-w", QueryTimeout, "-p", "MON-HW"},
+		ReportOutput: true,
+	}
 )
 
 func cmdMsgoutAllBusses(prefix, msg string, val int) CommandList {
@@ -81,8 +86,6 @@ func defaultUblxCmds() CommandList {
 		cmds = append(cmds, cmdDisableNmeaMsg(msg)...)
 	}
 
-	// Finally, save the state
-	cmds = append(cmds, SaveCommand)
 	return cmds
 }
 
@@ -91,6 +94,7 @@ type UBlox struct {
 	status       int
 	statusMutex  sync.Mutex
 	protoVersion string
+	initResults  []string // recorded output from extra init commands with ReportOutput=true
 	mockExp      func(cmdStr string) ([]string, error)
 	cmd          *exec.Cmd
 	reader       *bufio.Reader
@@ -100,28 +104,53 @@ type UBlox struct {
 	buffermutex  sync.Mutex
 }
 
-// NewUblox creates and initializes a new Ublox monitoring object
-// Returns an error if the underlying gps channel is not available or the protocol version could not be detected
-func NewUblox() (*UBlox, error) {
+// InitResults returns recorded output from extra init commands that had
+// ReportOutput set to true. Returns nil if no extra commands were provided
+// or none had ReportOutput set.
+func (u *UBlox) InitResults() []string {
+	return u.initResults
+}
+
+// NewUblox creates and initializes a new Ublox monitoring object.
+// Optional extraCmds are run after the default initialization commands
+// but before SAVE (e.g., GNSS configuration from HardwareConfig).
+// Returns an error if the underlying gps channel is not available or the protocol version could not be detected.
+func NewUblox(extraCmds ...Command) (*UBlox, error) {
 	u := UBlox{}
-	if err := u.Init(); err != nil {
+	if err := u.Init(extraCmds...); err != nil {
 		return nil, err
 	}
 	return &u, nil
 }
 
-// Init detects the protocol version and sets up the core message types we require for both GNSS monitoring and ts2phc
-func (u *UBlox) Init() error {
+// Init detects the protocol version and sets up the core message types
+// we require for both GNSS monitoring and ts2phc. Optional extraCmds
+// are run after the defaults but before the final SAVE.
+func (u *UBlox) Init(extraCmds ...Command) error {
 	runner, err := NewCommandRunner()
 	if err != nil {
 		return fmt.Errorf("no version detected: %w", err)
 	}
 	u.protoVersion = runner.protoVersion
 	glog.Infof("UBX protocol version detected: %s", u.protoVersion)
+
+	// Build the full init sequence: defaults → extras → MON-HW → SAVE
+	var cmds CommandList
+	cmds = append(cmds, defaultUblxCmds()...)
+	cmds = append(cmds, extraCmds...)
+	cmds = append(cmds, monHW, SaveCommand)
+
 	var errs []error
-	for _, cmd := range defaultUblxCmds() {
-		_, runErr := runner.Run(cmd)
+	for _, cmd := range cmds {
+		output, runErr := runner.Run(cmd)
 		errs = append(errs, runErr)
+		if cmd.ReportOutput {
+			if runErr != nil {
+				u.initResults = append(u.initResults, runErr.Error())
+			} else {
+				u.initResults = append(u.initResults, output)
+			}
+		}
 	}
 	return errors.Join(errs...)
 }

--- a/pkg/ublox/ublox.go
+++ b/pkg/ublox/ublox.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"os/exec"
-	"regexp"
 	"strconv"
 	"strings"
 	"sync"
@@ -14,40 +13,32 @@ import (
 	"github.com/golang/glog"
 )
 
-var regexProtoVersion = regexp.MustCompile(`PROTVER=(\d+\.\d+)`)
-
 const (
 	// UBXCommand is the full path to the ubxtool command in the container
 	UBXCommand = "/usr/local/bin/ubxtool"
 
-	UBXTOOL_NEW     = 0
-	UBXTOOL_ACTIVE  = 1
-	UBXTOOL_DEAD    = 2
-	UBXTOOL_STOPPED = 3
+	ubxtoolNew     = 0
+	ubxtoolActive  = 1
+	ubxtoolDead    = 2
+	ubxtoolStopped = 3
 
-	setOnlyTimeout = "0.1"
-	queryTimeout   = "0.5"
-	pollTimeout    = "1000000000"
-
-	fallbackProtocolVesion = "29.20"
-
-	cmdProtoVersion = "-p MON-VER"
+	pollTimeout = "1000000000"
 )
 
 var (
 	// Disable all binary messages
-	disableBinary = []string{"-d", "BINARY"}
+	disableBinary = Command{Args: []string{"-d", "BINARY"}}
 	// Re-enable NAV-CLOCK every 1s
-	enableBinaryNavClock = []string{"-p", "CFG-MSG,1,34,1"}
+	enableBinaryNavClock = Command{Args: []string{"-p", "CFG-MSG,1,34,1"}}
 	// Re-enable NAV-CLOCK every 1s
-	enableBinaryNavStatus = []string{"-p", "CFG-MSG,1,3,1"}
+	enableBinaryNavStatus = Command{Args: []string{"-p", "CFG-MSG,1,3,1"}}
 
 	// Enable all NMEA messages
-	enableNMEA = []string{"-e", "NMEA"}
+	enableNMEA = Command{Args: []string{"-e", "NMEA"}}
 	// Disable unneeded SA messages
-	disableSA = []string{"-p", "CFG-MSG,0xf0,0x02,0"}
+	disableSA = Command{Args: []string{"-p", "CFG-MSG,0xf0,0x02,0"}}
 	// Disable unneeded SV messages
-	disableSv = []string{"-p", "CFG-MSG,0xf0,0x03,0"}
+	disableSv = Command{Args: []string{"-p", "CFG-MSG,0xf0,0x03,0"}}
 
 	// Additional NMEA messages to disable by default
 	nmeaDisableMsg = []string{
@@ -58,28 +49,28 @@ var (
 	nmeaBusTypes = []string{
 		"I2C", "UART1", "UART2", "USB", "SPI",
 	}
-
-	// Final command: Save the ublox state
-	saveState = []string{"-p", "SAVE"}
 )
 
 // Generates a series of UblxCmds which disable the given message type on all bus types
-func cmdDisableNmeaMsg(msg string) [][]string {
-	result := make([][]string, len(nmeaBusTypes))
+func cmdDisableNmeaMsg(msg string) CommandList {
+	result := make(CommandList, len(nmeaBusTypes))
 	for i, bus := range nmeaBusTypes {
-		result[i] = []string{"-z", fmt.Sprintf("CFG-MSGOUT-NMEA_ID_%s_%s,0", msg, bus)}
+		result[i] = Command{
+			Args: []string{"-z", fmt.Sprintf("CFG-MSGOUT-NMEA_ID_%s_%s,0", msg, bus)},
+		}
 	}
 	return result
 }
 
 // Return the default set of commands we need to set at initialization
-func defaultUblxCmds() [][]string {
+func defaultUblxCmds() CommandList {
 	// Begin by disabling all binary commands, then re-adding only NAV-CLOCK and NAV-STATUS
-	cmds := [][]string{
+	cmds := CommandList{
 		disableBinary, enableBinaryNavClock, enableBinaryNavStatus,
 	}
 	// Next, enable all NMEA commands, but prune out any we don't need:
-	cmds = append(cmds,
+	cmds = append(
+		cmds,
 		enableNMEA, disableSA, disableSv,
 	)
 	// More pruning of all bus-specific NMEA messages
@@ -88,7 +79,7 @@ func defaultUblxCmds() [][]string {
 	}
 
 	// Finally, save the state
-	cmds = append(cmds, saveState)
+	cmds = append(cmds, SaveCommand)
 	return cmds
 }
 
@@ -118,61 +109,18 @@ func NewUblox() (*UBlox, error) {
 
 // Init detects the protocol version and sets up the core message types we require for both GNSS monitoring and ts2phc
 func (u *UBlox) Init() error {
-	protoVersion, err := u.query(cmdProtoVersion, regexProtoVersion)
+	runner, err := NewCommandRunner()
 	if err != nil {
-		return fmt.Errorf("no version detected: version for method %s with error %s", "MON-VER", err)
+		return fmt.Errorf("no version detected: %w", err)
 	}
-	u.protoVersion = protoVersion
-	glog.Infof("UBX protocol version detected: %s", protoVersion)
-	errs := []error{}
+	u.protoVersion = runner.protoVersion
+	glog.Infof("UBX protocol version detected: %s", u.protoVersion)
+	var errs []error
 	for _, cmd := range defaultUblxCmds() {
-		errs = append(errs, u.setOnly(cmd...))
+		_, runErr := runner.Run(cmd)
+		errs = append(errs, runErr)
 	}
 	return errors.Join(errs...)
-}
-
-// Execute a ubxtool query (run a command, wait for output, and match against the given regex for output)
-func (u *UBlox) query(command string, promptRE *regexp.Regexp) (string, error) {
-	args := []string{"-w", queryTimeout}
-	if u.protoVersion == "" {
-		// Only cmdProtoVersion can be run without a known protoVersion (because it establishes it)
-		if command != cmdProtoVersion {
-			return "", fmt.Errorf("cannot query UBlox without protocol version ")
-		}
-	} else {
-		args = append(args, "-P", u.protoVersion)
-	}
-	args = append(args, strings.Fields(command)...)
-	output, err := u.ubxtool(args...)
-	if err != nil {
-		return "", err
-	}
-	match := promptRE.FindStringSubmatch(output)
-	if len(match) > 0 {
-		return match[1], nil
-	}
-	return "", fmt.Errorf("ubxtool output did not match %s: %s", promptRE.String(), output)
-}
-
-// Execute a set-only command (run a command, do not wait for output)
-func (u *UBlox) setOnly(command ...string) error {
-	if u.protoVersion == "" {
-		return fmt.Errorf("cannot set data without protocol version")
-	}
-	args := []string{"-w", setOnlyTimeout, "-P", u.protoVersion}
-	args = append(args, command...)
-	_, err := u.ubxtool(args...)
-	return err
-}
-
-// Low-level command: Run ubxtool and return its output
-func (u *UBlox) ubxtool(command ...string) (string, error) {
-	glog.Infof("Running ubxtool %v...", command)
-	output, err := exec.Command(UBXCommand, command...).CombinedOutput()
-	if err != nil {
-		err = fmt.Errorf("ubxtool failed: [Stdout/Stderr: %s] %w", output, err)
-	}
-	return string(output), err
 }
 
 // UbloxPollPull safely pulls data from the u.buffer
@@ -190,27 +138,23 @@ func (u *UBlox) UbloxPollPull() string {
 
 // UbloxPollInit initializes the poll thread
 func (u *UBlox) UbloxPollInit() {
-	protoVersion := u.protoVersion
-	if protoVersion == "" {
-		// Since there's no error return, we best-effort by guessing the protocol version
-		protoVersion = fallbackProtocolVesion
-		glog.Warningf("Protocol version was not detected; falling back to %s", protoVersion)
-	}
-	if u.getStatus() == UBXTOOL_NEW || u.getStatus() == UBXTOOL_DEAD {
+	if u.getStatus() == ubxtoolNew || u.getStatus() == ubxtoolDead {
 		u.buffermutex.Lock()
 		u.bufferlen = 0
 		u.buffer = nil
 		u.buffermutex.Unlock()
 		// Run via `python -u ubxtool` to force unbuffered stdin/stdout
-		args := []string{"-u", UBXCommand, "-t", "-P", protoVersion, "-w", pollTimeout}
+		args := []string{"-u", UBXCommand, "-t", "-P", u.protoVersion, "-w", pollTimeout}
 		u.cmd = exec.Command("python3", args...)
 		stdoutreader, _ := u.cmd.StdoutPipe()
 		u.reader = bufio.NewReader(stdoutreader)
-		u.setStatus(UBXTOOL_ACTIVE)
+		u.setStatus(ubxtoolActive)
 		err := u.cmd.Start()
 		if err != nil {
 			glog.Errorf("UbloxPoll err=%s", err.Error())
-			u.setStatus(UBXTOOL_STOPPED)
+			// TODO: Switching this to ubxtoolDead would allow recovery in the
+			// future, but we are not making functional changes in this refactor.
+			u.setStatus(ubxtoolStopped)
 		} else {
 			pid := u.cmd.Process.Pid
 			glog.Infof("Starting ubxtool polling with PID=%d", pid)
@@ -224,8 +168,8 @@ func (u *UBlox) UbloxPollPushThread() {
 	for {
 		output, err := u.reader.ReadString('\n')
 		if err != nil {
-			if u.getStatus() != UBXTOOL_STOPPED {
-				u.setStatus(UBXTOOL_DEAD)
+			if u.getStatus() != ubxtoolStopped {
+				u.setStatus(ubxtoolDead)
 			}
 			glog.Errorf("ublox poll thread error %s", err)
 			return
@@ -258,8 +202,8 @@ func (u *UBlox) UbloxPollReset() {
 	pid := u.cmd.Process.Pid
 	glog.Infof("Resetting ubxtool polling with PID=%d", pid)
 	_ = u.cmd.Process.Kill()
-	if u.getStatus() != UBXTOOL_STOPPED {
-		u.setStatus(UBXTOOL_DEAD)
+	if u.getStatus() != ubxtoolStopped {
+		u.setStatus(ubxtoolDead)
 	}
 	u.cmd.Wait()
 }
@@ -268,7 +212,7 @@ func (u *UBlox) UbloxPollReset() {
 func (u *UBlox) UbloxPollStop() {
 	pid := u.cmd.Process.Pid
 	glog.Infof("Stopping ubxtool polling with PID=%d", pid)
-	u.setStatus(UBXTOOL_STOPPED)
+	u.setStatus(ubxtoolStopped)
 	_ = u.cmd.Process.Kill()
 	u.cmd.Wait()
 }

--- a/pkg/ublox/ublox.go
+++ b/pkg/ublox/ublox.go
@@ -28,51 +28,54 @@ const (
 var (
 	// Disable all binary messages
 	disableBinary = Command{Args: []string{"-d", "BINARY"}}
-	// Re-enable NAV-CLOCK every 1s
-	enableBinaryNavClock = Command{Args: []string{"-p", "CFG-MSG,1,34,1"}}
-	// Re-enable NAV-CLOCK every 1s
-	enableBinaryNavStatus = Command{Args: []string{"-p", "CFG-MSG,1,3,1"}}
+	// NAV message types to re-enable
+	navEnableMsg = []string{
+		"CLOCK", "STATUS", "TIMELS",
+	}
 
 	// Enable all NMEA messages
-	enableNMEA = Command{Args: []string{"-e", "NMEA"}}
-	// Disable unneeded SA messages
-	disableSA = Command{Args: []string{"-p", "CFG-MSG,0xf0,0x02,0"}}
-	// Disable unneeded SV messages
-	disableSv = Command{Args: []string{"-p", "CFG-MSG,0xf0,0x03,0"}}
-
-	// Additional NMEA messages to disable by default
+	enableNMEA     = Command{Args: []string{"-e", "NMEA"}}
 	nmeaDisableMsg = []string{
-		"VTG", "GST", "ZDA", "GBS",
+		"VTG", "GST", "ZDA", "GBS", "GSA", "GSV",
 	}
 
 	// All NMEA bus types to disable NMEA messages
-	nmeaBusTypes = []string{
+	ublxBusTypes = []string{
 		"I2C", "UART1", "UART2", "USB", "SPI",
 	}
 )
 
-// Generates a series of UblxCmds which disable the given message type on all bus types
-func cmdDisableNmeaMsg(msg string) CommandList {
-	result := make(CommandList, len(nmeaBusTypes))
-	for i, bus := range nmeaBusTypes {
+func cmdMsgoutAllBusses(prefix, msg string, val int) CommandList {
+	result := make(CommandList, len(ublxBusTypes))
+	for i, bus := range ublxBusTypes {
 		result[i] = Command{
-			Args: []string{"-z", fmt.Sprintf("CFG-MSGOUT-NMEA_ID_%s_%s,0", msg, bus)},
+			Args: []string{"-z", fmt.Sprintf("CFG-MSGOUT-%s_%s_%s,%d", prefix, msg, bus, val)},
 		}
 	}
 	return result
 }
 
+// Generates a series of UblxCmds which disable the given message type on all bus types
+func cmdDisableNmeaMsg(msg string) CommandList {
+	return cmdMsgoutAllBusses("NMEA_ID", msg, 0)
+}
+
+// Generate a series of commands to enable the given b8nary command on all bus types
+func cmdEnableNavMsg(msg string) CommandList {
+	return cmdMsgoutAllBusses("UBX_NAV", msg, 1)
+}
+
 // Return the default set of commands we need to set at initialization
 func defaultUblxCmds() CommandList {
-	// Begin by disabling all binary commands, then re-adding only NAV-CLOCK and NAV-STATUS
-	cmds := CommandList{
-		disableBinary, enableBinaryNavClock, enableBinaryNavStatus,
+	// Begin by disabling all binary commands, then re-adding the ones we need
+	cmds := CommandList{disableBinary}
+	// Re-enable required b8nary commands
+	for _, msg := range navEnableMsg {
+		cmds = append(cmds, cmdEnableNavMsg(msg)...)
 	}
+
 	// Next, enable all NMEA commands, but prune out any we don't need:
-	cmds = append(
-		cmds,
-		enableNMEA, disableSA, disableSv,
-	)
+	cmds = append(cmds, enableNMEA)
 	// More pruning of all bus-specific NMEA messages
 	for _, msg := range nmeaDisableMsg {
 		cmds = append(cmds, cmdDisableNmeaMsg(msg)...)

--- a/pkg/ublox/ublox.go
+++ b/pkg/ublox/ublox.go
@@ -50,41 +50,37 @@ var (
 	}
 )
 
-func cmdMsgoutAllBusses(prefix, msg string, val int) CommandList {
-	result := make(CommandList, len(ublxBusTypes))
-	for i, bus := range ublxBusTypes {
-		result[i] = Command{
-			Args: []string{"-z", fmt.Sprintf("CFG-MSGOUT-%s_%s_%s,%d", prefix, msg, bus, val)},
+func batchMsgoutAllBusses(prefix string, msgs []string, val int) Command {
+	result := Command{}
+	for _, msg := range msgs {
+		for _, bus := range ublxBusTypes {
+			result.Args = append(result.Args, "-z", fmt.Sprintf("CFG-MSGOUT-%s_%s_%s,%d", prefix, msg, bus, val))
 		}
 	}
 	return result
 }
 
 // Generates a series of UblxCmds which disable the given message type on all bus types
-func cmdDisableNmeaMsg(msg string) CommandList {
-	return cmdMsgoutAllBusses("NMEA_ID", msg, 0)
+func batchDisableNmeaMsgs(msgs []string) Command {
+	return batchMsgoutAllBusses("NMEA_ID", msgs, 0)
 }
 
 // Generate a series of commands to enable the given b8nary command on all bus types
-func cmdEnableNavMsg(msg string) CommandList {
-	return cmdMsgoutAllBusses("UBX_NAV", msg, 1)
+func batchEnableNavMsgs(msgs []string) Command {
+	return batchMsgoutAllBusses("UBX_NAV", msgs, 1)
 }
 
 // Return the default set of commands we need to set at initialization
 func defaultUblxCmds() CommandList {
 	// Begin by disabling all binary commands, then re-adding the ones we need
 	cmds := CommandList{disableBinary}
-	// Re-enable required b8nary commands
-	for _, msg := range navEnableMsg {
-		cmds = append(cmds, cmdEnableNavMsg(msg)...)
-	}
+	// Re-enable required binary commands
+	cmds = append(cmds, batchEnableNavMsgs(navEnableMsg))
 
 	// Next, enable all NMEA commands, but prune out any we don't need:
 	cmds = append(cmds, enableNMEA)
 	// More pruning of all bus-specific NMEA messages
-	for _, msg := range nmeaDisableMsg {
-		cmds = append(cmds, cmdDisableNmeaMsg(msg)...)
-	}
+	cmds = append(cmds, batchDisableNmeaMsgs(nmeaDisableMsg))
 
 	return cmds
 }

--- a/pkg/ublox/ublox_internal_test.go
+++ b/pkg/ublox/ublox_internal_test.go
@@ -19,9 +19,9 @@ func Test_CmdDisableNmeaMsg(t *testing.T) {
 	cmds := cmdDisableNmeaMsg("FOO")
 	assert.Equal(t, len(expected), len(cmds))
 	for _, cmd := range cmds {
-		assert.Equal(t, "-z", cmd[0])
-		if slices.Contains(expected, cmd[1]) {
-			found = append(found, cmd[1])
+		assert.Equal(t, "-z", cmd.Args[0])
+		if slices.Contains(expected, cmd.Args[1]) {
+			found = append(found, cmd.Args[1])
 		}
 	}
 	slices.Sort(expected)

--- a/pkg/ublox/ublox_internal_test.go
+++ b/pkg/ublox/ublox_internal_test.go
@@ -1,60 +1,85 @@
 package ublox
 
 import (
-	"slices"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
-func Test_CmdMsgoutAllBusses(t *testing.T) {
-	cmds := cmdMsgoutAllBusses("UBX_NAV", "CLOCK", 1)
-	assert.Equal(t, len(ublxBusTypes), len(cmds))
-	for i, bus := range ublxBusTypes {
-		assert.Equal(t, []string{"-z", "CFG-MSGOUT-UBX_NAV_CLOCK_" + bus + ",1"}, cmds[i].Args)
+func Test_BatchMsgoutAllBusses(t *testing.T) {
+	msgs := []string{navEnableMsg[0]} // single message
+	cmd := batchMsgoutAllBusses("UBX_NAV", msgs, 1)
+	// Should produce one -z pair per bus type
+	assert.Equal(t, len(ublxBusTypes)*2, len(cmd.Args))
+	for _, bus := range ublxBusTypes {
+		expected := fmt.Sprintf("CFG-MSGOUT-UBX_NAV_%s_%s,1", msgs[0], bus)
+		assert.Contains(t, cmd.Args, expected)
 	}
 }
 
-func Test_CmdDisableNmeaMsg(t *testing.T) {
-	expected := []string{
-		"CFG-MSGOUT-NMEA_ID_FOO_I2C,0",
-		"CFG-MSGOUT-NMEA_ID_FOO_UART1,0",
-		"CFG-MSGOUT-NMEA_ID_FOO_UART2,0",
-		"CFG-MSGOUT-NMEA_ID_FOO_USB,0",
-		"CFG-MSGOUT-NMEA_ID_FOO_SPI,0",
-	}
-	found := make([]string, 0, len(expected))
-	cmds := cmdDisableNmeaMsg("FOO")
-	assert.Equal(t, len(expected), len(cmds))
-	for _, cmd := range cmds {
-		assert.Equal(t, "-z", cmd.Args[0])
-		if slices.Contains(expected, cmd.Args[1]) {
-			found = append(found, cmd.Args[1])
+func Test_BatchMsgoutAllBusses_MultipleMessages(t *testing.T) {
+	cmd := batchMsgoutAllBusses("UBX_NAV", navEnableMsg, 1)
+	// N messages × 5 bus types × 2 args each (-z + value)
+	assert.Equal(t, len(navEnableMsg)*len(ublxBusTypes)*2, len(cmd.Args))
+	for _, msg := range navEnableMsg {
+		for _, bus := range ublxBusTypes {
+			expected := fmt.Sprintf("CFG-MSGOUT-UBX_NAV_%s_%s,1", msg, bus)
+			assert.Contains(t, cmd.Args, expected)
 		}
 	}
-	slices.Sort(expected)
-	slices.Sort(found)
-	assert.Equal(t, expected, found)
 }
 
-func Test_CmdEnableNavMsg(t *testing.T) {
-	expected := []string{
-		"CFG-MSGOUT-UBX_NAV_STATUS_I2C,1",
-		"CFG-MSGOUT-UBX_NAV_STATUS_UART1,1",
-		"CFG-MSGOUT-UBX_NAV_STATUS_UART2,1",
-		"CFG-MSGOUT-UBX_NAV_STATUS_USB,1",
-		"CFG-MSGOUT-UBX_NAV_STATUS_SPI,1",
-	}
-	found := make([]string, 0, len(expected))
-	cmds := cmdEnableNavMsg("STATUS")
-	assert.Equal(t, len(expected), len(cmds))
-	for _, cmd := range cmds {
-		assert.Equal(t, "-z", cmd.Args[0])
-		if slices.Contains(expected, cmd.Args[1]) {
-			found = append(found, cmd.Args[1])
+func Test_BatchDisableNmeaMsgs(t *testing.T) {
+	cmd := batchDisableNmeaMsgs([]string{"FOO", "BAR"})
+	for _, msg := range []string{"FOO", "BAR"} {
+		for _, bus := range ublxBusTypes {
+			expected := fmt.Sprintf("CFG-MSGOUT-NMEA_ID_%s_%s,0", msg, bus)
+			assert.Contains(t, cmd.Args, expected)
 		}
 	}
-	slices.Sort(expected)
-	slices.Sort(found)
-	assert.Equal(t, expected, found)
+}
+
+func Test_BatchEnableNavMsgs(t *testing.T) {
+	cmd := batchEnableNavMsgs(navEnableMsg)
+	for _, msg := range navEnableMsg {
+		for _, bus := range ublxBusTypes {
+			expected := fmt.Sprintf("CFG-MSGOUT-UBX_NAV_%s_%s,1", msg, bus)
+			assert.Contains(t, cmd.Args, expected)
+		}
+	}
+}
+
+func Test_DefaultUblxCmds(t *testing.T) {
+	cmds := defaultUblxCmds()
+
+	// Flatten all args for easy searching
+	var allArgs []string
+	for _, cmd := range cmds {
+		allArgs = append(allArgs, cmd.Args...)
+	}
+
+	// First command should disable all binary
+	assert.Equal(t, disableBinary, cmds[0])
+
+	// All NAV messages should be re-enabled on all bus types
+	for _, nav := range navEnableMsg {
+		for _, bus := range ublxBusTypes {
+			expected := fmt.Sprintf("CFG-MSGOUT-UBX_NAV_%s_%s,1", nav, bus)
+			assert.Contains(t, allArgs, expected,
+				"expected NAV %s enable on %s", nav, bus)
+		}
+	}
+
+	// NMEA should be enabled
+	assert.Contains(t, cmds, enableNMEA)
+
+	// All NMEA disable messages should be present on all bus types
+	for _, nmea := range nmeaDisableMsg {
+		for _, bus := range ublxBusTypes {
+			expected := fmt.Sprintf("CFG-MSGOUT-NMEA_ID_%s_%s,0", nmea, bus)
+			assert.Contains(t, allArgs, expected,
+				"expected NMEA %s disable on %s", nmea, bus)
+		}
+	}
 }

--- a/pkg/ublox/ublox_internal_test.go
+++ b/pkg/ublox/ublox_internal_test.go
@@ -7,6 +7,14 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func Test_CmdMsgoutAllBusses(t *testing.T) {
+	cmds := cmdMsgoutAllBusses("UBX_NAV", "CLOCK", 1)
+	assert.Equal(t, len(ublxBusTypes), len(cmds))
+	for i, bus := range ublxBusTypes {
+		assert.Equal(t, []string{"-z", "CFG-MSGOUT-UBX_NAV_CLOCK_" + bus + ",1"}, cmds[i].Args)
+	}
+}
+
 func Test_CmdDisableNmeaMsg(t *testing.T) {
 	expected := []string{
 		"CFG-MSGOUT-NMEA_ID_FOO_I2C,0",
@@ -17,6 +25,28 @@ func Test_CmdDisableNmeaMsg(t *testing.T) {
 	}
 	found := make([]string, 0, len(expected))
 	cmds := cmdDisableNmeaMsg("FOO")
+	assert.Equal(t, len(expected), len(cmds))
+	for _, cmd := range cmds {
+		assert.Equal(t, "-z", cmd.Args[0])
+		if slices.Contains(expected, cmd.Args[1]) {
+			found = append(found, cmd.Args[1])
+		}
+	}
+	slices.Sort(expected)
+	slices.Sort(found)
+	assert.Equal(t, expected, found)
+}
+
+func Test_CmdEnableNavMsg(t *testing.T) {
+	expected := []string{
+		"CFG-MSGOUT-UBX_NAV_STATUS_I2C,1",
+		"CFG-MSGOUT-UBX_NAV_STATUS_UART1,1",
+		"CFG-MSGOUT-UBX_NAV_STATUS_UART2,1",
+		"CFG-MSGOUT-UBX_NAV_STATUS_USB,1",
+		"CFG-MSGOUT-UBX_NAV_STATUS_SPI,1",
+	}
+	found := make([]string, 0, len(expected))
+	cmds := cmdEnableNavMsg("STATUS")
 	assert.Equal(t, len(expected), len(cmds))
 	for _, cmd := range cmds {
 		assert.Equal(t, "-z", cmd.Args[0])


### PR DESCRIPTION
This is the first phase of work for adapting HardwareConfig.v2 for T-GM use-cases.

Essentially this works do centralize ublox-handling logic (and part of the GNSS device autodetection logic) out of the addons/intel/ and into pkg/ublox instead, paving the way for better reuse, code de-duplication, and overall code quality.

On the way, these improvements happened too:
- Eliminating cryptic commands like `CFG-MSG,1,34,1` in favor of the more readable `CFG-MSGOUT-*` named commands
- Enabling `TIMELS` messages explicitly in the core ublox initialization code instead of assuming users would remember to not remove it in the plugin config commands (Note; this is `CFG-MSG,1,38,248` if you want to know where it's being done today)
- Enabling reporting global ubxtool setup data in the `NodePtpDevice` object
- Batching multiple `-z ...` commands into single ubxtool calls to reduce overall setup time

## Testing

Ran on WPC:
- T-GM issues the proper ublx commands (verified by log inspection and manual check of incoming ublx messages)
- T-GM reaches s2 as expected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved GNSS device detection and automatic serial-port selection for supported Intel profiles.
  * Added richer GNSS initialization handling so hardware status can reflect startup results.

* **Bug Fixes**
  * Fixed command execution for PTP GPS pipe workflows on Intel devices.
  * Improved behavior when no GNSS port is configured, using a sensible default.

* **Tests**
  * Expanded coverage for GNSS detection, command execution, and ublox initialization behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->