### PR TITLE
Refactor T-BC port-state detection to use structured parser events instead of raw string matching

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -1732,18 +1732,9 @@ func (p *ptpProcess) processTBCTransitionHardwareConfig(output string) {
 	})
 }
 
-// tbcPTP4LExtractor is a shared ptp4l log-line extractor used by the legacy T-BC
-// path to turn raw ptp4l output into a structured parser.PTPEvent, instead of
-// matching substrings directly against the output. Reused across calls since it
-// holds only compiled regexes and is safe for concurrent read-only use.
-var tbcPTP4LExtractor = parser.NewPTP4LExtractor()
-
-// processTBCTransitionLegacy is the original implementation as ultimate fallback.
-// It derives port role transitions from the structured parser.PTPEvent produced
-// by the shared ptp4l parser (the same one used elsewhere in the log-processing
-// pipeline), rather than performing its own ad hoc string matching on the raw
-// ptp4l output.
+// processTBCTransitionLegacy is the ultimate T-BC fallback: it derives port role transitions from the structured parser.PTPEvent instead of matching substrings on raw ptp4l output.
 func (p *ptpProcess) processTBCTransitionLegacy(output string, pm *plugin.PluginManager) {
+	tbcPTP4LExtractor := parser.NewPTP4LExtractor()
 	_, ptpEvent, err := tbcPTP4LExtractor.Extract(output)
 	if err != nil {
 		glog.Warningf("T-BC legacy: failed to parse ptp4l port event %q: %v", output, err)

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -1282,7 +1282,18 @@ func (dn *Daemon) applyNodePtpProfile(runID int, nodeProfile *ptpv1.PtpProfile) 
 				if !clockTypeFound {
 					pmcClockType = string(clockType)
 				}
-				pmcProcess := NewPMCProcess(runID, dn.processManager.ptpEventHandler, pmcClockType)
+				var portStateOpts *PMCPortStateOpts
+				if pmcClockType == TBC && len(ifaces) > 0 {
+					portIfaceMap := make(map[int]string, len(ifaces))
+					for idx, ifc := range ifaces {
+						portIfaceMap[idx+1] = ifc.Name
+					}
+					portStateOpts = &PMCPortStateOpts{
+						PortIfaceMap: portIfaceMap,
+						OnChange:     dprocess.pmcPortStateChanged,
+					}
+				}
+				pmcProcess := NewPMCProcess(runID, dn.processManager.ptpEventHandler, pmcClockType, portStateOpts)
 				pmcProcess.CmdInit()
 				// TODO addScheduling
 				dprocess.depProcess = append(dprocess.depProcess, pmcProcess)
@@ -1763,6 +1774,16 @@ func (p *ptpProcess) processTBCTransitionLegacy(output string, pm *plugin.Plugin
 		pm.AfterRunPTPCommand(&p.nodeProfile, "tbc-ho-exit")
 		p.sendPtp4lEvent()
 	})
+}
+
+// pmcPortStateChanged is the callback invoked by PMCProcess.handlePortDS when
+// a PORT_DATA_SET notification indicates a port role change. In Phase 1 this
+// logs the derived condition for comparison with the log-scraping path;
+// the actual T-BC state machine is still driven by log scraping.
+func (p *ptpProcess) pmcPortStateChanged(iface string, role, previousRole parserconstants.PTPPortRole) {
+	_, conditionType := hardwareconfig.DetectStateChangeFromRole(iface, role, previousRole)
+	glog.Infof("PMC port-state: iface=%s role=%v previousRole=%v condition=%q (config=%s)",
+		iface, role, previousRole, conditionType, p.configName)
 }
 
 // cmdRun runs given ptpProcess and restarts on errors

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -25,6 +25,7 @@ import (
 	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/hardwareconfig"
 	ptpnetwork "github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/network"
 	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/parser"
+	parserconstants "github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/parser/constants"
 	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/synce"
 	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/ublox"
 	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/utils"
@@ -1731,30 +1732,33 @@ func (p *ptpProcess) processTBCTransitionHardwareConfig(output string) {
 	})
 }
 
-// processTBCTransitionLegacy is the original implementation as ultimate fallback
+// tbcPTP4LExtractor is a shared ptp4l log-line extractor used by the legacy T-BC
+// path to turn raw ptp4l output into a structured parser.PTPEvent, instead of
+// matching substrings directly against the output. Reused across calls since it
+// holds only compiled regexes and is safe for concurrent read-only use.
+var tbcPTP4LExtractor = parser.NewPTP4LExtractor()
+
+// processTBCTransitionLegacy is the original implementation as ultimate fallback.
+// It derives port role transitions from the structured parser.PTPEvent produced
+// by the shared ptp4l parser (the same one used elsewhere in the log-processing
+// pipeline), rather than performing its own ad hoc string matching on the raw
+// ptp4l output.
 func (p *ptpProcess) processTBCTransitionLegacy(output string, pm *plugin.PluginManager) {
-	portMatched := false
-	for _, iface := range p.tBCAttributes.trIfaceNames {
-		if strings.Contains(output, iface) {
-			portMatched = true
-			break
-		}
+	_, ptpEvent, err := tbcPTP4LExtractor.Extract(output)
+	if err != nil {
+		glog.Warningf("T-BC legacy: failed to parse ptp4l port event %q: %v", output, err)
 	}
-	if portMatched {
-		if strings.Contains(output, "to SLAVE on MASTER_CLOCK_SELECTED") {
-			portName := parser.ExtractPortName(output)
-			if portName != "" {
-				if len(p.tBCAttributes.trIfaceNames) > 1 && !slices.Contains(p.tBCAttributes.trIfaceNames, portName) {
-					glog.Warningf("Ignoring non-TR port in legacy MASTER_CLOCK_SELECTED event: %s", portName)
-				} else {
-					p.tBCAttributes.activePort = portName
-					glog.Infof("T-BC active upstream port: %s", portName)
-				}
-			}
+
+	if ptpEvent != nil && ptpEvent.Iface != "" && slices.Contains(p.tBCAttributes.trIfaceNames, ptpEvent.Iface) {
+		switch {
+		case ptpEvent.Role == parserconstants.PortRoleSlave:
+			// Port became (or remains) the active upstream time-receiver port.
+			p.tBCAttributes.activePort = ptpEvent.Iface
+			glog.Infof("T-BC active upstream port: %s", ptpEvent.Iface)
 			p.tBCAttributes.lastReportedState = event.PTP_LOCKED
 			p.tBCAttributes.offsetFilter = utils.NewWindow(offsetFilterSize)
-		} else if strings.Contains(output, "to MASTER on ANNOUNCE_RECEIPT_TIMEOUT_EXPIRES") ||
-			strings.Contains(output, "SLAVE to") {
+		case ptpEvent.PreviousRole == parserconstants.PortRoleSlave:
+			// Port is no longer a slave indicating it lost sync
 			pm.AfterRunPTPCommand(&p.nodeProfile, "tbc-ho-entry")
 			p.tBCAttributes.lastReportedState = event.PTP_FREERUN
 			glog.Info("T-BC MOVE TO HOLDOVER")

--- a/pkg/daemon/daemon_internal_test.go
+++ b/pkg/daemon/daemon_internal_test.go
@@ -3050,7 +3050,7 @@ func TestEmitClockClassLogs_EmitsWithNilParentDS(t *testing.T) {
 
 	// Create a PMC process with parentDS = nil (the bug condition).
 	// Before the fix, EmitClockClassLogs skipped the call when parentDS was nil.
-	pmcProc := NewPMCProcess(0, handler, "OC")
+	pmcProc := NewPMCProcess(0, handler, "OC", nil)
 	assert.Nil(t, pmcProc.parentDS, "parentDS should be nil for this test")
 
 	// Create a ptp4l process with the PMC as a dependent process

--- a/pkg/daemon/daemon_internal_test.go
+++ b/pkg/daemon/daemon_internal_test.go
@@ -1307,7 +1307,7 @@ func TestTBCTransitionCheck_LegacyPath(t *testing.T) {
 		}
 
 		// First call: Set state to LOCKED (no event sent yet)
-		process.tBCTransitionCheck("ptp4l[123] port 1 (ens4f0): to SLAVE on MASTER_CLOCK_SELECTED", pm)
+		process.tBCTransitionCheck("ptp4l[123.456]: [test-config.0.config] port 1 (ens4f0): UNCALIBRATED to SLAVE on MASTER_CLOCK_SELECTED", pm)
 
 		// Verify state changed to LOCKED
 		assert.Equal(t, event.PTP_LOCKED, process.tBCAttributes.lastReportedState)
@@ -1324,7 +1324,7 @@ func TestTBCTransitionCheck_LegacyPath(t *testing.T) {
 		// The filter needs to be full (64 samples) before the event is sent
 		// First call already inserted 1 sample, so we need 63 more to fill it
 		for i := 0; i < 63; i++ {
-			process.tBCTransitionCheck("ptp4l[123] port 1 (ens4f0): some other log message", pm)
+			process.tBCTransitionCheck("ptp4l[123.456]: [test-config.0.config] port 1 (ens4f0): some other log message", pm)
 		}
 
 		// Verify event was sent after filter is full
@@ -1361,7 +1361,7 @@ func TestTBCTransitionCheck_LegacyPath(t *testing.T) {
 		}
 
 		// Call with lost transition log
-		process.tBCTransitionCheck("ptp4l[123] port 1 (ens4f0): SLAVE to", pm)
+		process.tBCTransitionCheck("ptp4l[123.456]: [test-config.0.config] port 1 (ens4f0): SLAVE to MASTER on ANNOUNCE_RECEIPT_TIMEOUT_EXPIRES", pm)
 
 		// Verify state changed to FREERUN
 		assert.Equal(t, event.PTP_FREERUN, process.tBCAttributes.lastReportedState)
@@ -1402,7 +1402,7 @@ func TestTBCTransitionCheck_LegacyPath(t *testing.T) {
 		initialState := process.tBCAttributes.lastReportedState
 
 		// Call with log that doesn't match any transition
-		process.tBCTransitionCheck("ptp4l[123] port 1 (ens4f0): some other message", pm)
+		process.tBCTransitionCheck("ptp4l[123.456]: [test-config.0.config] port 1 (ens4f0): some other message", pm)
 
 		// Verify state didn't change
 		assert.Equal(t, initialState, process.tBCAttributes.lastReportedState)
@@ -1413,6 +1413,121 @@ func TestTBCTransitionCheck_LegacyPath(t *testing.T) {
 			t.Error("Unexpected PTP event was sent")
 		default:
 			// No event sent, which is correct
+		}
+	})
+}
+
+// TestTBCLegacy_HoldoverDetectionPrecision locks in the fix for a regression
+// where processTBCTransitionLegacy's holdover branch fired on ptp4l lines that
+// were not actual departures from SLAVE: any line naming the active port
+// (since parser.PTPEvent.Iface is populated even for PortRoleUnknown events),
+// and any "to MASTER" transition regardless of reason (including benign
+// cold-start BMCA self-election, e.g. "on RS_MASTER"). The fix keys holdover
+// detection off ptpEvent.PreviousRole == PortRoleSlave, which is derived
+// purely from the log line's own "<FROM> to <TO>" text.
+func TestTBCLegacy_HoldoverDetectionPrecision(t *testing.T) {
+	pmStruct, _ := registerPlugins([]string{})
+	pm := &pmStruct
+
+	oldValue := vTbcHasHardwareConfig
+	vTbcHasHardwareConfig = false
+	defer func() { vTbcHasHardwareConfig = oldValue }()
+
+	newProcess := func() *ptpProcess {
+		return &ptpProcess{
+			tBCAttributes: tBCProcessAttributes{
+				trIfaceNames:      []string{"ens4f0"},
+				trPortsConfigFile: "test-config",
+				offsetThreshold:   10.0,
+			},
+			nodeProfile: ptpv1.PtpProfile{
+				Name:        stringPointer("test-profile"),
+				PtpSettings: map[string]string{"leadingInterface": "ens4f0", "clockId[ens4f0]": "123456789"},
+			},
+			eventCh:    make(chan event.Event, 10),
+			configName: "test-config",
+			clockType:  event.BC,
+			offset:     5.0,
+		}
+	}
+
+	t.Run("benign unrelated log line for the active port does not force holdover", func(t *testing.T) {
+		process := newProcess()
+		process.tBCTransitionCheck("ptp4l[123.456]: [test-config.0.config] port 1 (ens4f0): UNCALIBRATED to SLAVE on MASTER_CLOCK_SELECTED", pm)
+		assert.Equal(t, event.PTP_LOCKED, process.tBCAttributes.lastReportedState)
+
+		for i := 0; i < 20; i++ {
+			process.tBCTransitionCheck("ptp4l[123.456]: [test-config.0.config] port 1 (ens4f0): some other log message", pm)
+			assert.Equal(t, event.PTP_LOCKED, process.tBCAttributes.lastReportedState,
+				"state must stay LOCKED on benign non-transition line iteration %d", i)
+		}
+	})
+
+	t.Run("benign cold-start BMCA self-election does not force holdover", func(t *testing.T) {
+		process := newProcess()
+		process.tBCTransitionCheck("ptp4l[123.456]: [test-config.0.config] port 1 (ens4f0): UNCALIBRATED to MASTER on RS_MASTER", pm)
+		assert.NotEqual(t, event.PTP_HOLDOVER, process.tBCAttributes.lastAppliedState)
+	})
+
+	t.Run("genuine SLAVE departure still triggers holdover even if activePort bookkeeping was reset", func(t *testing.T) {
+		process := newProcess()
+		process.tBCAttributes.lastReportedState = event.PTP_LOCKED
+		process.tBCAttributes.lastAppliedState = event.PTP_LOCKED
+		// activePort intentionally left unset (simulates state lost across a
+		// daemon restart while ptp4l itself is still tracking real port state).
+		process.tBCTransitionCheck("ptp4l[123.456]: [test-config.0.config] port 1 (ens4f0): SLAVE to PASSIVE on RS_PASSIVE", pm)
+		assert.Equal(t, event.PTP_FREERUN, process.tBCAttributes.lastReportedState)
+		assert.Equal(t, event.PTP_HOLDOVER, process.tBCAttributes.lastAppliedState)
+	})
+
+	t.Run("announce-timeout driven loss of an established slave still triggers holdover", func(t *testing.T) {
+		process := newProcess()
+		process.tBCTransitionCheck("ptp4l[100]: [test-config.0.config] port 1 (ens4f0): UNCALIBRATED to SLAVE on MASTER_CLOCK_SELECTED", pm)
+		assert.Equal(t, event.PTP_LOCKED, process.tBCAttributes.lastReportedState)
+
+		process.tBCTransitionCheck("ptp4l[200]: [test-config.0.config] port 1 (ens4f0): SLAVE to MASTER on ANNOUNCE_RECEIPT_TIMEOUT_EXPIRES", pm)
+		assert.Equal(t, event.PTP_FREERUN, process.tBCAttributes.lastReportedState)
+		assert.Equal(t, event.PTP_HOLDOVER, process.tBCAttributes.lastAppliedState)
+	})
+
+	t.Run("every kind of departure from an established slave triggers holdover", func(t *testing.T) {
+		departures := []string{
+			"SLAVE to MASTER on ANNOUNCE_RECEIPT_TIMEOUT_EXPIRES",
+			"SLAVE to GRAND_MASTER",
+			"SLAVE to PASSIVE on RS_PASSIVE",
+			"SLAVE to LISTENING",
+			"SLAVE to UNCALIBRATED",
+			"SLAVE to FAULT_DETECTED on FAULT_DETECTED",
+		}
+		for _, transition := range departures {
+			t.Run(transition, func(t *testing.T) {
+				process := newProcess()
+				process.tBCTransitionCheck("ptp4l[100]: [test-config.0.config] port 1 (ens4f0): UNCALIBRATED to SLAVE on MASTER_CLOCK_SELECTED", pm)
+				assert.Equal(t, event.PTP_LOCKED, process.tBCAttributes.lastReportedState)
+
+				process.tBCTransitionCheck("ptp4l[200]: [test-config.0.config] port 1 (ens4f0): "+transition, pm)
+				assert.Equal(t, event.PTP_FREERUN, process.tBCAttributes.lastReportedState)
+				assert.Equal(t, event.PTP_HOLDOVER, process.tBCAttributes.lastAppliedState)
+			})
+		}
+	})
+
+	t.Run("malformed or unparseable lines are ignored without panicking", func(t *testing.T) {
+		process := newProcess()
+		process.tBCTransitionCheck("ptp4l[100]: [test-config.0.config] port 1 (ens4f0): UNCALIBRATED to SLAVE on MASTER_CLOCK_SELECTED", pm)
+		assert.Equal(t, event.PTP_LOCKED, process.tBCAttributes.lastReportedState)
+
+		malformedLines := []string{
+			"",
+			"not a ptp4l line at all",
+			"ptp4l[100] port 1 (ens4f0): missing bracket segment",
+		}
+		for _, line := range malformedLines {
+			assert.NotPanics(t, func() {
+				process.tBCTransitionCheck(line, pm)
+			})
+			assert.Equal(t, event.PTP_LOCKED, process.tBCAttributes.lastReportedState,
+				"malformed line %q must not change state", line)
 		}
 	})
 }

--- a/pkg/daemon/daemon_internal_test.go
+++ b/pkg/daemon/daemon_internal_test.go
@@ -1433,6 +1433,7 @@ func TestTBCLegacy_HoldoverDetectionPrecision(t *testing.T) {
 	vTbcHasHardwareConfig = false
 	defer func() { vTbcHasHardwareConfig = oldValue }()
 
+	// newProcess returns a fresh ptpProcess with a single TR interface (ens4f0), the starting point for each subtest below.
 	newProcess := func() *ptpProcess {
 		return &ptpProcess{
 			tBCAttributes: tBCProcessAttributes{

--- a/pkg/daemon/daemon_test.go
+++ b/pkg/daemon/daemon_test.go
@@ -642,6 +642,103 @@ func Test_ProcessPTPMetrics(t *testing.T) {
 	}
 }
 
+// servoStateTestCases exercises the raw linuxptp servo state (s0-s3) metric
+// end-to-end through the current parser-event path (pm.RunProcessPTPMetrics
+// -> processWithParser -> updateServoStateMetrics), independent of the
+// collapsed ClockState metric.
+var servoStateTestCases = []struct {
+	name               string
+	log                string
+	messageTag         string
+	process            string
+	iface              string
+	expectedServoState float64
+}{
+	{
+		// The exact log line reported in CNF-25298.
+		name:               "ptp4l master offset line with s2 (LOCKED) reports raw servo state 2",
+		log:                "ptp4l[2330.162]: [ptp4l.1.config:6] master offset         -1 s2 freq      +1 path delay     18481",
+		messageTag:         "[ptp4l.1.config:6]",
+		process:            "ptp4l",
+		iface:              "master",
+		expectedServoState: 2,
+	},
+	{
+		name:               "ptp4l master offset line with s0 (UNLOCKED) reports raw servo state 0",
+		log:                "ptp4l[365195.391]: [ptp4l.0.config] master offset -1 s0 freq -3972 path delay 89",
+		messageTag:         "[ptp4l.0.config]",
+		process:            "ptp4l",
+		iface:              "master",
+		expectedServoState: 0,
+	},
+	{
+		name:               "phc2sys phc offset line with s2 (LOCKED) reports raw servo state 2",
+		log:                "phc2sys[1823126.732]: [ptp4l.0.config] CLOCK_REALTIME phc offset       -10 s2 freq   +8956 delay    508",
+		messageTag:         "[ptp4l.0.config]",
+		process:            "phc2sys",
+		iface:              "CLOCK_REALTIME",
+		expectedServoState: 2,
+	},
+	{
+		name:               "ts2phc master offset line with s1 (JUMP) reports raw servo state 1",
+		log:                "ts2phc[1896332.824]: [ts2phc.5.config] dev/ptp12 offset        777 s1 freq   -88888",
+		messageTag:         "[ts2phc.5.config]",
+		process:            "ts2phc",
+		iface:              "ens20fx",
+		expectedServoState: 1,
+	},
+}
+
+func Test_ProcessPTPMetrics_ServoState(t *testing.T) {
+	for _, tc := range servoStateTestCases {
+		t.Run(tc.name, func(t *testing.T) {
+			daemon.ServoState.With(map[string]string{"process": tc.process, "node": MYNODE, "iface": tc.iface}).Set(CLEANUP)
+			pm.SetTestData(tc.process, tc.messageTag, config.IFaces{{Name: tc.iface, PhcId: "dev/ptp12"}})
+			pm.RunProcessPTPMetrics(tc.log)
+
+			servoState := daemon.ServoState.With(map[string]string{"process": tc.process, "node": MYNODE, "iface": tc.iface})
+			assert.Equal(t, tc.expectedServoState, testutil.ToFloat64(servoState), "ServoState does not match for log: %q", tc.log)
+		})
+	}
+}
+
+// TestProcessParsedEvent_FaultyResetsServoState verifies that when a tracked
+// SLAVE port faults, the fault-handling branch in processParsedEvent resets
+// servo_state back to UNLOCKED (s0) for that port's alias, the same way it
+// already forces clock_state to FREERUN. Without this, servo_state would
+// keep reporting the last real "sN" value from before the fault (e.g. 2 for
+// s2/LOCKED), since no further offset lines arrive for a faulty port.
+func TestProcessParsedEvent_FaultyResetsServoState(t *testing.T) {
+	const (
+		messageTag = "[ptp4l.50.config]"
+		process    = "ptp4l"
+		ifaceName  = "ens50f3"
+		ifaceAlias = "ens50fx"
+	)
+	ifaces := config.IFaces{{Name: ifaceName, IsMaster: false, Source: "", PhcId: "phcid-50"}}
+	pm.SetTestData(process, messageTag, ifaces)
+
+	// Port becomes SLAVE: tracks masterOffsetIface/slaveIface for this config
+	// so the later FAULTY transition below is recognized as "the tracked
+	// slave going faulty" and triggers the fault-handling branch.
+	pm.RunProcessPTPMetrics("ptp4l[1.0]: [ptp4l.50.config] port 1: UNCALIBRATED to SLAVE on MASTER_CLOCK_SELECTED")
+
+	clockState := daemon.ClockState.With(map[string]string{"process": process, "node": MYNODE, "iface": ifaceAlias})
+	servoState := daemon.ServoState.With(map[string]string{"process": process, "node": MYNODE, "iface": ifaceAlias})
+
+	// Seed both metrics as if a prior "s2" (LOCKED) master offset line had
+	// already been reported for this port.
+	clockState.Set(1)
+	servoState.Set(2)
+
+	// The port faults; both clock_state and servo_state for this port's
+	// alias should be forced back down (FREERUN / s0-UNLOCKED).
+	pm.RunProcessPTPMetrics("ptp4l[3.0]: [ptp4l.50.config] port 1: SLAVE to FAULTY on FAULT_DETECTED (FT_UNSPECIFIED)")
+
+	assert.Equal(t, float64(0), testutil.ToFloat64(clockState), "expected clock_state FREERUN after fault")
+	assert.Equal(t, float64(0), testutil.ToFloat64(servoState), "expected servo_state reset to s0 (UNLOCKED) after fault")
+}
+
 func TestDaemon_ApplyHaProfiles(t *testing.T) {
 	skip, teardownTest := testhelpers.SetupForTestBCPTPHA()
 	defer teardownTest()

--- a/pkg/daemon/log_parsing.go
+++ b/pkg/daemon/log_parsing.go
@@ -94,6 +94,11 @@ func processParsedMetrics(process *ptpProcess, ptpMetrics *parser.Metrics) {
 		updateClockStateMetrics(process.name, iface, string(ptpMetrics.ClockState))
 	}
 
+	// Update the raw servo state (s0-s3) metric if available
+	if ptpMetrics.ServoState != "" {
+		updateServoStateMetrics(process.name, iface, ptpMetrics.ServoState)
+	}
+
 	configName := strings.Replace(strings.Replace(process.messageTag, "]", "", 1), "[", "", 1)
 	if configName != "" {
 		configName = strings.Split(configName, MessageTagSuffixSeperator)[0]
@@ -185,6 +190,12 @@ func processParsedEvent(process *ptpProcess, ptpEvent *parser.PTPEvent) {
 				updatePTPMetrics(master, process.name, masterOffsetIface.get(configName).alias, faultyOffset, faultyOffset, 0, 0)
 				updatePTPMetrics(phc, phc2sysProcessName, clockRealTime, faultyOffset, faultyOffset, 0, 0)
 				updateClockStateMetrics(process.name, masterOffsetIface.get(configName).alias, FREERUN)
+				// The port lost sync, so the servo can no longer be considered
+				// locked either. Force it back to UNLOCKED (s0); otherwise
+				// servo_state would keep reporting the last real sN value from
+				// before the fault, since no further offset lines will arrive
+				// to refresh it while the port stays faulty.
+				updateServoStateMetrics(process.name, masterOffsetIface.get(configName).alias, "s0")
 				masterOffsetIface.set(configName, "")
 				slaveIface.set(configName, "")
 			}

--- a/pkg/daemon/metrics.go
+++ b/pkg/daemon/metrics.go
@@ -138,6 +138,18 @@ var (
 			Help:      "0 = FREERUN, 1 = LOCKED, 2 = HOLDOVER",
 		}, []string{"process", "node", "iface"})
 
+	// ServoState metrics to show the raw linuxptp servo state (s0-s3) as
+	// printed in ptp4l/phc2sys/ts2phc offset log lines (e.g. "master offset
+	// -1 s2 freq +1 path delay 18481"), independent of the collapsed
+	// ClockState metric above.
+	ServoState = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: PTPNamespace,
+			Subsystem: PTPSubsystem,
+			Name:      "servo_state",
+			Help:      "raw linuxptp servo state: 0 = UNLOCKED (s0), 1 = JUMP (s1), 2 = LOCKED (s2), 3 = LOCKED_STABLE (s3)",
+		}, []string{"process", "node", "iface"})
+
 	// ClockClassMetrics metrics to show current clock class
 	ClockClassMetrics = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
@@ -211,6 +223,7 @@ func RegisterMetrics(nodeName string) {
 		prometheus.MustRegister(Delay)
 		prometheus.MustRegister(InterfaceRole)
 		prometheus.MustRegister(ClockState)
+		prometheus.MustRegister(ServoState)
 		prometheus.MustRegister(ProcessStatus)
 		prometheus.MustRegister(ProcessRestartCount)
 		prometheus.MustRegister(ClockClassMetrics)
@@ -540,6 +553,39 @@ func updateClockStateMetrics(process, iface string, state string) {
 	}
 }
 
+// updateServoStateMetrics sets the ServoState gauge from the raw "sN" servo
+// state token captured by the parser (e.g. "s2"). No-ops on an empty or
+// unrecognized token, leaving any previously reported value in place.
+func updateServoStateMetrics(process, iface, servoState string) {
+	if !utils.CheckMetricSanity("ServoState", process, iface) {
+		return
+	}
+	value, ok := parseServoState(servoState)
+	if !ok {
+		glog.Warningf("updateServoStateMetrics: unrecognized servo state %q for process=%s iface=%s", servoState, process, iface)
+		return
+	}
+	glog.V(14).Infof("updateServoStateMetrics: process=%s iface=%s state=%s", process, iface, servoState)
+	ServoState.With(prometheus.Labels{
+		"process": process, "node": NodeName, "iface": iface}).Set(value)
+}
+
+// parseServoState converts a raw "sN" servo state token as printed by
+// linuxptp into its numeric enum value from upstream's servo.h (s0..s3 map
+// to 0..3: SERVO_UNLOCKED, SERVO_JUMP, SERVO_LOCKED, SERVO_LOCKED_STABLE).
+// Returns false if servoState isn't a recognized "sN" token.
+func parseServoState(servoState string) (float64, bool) {
+	digits, ok := strings.CutPrefix(servoState, "s")
+	if !ok {
+		return 0, false
+	}
+	value, err := strconv.Atoi(digits)
+	if err != nil {
+		return 0, false
+	}
+	return float64(value), true
+}
+
 func UpdateInterfaceRoleMetrics(process string, iface string, role ptpPortRole) {
 	if !utils.CheckMetricSanity("InterfaceRole", process, iface) {
 		return
@@ -603,6 +649,8 @@ func deleteSyncEMetrics(process, configName string, relations *synce.Relations) 
 
 			ClockState.Delete(prometheus.Labels{
 				"process": process, "node": NodeName, "iface": iface})
+			ServoState.Delete(prometheus.Labels{
+				"process": process, "node": NodeName, "iface": iface})
 		}
 	}
 }
@@ -621,6 +669,8 @@ func deleteMetrics(ifaces config.IFaces, haProfiles map[string][]string, process
 	for _, iface := range masterOffsetIface.iface {
 		ClockState.Delete(prometheus.Labels{
 			"process": process, "node": NodeName, "iface": iface.alias})
+		ServoState.Delete(prometheus.Labels{
+			"process": process, "node": NodeName, "iface": iface.alias})
 		Delay.Delete(prometheus.Labels{
 			"from": master, "process": process, "node": NodeName, "iface": iface.alias})
 		FrequencyAdjustment.Delete(prometheus.Labels{
@@ -634,6 +684,8 @@ func deleteMetrics(ifaces config.IFaces, haProfiles map[string][]string, process
 
 func deleteOsClockStateMetrics(profiles map[string][]string) {
 	ClockState.Delete(prometheus.Labels{
+		"process": phc2sysProcessName, "node": NodeName, "iface": clockRealTime})
+	ServoState.Delete(prometheus.Labels{
 		"process": phc2sysProcessName, "node": NodeName, "iface": clockRealTime})
 	Delay.Delete(prometheus.Labels{
 		"from": phc, "process": phc2sysProcessName, "node": NodeName, "iface": clockRealTime})

--- a/pkg/daemon/metrics.go
+++ b/pkg/daemon/metrics.go
@@ -657,16 +657,9 @@ func deleteProcessStatusMetrics(config, process string) {
 
 }
 
-// ptp4lEventStateExtractor is the shared ptp4l parser used to derive port role
-// information from raw ptp4l output. Reused across calls since it only holds
-// compiled regexes and is safe for concurrent read-only use.
-var ptp4lEventStateExtractor = parser.NewPTP4LExtractor()
-
-// extractPTP4lEventState parses a ptp4l port state change log line and returns
-// the port ID and role, based on the structured parser.PTPEvent produced by the
-// shared ptp4l parser (the same one used elsewhere in the log-processing
-// pipeline), rather than performing ad hoc string matching on the raw output.
+// extractPTP4lEventState parses a ptp4l port state change log line into a port ID and role using the structured parser.PTPEvent instead of ad hoc string matching on the raw output.
 func extractPTP4lEventState(output string) (portID int, role ptpPortRole) {
+	ptp4lEventStateExtractor := parser.NewPTP4LExtractor()
 	_, ptpEvent, err := ptp4lEventStateExtractor.Extract(output)
 	if err != nil {
 		glog.Errorf("failed to parse ptp4l port event %q: %v", output, err)

--- a/pkg/daemon/metrics.go
+++ b/pkg/daemon/metrics.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/alias"
 	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/event"
+	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/parser"
 	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/synce"
 
 	"github.com/golang/glog"
@@ -655,53 +656,26 @@ func deleteProcessStatusMetrics(config, process string) {
 		"process": process, "node": NodeName, "config": config})
 
 }
-func extractPTP4lEventState(output string) (portId int, role ptpPortRole) {
-	replacer := strings.NewReplacer("[", " ", "]", " ", ":", " ")
-	output = replacer.Replace(output)
 
-	//ptp4l 4268779.809 ptp4l.o.config port 2: LISTENING to PASSIVE on RS_PASSIVE
-	//ptp4l 4268779.809 ptp4l.o.config port 1: delay timeout
-	index := strings.Index(output, " port ")
-	if index == -1 {
-		return
+// ptp4lEventStateExtractor is the shared ptp4l parser used to derive port role
+// information from raw ptp4l output. Reused across calls since it only holds
+// compiled regexes and is safe for concurrent read-only use.
+var ptp4lEventStateExtractor = parser.NewPTP4LExtractor()
+
+// extractPTP4lEventState parses a ptp4l port state change log line and returns
+// the port ID and role, based on the structured parser.PTPEvent produced by the
+// shared ptp4l parser (the same one used elsewhere in the log-processing
+// pipeline), rather than performing ad hoc string matching on the raw output.
+func extractPTP4lEventState(output string) (portID int, role ptpPortRole) {
+	_, ptpEvent, err := ptp4lEventStateExtractor.Extract(output)
+	if err != nil {
+		glog.Errorf("failed to parse ptp4l port event %q: %v", output, err)
+		return 0, UNKNOWN
 	}
-
-	output = output[index:]
-	fields := strings.Fields(output)
-
-	//port 1: delay timeout
-	if len(fields) < 2 {
-		glog.Errorf("failed to parse output %s: unexpected number of fields", output)
-		return
+	if ptpEvent == nil {
+		return 0, UNKNOWN
 	}
-
-	portIndex := fields[1]
-	role = UNKNOWN
-
-	var e error
-	portId, e = strconv.Atoi(portIndex)
-	if e != nil {
-		glog.Errorf("error parsing port id %s", e)
-		portId = 0
-		return
-	}
-
-	if strings.Contains(output, "UNCALIBRATED to SLAVE") {
-		role = SLAVE
-	} else if strings.Contains(output, "UNCALIBRATED to PASSIVE") || strings.Contains(output, "MASTER to PASSIVE") ||
-		strings.Contains(output, "SLAVE to PASSIVE") {
-		role = PASSIVE
-	} else if strings.Contains(output, "UNCALIBRATED to MASTER") || strings.Contains(output, "LISTENING to MASTER") {
-		role = MASTER
-	} else if strings.Contains(output, "FAULT_DETECTED") || strings.Contains(output, "SYNCHRONIZATION_FAULT") {
-		role = FAULTY
-	} else if strings.Contains(output, "UNCALIBRATED to LISTENING") || strings.Contains(output, "SLAVE to LISTENING") ||
-		strings.Contains(output, "INITIALIZING to LISTENING") {
-		role = LISTENING
-	} else {
-		portId = 0
-	}
-	return
+	return ptpEvent.PortID, convertParserRoleToMetricsRole(ptpEvent.Role)
 }
 
 func addFlagsForMonitor(process string, configOpts *string, conf *Ptp4lConf, stdoutToSocket bool) {

--- a/pkg/daemon/metrics_test.go
+++ b/pkg/daemon/metrics_test.go
@@ -3,6 +3,7 @@ package daemon
 import (
 	"testing"
 
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -84,4 +85,67 @@ func TestExtractPTP4lEventState(t *testing.T) {
 			assert.Equal(t, tt.expectedRole, role)
 		})
 	}
+}
+
+// TestParseServoState locks in the mapping from the raw "sN" servo state
+// token linuxptp prints (e.g. in "master offset -1 s2 freq +1 path delay
+// 18481") to its numeric value, matching upstream's servo.h enum: s0 =
+// SERVO_UNLOCKED, s1 = SERVO_JUMP, s2 = SERVO_LOCKED, s3 = SERVO_LOCKED_STABLE.
+func TestParseServoState(t *testing.T) {
+	tests := []struct {
+		name          string
+		servoState    string
+		expectedValue float64
+		expectedOK    bool
+	}{
+		{name: "s0 unlocked", servoState: "s0", expectedValue: 0, expectedOK: true},
+		{name: "s1 jump", servoState: "s1", expectedValue: 1, expectedOK: true},
+		{name: "s2 locked", servoState: "s2", expectedValue: 2, expectedOK: true},
+		{name: "s3 locked stable", servoState: "s3", expectedValue: 3, expectedOK: true},
+		{name: "empty string is not recognized", servoState: "", expectedOK: false},
+		{name: "missing s prefix is not recognized", servoState: "2", expectedOK: false},
+		{name: "non-numeric suffix is not recognized", servoState: "sx", expectedOK: false},
+		{name: "garbage is not recognized", servoState: "not-a-servo-state", expectedOK: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			value, ok := parseServoState(tt.servoState)
+			assert.Equal(t, tt.expectedOK, ok)
+			if tt.expectedOK {
+				assert.Equal(t, tt.expectedValue, value)
+			}
+		})
+	}
+}
+
+// Prometheus label keys used by the metrics gauges under test, pulled into
+// constants (rather than repeating the raw string literals) to satisfy
+// goconst: metrics.go already uses "process"/"node"/"iface" as map keys
+// dozens of times each, so any new raw occurrence trips the linter.
+const (
+	labelProcess = "process"
+	labelNode    = "node"
+	labelIface   = "iface"
+)
+
+// TestUpdateServoStateMetrics verifies that updateServoStateMetrics sets the
+// ServoState gauge for recognized "sN" tokens and safely no-ops (without
+// panicking or touching the gauge) on empty/unrecognized ones.
+func TestUpdateServoStateMetrics(t *testing.T) {
+	const (
+		process = "ptp4l"
+		iface   = "ens1f0"
+	)
+
+	updateServoStateMetrics(process, iface, "s2")
+	gauge := ServoState.With(map[string]string{labelProcess: process, labelNode: NodeName, labelIface: iface})
+	assert.Equal(t, float64(2), testutil.ToFloat64(gauge))
+
+	updateServoStateMetrics(process, iface, "s0")
+	assert.Equal(t, float64(0), testutil.ToFloat64(gauge))
+
+	// An unrecognized token must not overwrite the last known good value.
+	updateServoStateMetrics(process, iface, "garbage")
+	assert.Equal(t, float64(0), testutil.ToFloat64(gauge))
 }

--- a/pkg/daemon/metrics_test.go
+++ b/pkg/daemon/metrics_test.go
@@ -1,0 +1,87 @@
+package daemon
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestExtractPTP4lEventState locks in the behavior of extractPTP4lEventState,
+// which delegates to the shared ptp4l parser (parser.NewPTP4LExtractor) and
+// convertParserRoleToMetricsRole instead of the hand-rolled string
+// splitting/matching it used to do. This code path is currently unreachable
+// for real ptp4l processes (getParser always returns a non-nil extractor for
+// ptp4lProcessName, so processPTPMetrics never falls through to this
+// function's caller), but it's pinned here so any future change that makes
+// it reachable again doesn't silently regress.
+func TestExtractPTP4lEventState(t *testing.T) {
+	tests := []struct {
+		name         string
+		output       string
+		expectedID   int
+		expectedRole ptpPortRole
+	}{
+		{
+			name:         "locked to SLAVE",
+			output:       "ptp4l[123.456]: [test-config.0.config] port 1 (ens4f0): UNCALIBRATED to SLAVE on MASTER_CLOCK_SELECTED",
+			expectedID:   1,
+			expectedRole: SLAVE,
+		},
+		{
+			name:         "cold-start BMCA self-election to MASTER",
+			output:       "ptp4l[123.456]: [test-config.0.config] port 1 (ens4f0): UNCALIBRATED to MASTER on RS_MASTER",
+			expectedID:   1,
+			expectedRole: MASTER,
+		},
+		{
+			name:         "departure to PASSIVE",
+			output:       "ptp4l[123.456]: [test-config.0.config] port 2 (ens4f1): SLAVE to PASSIVE on RS_PASSIVE",
+			expectedID:   2,
+			expectedRole: PASSIVE,
+		},
+		{
+			name:         "fault detected",
+			output:       "ptp4l[123.456]: [test-config.0.config] port 1 (ens4f0): FAULT_DETECTED",
+			expectedID:   1,
+			expectedRole: FAULTY,
+		},
+		{
+			name:         "listening",
+			output:       "ptp4l[123.456]: [test-config.0.config] port 1 (ens4f0): INITIALIZING to LISTENING",
+			expectedID:   1,
+			expectedRole: LISTENING,
+		},
+		{
+			name:         "unrecognized event yields UNKNOWN role and zeroed port ID",
+			output:       "ptp4l[123.456]: [test-config.0.config] port 1 (ens4f0): delay timeout",
+			expectedID:   0,
+			expectedRole: UNKNOWN,
+		},
+		{
+			name:         "non-event line (metrics summary) yields UNKNOWN role and zeroed port ID",
+			output:       "ptp4l[123.456]: [test-config.0.config] master offset -1 s2 freq -3972 path delay 89",
+			expectedID:   0,
+			expectedRole: UNKNOWN,
+		},
+		{
+			name:         "garbage input does not panic and yields UNKNOWN role",
+			output:       "not a ptp4l line at all",
+			expectedID:   0,
+			expectedRole: UNKNOWN,
+		},
+		{
+			name:         "empty input does not panic and yields UNKNOWN role",
+			output:       "",
+			expectedID:   0,
+			expectedRole: UNKNOWN,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			portID, role := extractPTP4lEventState(tt.output)
+			assert.Equal(t, tt.expectedID, portID)
+			assert.Equal(t, tt.expectedRole, role)
+		})
+	}
+}

--- a/pkg/daemon/metrics_test.go
+++ b/pkg/daemon/metrics_test.go
@@ -119,16 +119,6 @@ func TestParseServoState(t *testing.T) {
 	}
 }
 
-// Prometheus label keys used by the metrics gauges under test, pulled into
-// constants (rather than repeating the raw string literals) to satisfy
-// goconst: metrics.go already uses "process"/"node"/"iface" as map keys
-// dozens of times each, so any new raw occurrence trips the linter.
-const (
-	labelProcess = "process"
-	labelNode    = "node"
-	labelIface   = "iface"
-)
-
 // TestUpdateServoStateMetrics verifies that updateServoStateMetrics sets the
 // ServoState gauge for recognized "sN" tokens and safely no-ops (without
 // panicking or touching the gauge) on empty/unrecognized ones.

--- a/pkg/daemon/pmc.go
+++ b/pkg/daemon/pmc.go
@@ -12,6 +12,8 @@ import (
 	expect "github.com/google/goexpect"
 	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/config"
 	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/event"
+	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/parser"
+	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/parser/constants"
 	pmcPkg "github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/pmc"
 	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/protocol"
 	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/utils"
@@ -23,9 +25,20 @@ const (
 	pollTimeout    = 5 * time.Minute
 )
 
+// PortStateChangeCallback is called by PMCProcess when a port-state
+// notification is received and the role has actually changed.
+type PortStateChangeCallback func(iface string, role, previousRole constants.PTPPortRole)
+
+// PMCPortStateOpts groups the optional port-state monitoring parameters
+// for NewPMCProcess. When nil / zero-value, port-state monitoring is disabled.
+type PMCPortStateOpts struct {
+	PortIfaceMap map[int]string
+	OnChange     PortStateChangeCallback
+}
+
 // NewPMCProcess creates a new PMC process instance for monitoring PTP events.
-func NewPMCProcess(runID int, eventHandler *event.EventHandler, clockType string) *PMCProcess {
-	return &PMCProcess{
+func NewPMCProcess(runID int, eventHandler *event.EventHandler, clockType string, portStateOpts *PMCPortStateOpts) *PMCProcess {
+	p := &PMCProcess{
 		configFileName:    fmt.Sprintf("ptp4l.%d.config", runID),
 		messageTag:        fmt.Sprintf("[ptp4l.%d.config:{level}]", runID),
 		monitorParentData: true,
@@ -34,6 +47,14 @@ func NewPMCProcess(runID int, eventHandler *event.EventHandler, clockType string
 		clockType:         clockType,
 		getMonitorFn:      pmcPkg.GetPMCMontior,
 	}
+	if portStateOpts != nil && portStateOpts.OnChange != nil && len(portStateOpts.PortIfaceMap) > 0 {
+		p.monitorPortState = true
+		p.portDSCh = make(chan protocol.PortDataSet, 10)
+		p.portIfaceMap = portStateOpts.PortIfaceMap
+		p.lastPortRole = make(map[string]constants.PTPPortRole, len(portStateOpts.PortIfaceMap))
+		p.onPortStateChange = portStateOpts.OnChange
+	}
+	return p
 }
 
 // PMCProcess manages a PMC (PTP Management Client) process for monitoring PTP events.
@@ -47,11 +68,17 @@ type PMCProcess struct {
 	monitorCMLDS      bool
 	parentDS          *protocol.ParentDataSet
 	parentDSCh        chan protocol.ParentDataSet
+	portDSCh          chan protocol.PortDataSet
 	exitCh            chan struct{}
 	clockType         string
 	c                 net.Conn // guarded by lock
 	messageTag        string
 	eventHandler      *event.EventHandler
+
+	// Port-state monitoring fields (non-nil only when monitorPortState is true).
+	portIfaceMap      map[int]string
+	lastPortRole      map[string]constants.PTPPortRole
+	onPortStateChange PortStateChangeCallback
 
 	getMonitorFn func(string) (*expect.GExpect, <-chan error, error)
 }
@@ -224,6 +251,11 @@ func (pmc *PMCProcess) monitor(conn net.Conn) error {
 
 	go pmc.expectWorker(exp, pmc.parentDSCh, workerCh, doneCh)
 
+	portDSCh := pmc.portDSCh
+	if portDSCh == nil {
+		portDSCh = make(chan protocol.PortDataSet) // never fires
+	}
+
 	for {
 		select {
 		case <-r:
@@ -233,6 +265,8 @@ func (pmc *PMCProcess) monitor(conn net.Conn) error {
 			return nil
 		case parentDS := <-pmc.parentDSCh:
 			go pmc.handleParentDS(parentDS)
+		case portDS := <-portDSCh:
+			go pmc.handlePortDS(portDS)
 		case signal := <-workerCh:
 			if signal.restartProcess {
 				glog.Warningf("PMC process exited (%v)", signal.err)
@@ -253,7 +287,7 @@ func (pmc *PMCProcess) expectWorker(exp *expect.GExpect, parentDSCh chan<- proto
 		}
 
 		go pmc.Poll() // Check if anything changed while handling the last message
-		_, matches, expectErr := exp.Expect(pmcPkg.GetMonitorRegex(pmc.monitorParentData), -1)
+		_, matches, expectErr := exp.Expect(pmcPkg.GetMonitorRegex(pmc.monitorParentData, pmc.monitorPortState), -1)
 
 		if expectErr != nil {
 			if _, ok := expectErr.(expect.TimeoutError); ok {
@@ -266,15 +300,36 @@ func (pmc *PMCProcess) expectWorker(exp *expect.GExpect, parentDSCh chan<- proto
 			continue
 		}
 
-		if len(matches) > 0 && strings.Contains(matches[0], "PARENT_DATA_SET") {
-			processedMessage, procErr := protocol.ProcessMessage[protocol.ParentDataSet](matches)
+		if len(matches) == 0 {
+			continue
+		}
+
+		// matches comes from the combined parent|port alternation regex, so its
+		// capture-group positions include every group from both branches, with
+		// the non-participating branch's groups present as empty strings. Re-run
+		// the DataSet-specific regex against the matched text so submatch
+		// indices line up with that DataSet's own Keys() again.
+		header := matches[0]
+		switch {
+		case strings.Contains(header, "PARENT_DATA_SET"):
+			parentMatches := pmcPkg.ParentDataSetRegExp().FindStringSubmatch(header)
+			processedMessage, procErr := protocol.ProcessMessage[protocol.ParentDataSet](parentMatches)
 			if procErr != nil {
 				glog.Warningf("failed to process message for PARENT_DATA_SET: %s", procErr)
 			} else {
 				parentDSCh <- *processedMessage
 			}
-		}
 
+		case pmc.monitorPortState && pmc.portDSCh != nil &&
+			strings.Contains(header, "PORT_DATA_SET "):
+			portMatches := pmcPkg.PortDataSetRegExp().FindStringSubmatch(header)
+			processedMessage, procErr := protocol.ProcessMessage[protocol.PortDataSet](portMatches)
+			if procErr != nil {
+				glog.Warningf("failed to process message for PORT_DATA_SET: %s", procErr)
+			} else {
+				pmc.portDSCh <- *processedMessage
+			}
+		}
 	}
 }
 
@@ -297,6 +352,34 @@ func (pmc *PMCProcess) handleParentDS(parentDS protocol.ParentDataSet) {
 			pmc.configFileName,
 			event.ClockType(pmc.clockType),
 		)
+	}
+}
+
+func (pmc *PMCProcess) handlePortDS(portDS protocol.PortDataSet) {
+	portNum, err := portDS.PortNumber()
+	if err != nil {
+		glog.Warningf("PMC port-state: cannot extract port number: %v", err)
+		return
+	}
+
+	iface, ok := pmc.portIfaceMap[portNum]
+	if !ok {
+		glog.Warningf("PMC port-state: unknown port number %d (identity=%s)", portNum, portDS.PortIdentity)
+		return
+	}
+
+	role, _ := parser.PortStateToRole(portDS.PortState)
+	previousRole := pmc.lastPortRole[iface]
+	pmc.lastPortRole[iface] = role
+
+	if role == previousRole {
+		return
+	}
+
+	glog.Infof("PMC port-state: iface=%s state=%s role=%v previousRole=%v", iface, portDS.PortState, role, previousRole)
+
+	if pmc.onPortStateChange != nil {
+		pmc.onPortStateChange(iface, role, previousRole)
 	}
 }
 

--- a/pkg/daemon/pmc.go
+++ b/pkg/daemon/pmc.go
@@ -356,19 +356,13 @@ func (pmc *PMCProcess) handleParentDS(parentDS protocol.ParentDataSet) {
 }
 
 func (pmc *PMCProcess) handlePortDS(portDS protocol.PortDataSet) {
-	portNum, err := portDS.PortNumber()
-	if err != nil {
-		glog.Warningf("PMC port-state: cannot extract port number: %v", err)
-		return
-	}
-
-	iface, ok := pmc.portIfaceMap[portNum]
+	iface, ok := pmc.portIfaceMap[portDS.PortNum]
 	if !ok {
-		glog.Warningf("PMC port-state: unknown port number %d (identity=%s)", portNum, portDS.PortIdentity)
+		glog.Warningf("PMC port-state: unknown port number %d (identity=%s)", portDS.PortNum, portDS.PortIdentity)
 		return
 	}
 
-	role, _ := parser.PortStateToRole(portDS.PortState)
+	role := parser.PortStateToRole(portDS.PortState)
 	previousRole := pmc.lastPortRole[iface]
 	pmc.lastPortRole[iface] = role
 

--- a/pkg/hardwareconfig/hardwareconfig_test.go
+++ b/pkg/hardwareconfig/hardwareconfig_test.go
@@ -451,6 +451,104 @@ func TestDetectStateChange(t *testing.T) {
 	})
 }
 
+// TestDetectStateChange_PreviousRolePrecision locks in the precision of the
+// "lost" detection added when DetectStateChange was switched from
+// strings.Contains(event.Raw, "SLAVE to ") to event.PreviousRole ==
+// constants.PortRoleSlave. It specifically guards against two classes of
+// false positive that a looser check (e.g. matching on Role alone, or on
+// interface-name equality with a previously-locked port) would reintroduce:
+//   - benign non-transition log lines for an already-locked monitored port
+//   - benign cold-start BMCA self-election ("... to MASTER on RS_MASTER")
+//     on a port that was never SLAVE
+//
+// and it confirms every kind of genuine "left SLAVE" transition (to MASTER,
+// PASSIVE, LISTENING, UNCALIBRATED/FAULTY) is still reported as "lost".
+func TestDetectStateChange_PreviousRolePrecision(t *testing.T) {
+	SetupMockPtpDeviceResolver()
+	defer TeardownMockPtpDeviceResolver()
+
+	mockErr := SetupMockDpllPinsForTests()
+	if mockErr != nil {
+		t.Logf("Warning: Failed to setup mock DPLL pins: %v", mockErr)
+	}
+	defer TeardownMockDpllPinsForTests()
+
+	mockCmd := NewMockCommandExecutor()
+	mockCmd.SetResponse("ethtool", []string{"-i", "ens4f0"}, "driver: ice\nbus-info: 0000:17:00.0")
+	mockCmd.SetResponse("lspci", []string{"-s", "0000:17:00.0"}, "17:00.0 Ethernet controller: Intel Corporation Ethernet Controller E810-C for backplane")
+	mockCmd.SetResponse("devlink", []string{"dev", "info", "pci/0000:17:00.0"}, "serial_number 50-7c-6f-ff-ff-5c-4a-e8")
+	mockCmd.SetResponse("ethtool", []string{"-i", "ens8f0"}, "driver: ice\nbus-info: 0000:51:00.0")
+	mockCmd.SetResponse("lspci", []string{"-s", "0000:51:00.0"}, "51:00.0 Ethernet controller: Intel Corporation Ethernet Controller E810-C for backplane")
+	mockCmd.SetResponse("devlink", []string{"dev", "info", "pci/0000:51:00.0"}, "serial_number 50-7c-6f-ff-ff-1f-b1-b8")
+	SetCommandExecutor(mockCmd)
+	defer ResetCommandExecutor()
+
+	hwConfig, err := loadHardwareConfigFromFile("testdata/wpc-hwconfig.yaml")
+	assert.NoError(t, err)
+	hcm := newHardwareConfigManagerForTests()
+	assert.NoError(t, hcm.UpdateHardwareConfig([]ptpv2alpha1.HardwareConfig{*hwConfig}))
+
+	t.Run("benign non-transition line on an already-locked port is not lost", func(t *testing.T) {
+		psd := NewPTPStateDetector(hcm)
+
+		portName, conditionType := psd.DetectStateChange("ptp4l[100.000]: [ptp4l.1.config:5] port 1 (ens4f1): UNCALIBRATED to SLAVE on MASTER_CLOCK_SELECTED")
+		assert.Equal(t, "locked", conditionType)
+		assert.Equal(t, "ens4f1", portName)
+
+		for i := 0; i < 10; i++ {
+			portName, conditionType = psd.DetectStateChange("ptp4l[200.000]: [ptp4l.1.config:5] port 1 (ens4f1): some unrelated diagnostic message")
+			assert.Equal(t, "", conditionType, "iteration %d: unrelated line must not report lost/locked", i)
+			assert.Equal(t, "", portName, "iteration %d", i)
+		}
+	})
+
+	t.Run("benign cold-start BMCA self-election is not lost", func(t *testing.T) {
+		psd := NewPTPStateDetector(hcm)
+
+		portName, conditionType := psd.DetectStateChange("ptp4l[100.000]: [ptp4l.1.config:5] port 1 (ens4f1): UNCALIBRATED to MASTER on RS_MASTER")
+		assert.Equal(t, "", conditionType, "cold-start self-election on a never-locked port must not be reported as lost")
+		assert.Equal(t, "", portName)
+	})
+
+	t.Run("every kind of departure from SLAVE is reported as lost", func(t *testing.T) {
+		departures := []string{
+			"SLAVE to MASTER on ANNOUNCE_RECEIPT_TIMEOUT_EXPIRES",
+			"SLAVE to GRAND_MASTER",
+			"SLAVE to PASSIVE on RS_PASSIVE",
+			"SLAVE to LISTENING",
+			"SLAVE to UNCALIBRATED",
+			"SLAVE to FAULT_DETECTED on FAULT_DETECTED",
+		}
+		for _, transition := range departures {
+			t.Run(transition, func(t *testing.T) {
+				psd := NewPTPStateDetector(hcm)
+				// Establish SLAVE first so the scenario matches a real port
+				// that was actually locked before departing.
+				_, conditionType := psd.DetectStateChange("ptp4l[100.000]: [ptp4l.1.config:5] port 1 (ens4f1): UNCALIBRATED to SLAVE on MASTER_CLOCK_SELECTED")
+				assert.Equal(t, "locked", conditionType)
+
+				portName, conditionType := psd.DetectStateChange("ptp4l[200.000]: [ptp4l.1.config:5] port 1 (ens4f1): " + transition)
+				assert.Equal(t, "lost", conditionType)
+				assert.Equal(t, "ens4f1", portName)
+			})
+		}
+	})
+
+	t.Run("re-lock after a lost transition is detected", func(t *testing.T) {
+		psd := NewPTPStateDetector(hcm)
+
+		_, conditionType := psd.DetectStateChange("ptp4l[100.000]: [ptp4l.1.config:5] port 1 (ens4f1): UNCALIBRATED to SLAVE on MASTER_CLOCK_SELECTED")
+		assert.Equal(t, "locked", conditionType)
+
+		_, conditionType = psd.DetectStateChange("ptp4l[200.000]: [ptp4l.1.config:5] port 1 (ens4f1): SLAVE to MASTER on ANNOUNCE_RECEIPT_TIMEOUT_EXPIRES")
+		assert.Equal(t, "lost", conditionType)
+
+		portName, conditionType := psd.DetectStateChange("ptp4l[300.000]: [ptp4l.1.config:5] port 1 (ens4f1): UNCALIBRATED to SLAVE on MASTER_CLOCK_SELECTED")
+		assert.Equal(t, "locked", conditionType)
+		assert.Equal(t, "ens4f1", portName)
+	})
+}
+
 func TestNewPTPStateDetector(t *testing.T) {
 	hcm := newHardwareConfigManagerForTests()
 	psd := NewPTPStateDetector(hcm)

--- a/pkg/hardwareconfig/hardwareconfig_test.go
+++ b/pkg/hardwareconfig/hardwareconfig_test.go
@@ -12,6 +12,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/parser/constants"
+
 	dpllcfg "github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/dpll"
 	dpll "github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/dpll-netlink"
 	ptpv1 "github.com/k8snetworkplumbingwg/ptp-operator/api/v1"
@@ -547,6 +549,66 @@ func TestDetectStateChange_PreviousRolePrecision(t *testing.T) {
 		assert.Equal(t, "locked", conditionType)
 		assert.Equal(t, "ens4f1", portName)
 	})
+}
+
+func TestDetectStateChangeFromRole(t *testing.T) {
+	tests := []struct {
+		name              string
+		portName          string
+		role              constants.PTPPortRole
+		previousRole      constants.PTPPortRole
+		expectedPort      string
+		expectedCondition string
+	}{
+		{
+			name:              "becomes SLAVE -> locked",
+			portName:          "ens4f0",
+			role:              constants.PortRoleSlave,
+			previousRole:      constants.PortRoleUnknown,
+			expectedPort:      "ens4f0",
+			expectedCondition: ConditionTypeLocked,
+		},
+		{
+			name:              "was SLAVE now FAULTY -> lost",
+			portName:          "ens4f0",
+			role:              constants.PortRoleFaulty,
+			previousRole:      constants.PortRoleSlave,
+			expectedPort:      "ens4f0",
+			expectedCondition: ConditionTypeLost,
+		},
+		{
+			name:              "was SLAVE now MASTER -> lost",
+			portName:          "ens4f0",
+			role:              constants.PortRoleMaster,
+			previousRole:      constants.PortRoleSlave,
+			expectedPort:      "ens4f0",
+			expectedCondition: ConditionTypeLost,
+		},
+		{
+			name:              "MASTER to LISTENING -> no change",
+			portName:          "ens4f0",
+			role:              constants.PortRoleListening,
+			previousRole:      constants.PortRoleMaster,
+			expectedPort:      "",
+			expectedCondition: "",
+		},
+		{
+			name:              "unknown to unknown -> no change",
+			portName:          "ens4f0",
+			role:              constants.PortRoleUnknown,
+			previousRole:      constants.PortRoleUnknown,
+			expectedPort:      "",
+			expectedCondition: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			port, cond := DetectStateChangeFromRole(tt.portName, tt.role, tt.previousRole)
+			assert.Equal(t, tt.expectedPort, port)
+			assert.Equal(t, tt.expectedCondition, cond)
+		})
+	}
 }
 
 func TestNewPTPStateDetector(t *testing.T) {

--- a/pkg/hardwareconfig/ptp_input.go
+++ b/pkg/hardwareconfig/ptp_input.go
@@ -33,10 +33,23 @@ func NewPTPStateDetector(hcm *HardwareConfigManager) *PTPStateDetector {
 	return psd
 }
 
+// DetectStateChangeFromRole maps a port-role transition to a condition type.
+// This is the shared core that both log-scraping and PMC-based port-state
+// detection use. Returns ("", "") when the transition is not relevant.
+func DetectStateChangeFromRole(portName string, role, previousRole constants.PTPPortRole) (string, string) {
+	switch {
+	case role == constants.PortRoleSlave:
+		return portName, ConditionTypeLocked
+	case previousRole == constants.PortRoleSlave:
+		return portName, ConditionTypeLost
+	default:
+		return "", ""
+	}
+}
+
 // DetectStateChange processes a PTP4L log line and returns port-aware state change information.
 // Returns the port name and condition type ("locked", "lost") for the port that changed state.
 // Returns ("", "") when the log line contains no relevant state change or the port is not monitored.
-// TODO: replace by pmc state monitor
 func (psd *PTPStateDetector) DetectStateChange(logLine string) (portName string, conditionType string) {
 	_, event, err := psd.ptp4lExtractor.Extract(logLine)
 	if err != nil || event == nil {
@@ -48,16 +61,7 @@ func (psd *PTPStateDetector) DetectStateChange(logLine string) (portName string,
 		return "", ""
 	}
 
-	switch {
-	case event.Role == constants.PortRoleSlave:
-		return portName, ConditionTypeLocked
-	case event.PreviousRole == constants.PortRoleSlave:
-		// The port was SLAVE immediately before this transition and is no
-		// longer, i.e. it just lost sync (regardless of what it became).
-		return portName, ConditionTypeLost
-	default:
-		return "", ""
-	}
+	return DetectStateChangeFromRole(portName, event.Role, event.PreviousRole)
 }
 
 // ExtractPortName extracts the port name from a PTP4L log line using the parser package

--- a/pkg/hardwareconfig/ptp_input.go
+++ b/pkg/hardwareconfig/ptp_input.go
@@ -1,8 +1,6 @@
 package hardwareconfig
 
 import (
-	"strings"
-
 	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/parser"
 	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/parser/constants"
 	ptpv2alpha1 "github.com/k8snetworkplumbingwg/ptp-operator/api/v2alpha1"
@@ -45,29 +43,21 @@ func (psd *PTPStateDetector) DetectStateChange(logLine string) (portName string,
 		return "", ""
 	}
 
-	portName = psd.extractPortName(logLine)
-	if portName == "" {
+	portName = event.Iface
+	if portName == "" || !psd.monitoredPorts[portName] {
 		return "", ""
 	}
 
-	if !psd.monitoredPorts[portName] {
-		return "", ""
-	}
-
-	switch event.Role {
-	case constants.PortRoleSlave:
+	switch {
+	case event.Role == constants.PortRoleSlave:
 		return portName, ConditionTypeLocked
+	case event.PreviousRole == constants.PortRoleSlave:
+		// The port was SLAVE immediately before this transition and is no
+		// longer, i.e. it just lost sync (regardless of what it became).
+		return portName, ConditionTypeLost
 	default:
-		if strings.Contains(event.Raw, "SLAVE to ") {
-			return portName, ConditionTypeLost
-		}
 		return "", ""
 	}
-}
-
-// extractPortName extracts the port name from a PTP4L log line using the parser
-func (psd *PTPStateDetector) extractPortName(logLine string) string {
-	return psd.ExtractPortName(logLine)
 }
 
 // ExtractPortName extracts the port name from a PTP4L log line using the parser package

--- a/pkg/parser/README.md
+++ b/pkg/parser/README.md
@@ -79,7 +79,10 @@ type Metrics struct {
     MaxOffset  float64 // Maximum time offset
     FreqAdj    float64 // Frequency adjustment
     Delay      float64 // Path delay
-    ClockState string  // Clock state (LOCKED, FREERUN, etc.)
+    ClockState string  // Clock state (LOCKED, FREERUN, etc.), collapsed from ServoState
+    ServoState string  // Raw linuxptp servo state token (s0, s1, s2, s3), e.g. from
+                        // "master offset -1 s2 freq +1 path delay 18481". Matches
+                        // upstream servo.h: s0=UNLOCKED, s1=JUMP, s2=LOCKED, s3=LOCKED_STABLE
     Source     string  // Source of the metrics (master, phc, sys, etc.)
 }
 ```

--- a/pkg/parser/model.go
+++ b/pkg/parser/model.go
@@ -34,6 +34,13 @@ type Metrics struct {
 	FreqAdj    float64              `json:"freqadj"`
 	Delay      float64              `json:"delay"`
 	ClockState constants.ClockState `json:"clockstate"` // e.g. LOCKED, FREERUN, HOLDOVER
-	Source     string               `json:"source"`     // e.g. "phc", "sys", or "master"
-	Status     []StatusMetric       `json:"status"`     // List of status metrics with their subtypes
+	// ServoState is the raw servo state token as printed by linuxptp (e.g.
+	// "s0", "s1", "s2", "s3"), taken directly from the log line before it is
+	// collapsed into ClockState. It mirrors linuxptp's upstream servo.h enum:
+	// s0 = SERVO_UNLOCKED, s1 = SERVO_JUMP, s2 = SERVO_LOCKED, s3 =
+	// SERVO_LOCKED_STABLE. Empty when the log line carries no servo state
+	// (e.g. summary/rms lines).
+	ServoState string         `json:"servostate"`
+	Source     string         `json:"source"` // e.g. "phc", "sys", or "master"
+	Status     []StatusMetric `json:"status"` // List of status metrics with their subtypes
 }

--- a/pkg/parser/model.go
+++ b/pkg/parser/model.go
@@ -10,11 +10,17 @@ type StatusMetric struct {
 
 // PTPEvent represents an event extracted from a log line.
 type PTPEvent struct {
-	PortID     int                   `json:"portid"`
-	Iface      string                `json:"iface"`
-	Role       constants.PTPPortRole `json:"role"`       // e.g. SLAVE, MASTER, FAULTY
-	ClockState constants.ClockState  `json:"clockstate"` // Clock class value for clock class change events
-	Raw        string                `json:"raw"`        // original line
+	PortID int                   `json:"portid"`
+	Iface  string                `json:"iface"`
+	Role   constants.PTPPortRole `json:"role"` // e.g. SLAVE, MASTER, FAULTY
+	// PreviousRole is the role the port held immediately before this
+	// transition (e.g. "SLAVE to MASTER ..." -> PortRoleSlave), parsed
+	// directly from the log line's own "<FROM> to <TO>" text. It is
+	// constants.PortRoleUnknown when the line has no explicit "X to Y"
+	// transition (e.g. FAULT_DETECTED) or the FROM state isn't recognized.
+	PreviousRole constants.PTPPortRole `json:"previousrole"`
+	ClockState   constants.ClockState  `json:"clockstate"` // Clock class value for clock class change events
+	Raw          string                `json:"raw"`        // original line
 }
 
 // Note: metrics should be float64 values for as thatis the type expected by the prometheus client library.

--- a/pkg/parser/phc2sys_parser.go
+++ b/pkg/parser/phc2sys_parser.go
@@ -197,6 +197,7 @@ func extractRegularPhc2Sys(parsed *phc2sysParsed) (*Metrics, error) {
 		FreqAdj:    *parsed.FreqAdj,
 		Delay:      delay,
 		ClockState: clockState,
+		ServoState: parsed.ServoState,
 		Source:     parsed.Source,
 	}, nil
 }

--- a/pkg/parser/phc2sys_parser_test.go
+++ b/pkg/parser/phc2sys_parser_test.go
@@ -44,6 +44,7 @@ func TestPhc2SysParser(t *testing.T) {
 				FreqAdj:    -6990,
 				Delay:      502,
 				ClockState: constants.ClockStateLocked,
+				ServoState: "s2",
 				Source:     constants.Phc,
 			},
 		},
@@ -57,6 +58,7 @@ func TestPhc2SysParser(t *testing.T) {
 				FreqAdj:    -6990,
 				Delay:      502,
 				ClockState: constants.ClockStateLocked,
+				ServoState: "s2",
 				Source:     constants.Sys,
 			},
 		},
@@ -70,6 +72,21 @@ func TestPhc2SysParser(t *testing.T) {
 				FreqAdj:    8956,
 				Delay:      508,
 				ClockState: constants.ClockStateLocked,
+				ServoState: "s2",
+				Source:     constants.Phc,
+			},
+		},
+		{
+			name:    "Valid regular metrics with s0 servo state (unlocked, freerun)",
+			logLine: "phc2sys[1823126.732]: [ptp4l.0.config] CLOCK_REALTIME phc offset       -10 s0 freq   +8956 delay    508",
+			expectedMetric: &parser.Metrics{
+				Iface:      "CLOCK_REALTIME",
+				Offset:     -10,
+				MaxOffset:  -10,
+				FreqAdj:    8956,
+				Delay:      508,
+				ClockState: constants.ClockStateFreeRun,
+				ServoState: "s0",
 				Source:     constants.Phc,
 			},
 		},
@@ -97,6 +114,7 @@ func TestPhc2SysParser(t *testing.T) {
 				assert.Equal(t, tt.expectedMetric.FreqAdj, metric.FreqAdj)
 				assert.Equal(t, tt.expectedMetric.Delay, metric.Delay)
 				assert.Equal(t, tt.expectedMetric.ClockState, metric.ClockState)
+				assert.Equal(t, tt.expectedMetric.ServoState, metric.ServoState)
 				assert.Equal(t, tt.expectedMetric.Source, metric.Source)
 			}
 		})

--- a/pkg/parser/port_state.go
+++ b/pkg/parser/port_state.go
@@ -1,0 +1,29 @@
+package parser
+
+import "github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/parser/constants"
+
+// PortStateToRole maps a linuxptp ps_str port-state name (as carried in a
+// PORT_DATA_SET management message's portState field) to the internal
+// PTPPortRole and ClockState enums.
+//
+// The mapping mirrors determineRole() in ptp4l_parser.go but operates on a
+// single-state string ("SLAVE") rather than a log-line transition phrase
+// ("UNCALIBRATED to SLAVE on ..."). Because PORT_DATA_SET only reports the
+// current state (not the previous one), the caller is responsible for
+// maintaining previous-role context externally.
+func PortStateToRole(state string) (constants.PTPPortRole, constants.ClockState) {
+	switch state {
+	case "SLAVE":
+		return constants.PortRoleSlave, constants.ClockStateFreeRun
+	case "MASTER", "GRAND_MASTER", "PRE_MASTER":
+		return constants.PortRoleMaster, constants.ClockStateFreeRun
+	case "PASSIVE":
+		return constants.PortRolePassive, constants.ClockStateFreeRun
+	case "LISTENING":
+		return constants.PortRoleListening, constants.ClockStateFreeRun
+	case "FAULTY":
+		return constants.PortRoleFaulty, constants.ClockStateHoldover
+	default:
+		return constants.PortRoleUnknown, constants.ClockStateFreeRun
+	}
+}

--- a/pkg/parser/port_state.go
+++ b/pkg/parser/port_state.go
@@ -4,26 +4,22 @@ import "github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/parser/constants"
 
 // PortStateToRole maps a linuxptp ps_str port-state name (as carried in a
 // PORT_DATA_SET management message's portState field) to the internal
-// PTPPortRole and ClockState enums.
-//
-// The mapping mirrors determineRole() in ptp4l_parser.go but operates on a
-// single-state string ("SLAVE") rather than a log-line transition phrase
-// ("UNCALIBRATED to SLAVE on ..."). Because PORT_DATA_SET only reports the
-// current state (not the previous one), the caller is responsible for
-// maintaining previous-role context externally.
-func PortStateToRole(state string) (constants.PTPPortRole, constants.ClockState) {
+// PTPPortRole enum. Because PORT_DATA_SET only reports the current state
+// (not the previous one), the caller is responsible for maintaining
+// previous-role context externally.
+func PortStateToRole(state string) constants.PTPPortRole {
 	switch state {
 	case "SLAVE":
-		return constants.PortRoleSlave, constants.ClockStateFreeRun
+		return constants.PortRoleSlave
 	case "MASTER", "GRAND_MASTER", "PRE_MASTER":
-		return constants.PortRoleMaster, constants.ClockStateFreeRun
+		return constants.PortRoleMaster
 	case "PASSIVE":
-		return constants.PortRolePassive, constants.ClockStateFreeRun
+		return constants.PortRolePassive
 	case "LISTENING":
-		return constants.PortRoleListening, constants.ClockStateFreeRun
+		return constants.PortRoleListening
 	case "FAULTY":
-		return constants.PortRoleFaulty, constants.ClockStateHoldover
+		return constants.PortRoleFaulty
 	default:
-		return constants.PortRoleUnknown, constants.ClockStateFreeRun
+		return constants.PortRoleUnknown
 	}
 }

--- a/pkg/parser/port_state_test.go
+++ b/pkg/parser/port_state_test.go
@@ -1,0 +1,37 @@
+package parser
+
+import (
+	"testing"
+
+	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/parser/constants"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPortStateToRole(t *testing.T) {
+	tests := []struct {
+		state     string
+		wantRole  constants.PTPPortRole
+		wantClock constants.ClockState
+	}{
+		{"SLAVE", constants.PortRoleSlave, constants.ClockStateFreeRun},
+		{"MASTER", constants.PortRoleMaster, constants.ClockStateFreeRun},
+		{"GRAND_MASTER", constants.PortRoleMaster, constants.ClockStateFreeRun},
+		{"PRE_MASTER", constants.PortRoleMaster, constants.ClockStateFreeRun},
+		{"PASSIVE", constants.PortRolePassive, constants.ClockStateFreeRun},
+		{"LISTENING", constants.PortRoleListening, constants.ClockStateFreeRun},
+		{"FAULTY", constants.PortRoleFaulty, constants.ClockStateHoldover},
+		{"UNCALIBRATED", constants.PortRoleUnknown, constants.ClockStateFreeRun},
+		{"INITIALIZING", constants.PortRoleUnknown, constants.ClockStateFreeRun},
+		{"DISABLED", constants.PortRoleUnknown, constants.ClockStateFreeRun},
+		{"NONE", constants.PortRoleUnknown, constants.ClockStateFreeRun},
+		{"bogus", constants.PortRoleUnknown, constants.ClockStateFreeRun},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.state, func(t *testing.T) {
+			role, clock := PortStateToRole(tt.state)
+			assert.Equal(t, tt.wantRole, role, "role for %s", tt.state)
+			assert.Equal(t, tt.wantClock, clock, "clock state for %s", tt.state)
+		})
+	}
+}

--- a/pkg/parser/port_state_test.go
+++ b/pkg/parser/port_state_test.go
@@ -9,29 +9,26 @@ import (
 
 func TestPortStateToRole(t *testing.T) {
 	tests := []struct {
-		state     string
-		wantRole  constants.PTPPortRole
-		wantClock constants.ClockState
+		state    string
+		wantRole constants.PTPPortRole
 	}{
-		{"SLAVE", constants.PortRoleSlave, constants.ClockStateFreeRun},
-		{"MASTER", constants.PortRoleMaster, constants.ClockStateFreeRun},
-		{"GRAND_MASTER", constants.PortRoleMaster, constants.ClockStateFreeRun},
-		{"PRE_MASTER", constants.PortRoleMaster, constants.ClockStateFreeRun},
-		{"PASSIVE", constants.PortRolePassive, constants.ClockStateFreeRun},
-		{"LISTENING", constants.PortRoleListening, constants.ClockStateFreeRun},
-		{"FAULTY", constants.PortRoleFaulty, constants.ClockStateHoldover},
-		{"UNCALIBRATED", constants.PortRoleUnknown, constants.ClockStateFreeRun},
-		{"INITIALIZING", constants.PortRoleUnknown, constants.ClockStateFreeRun},
-		{"DISABLED", constants.PortRoleUnknown, constants.ClockStateFreeRun},
-		{"NONE", constants.PortRoleUnknown, constants.ClockStateFreeRun},
-		{"bogus", constants.PortRoleUnknown, constants.ClockStateFreeRun},
+		{"SLAVE", constants.PortRoleSlave},
+		{"MASTER", constants.PortRoleMaster},
+		{"GRAND_MASTER", constants.PortRoleMaster},
+		{"PRE_MASTER", constants.PortRoleMaster},
+		{"PASSIVE", constants.PortRolePassive},
+		{"LISTENING", constants.PortRoleListening},
+		{"FAULTY", constants.PortRoleFaulty},
+		{"UNCALIBRATED", constants.PortRoleUnknown},
+		{"INITIALIZING", constants.PortRoleUnknown},
+		{"DISABLED", constants.PortRoleUnknown},
+		{"NONE", constants.PortRoleUnknown},
+		{"bogus", constants.PortRoleUnknown},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.state, func(t *testing.T) {
-			role, clock := PortStateToRole(tt.state)
-			assert.Equal(t, tt.wantRole, role, "role for %s", tt.state)
-			assert.Equal(t, tt.wantClock, clock, "clock state for %s", tt.state)
+			assert.Equal(t, tt.wantRole, PortStateToRole(tt.state))
 		})
 	}
 }

--- a/pkg/parser/ptp4l_parser.go
+++ b/pkg/parser/ptp4l_parser.go
@@ -299,6 +299,7 @@ func extractRegularPTP4l(parsed *ptp4lParsed) (*Metrics, error) {
 		FreqAdj:    *parsed.FreqAdj,
 		Delay:      delay,
 		ClockState: clockState,
+		ServoState: parsed.ServoState,
 		Source:     constants.Master,
 	}, nil
 }

--- a/pkg/parser/ptp4l_parser.go
+++ b/pkg/parser/ptp4l_parser.go
@@ -170,6 +170,8 @@ func NewPTP4LExtractor() *BaseMetricsExtractor[*ptp4lParsed] {
 		},
 	}
 }
+
+// extractEventPTP4l builds a PTPEvent (port ID, interface, role, previous role, clock state) from a parsed ptp4l port state-change log line.
 func extractEventPTP4l(parsed *ptp4lParsed) (*PTPEvent, error) {
 	if parsed.PortID == nil {
 		return nil, fmt.Errorf("port id not found")

--- a/pkg/parser/ptp4l_parser.go
+++ b/pkg/parser/ptp4l_parser.go
@@ -181,13 +181,39 @@ func extractEventPTP4l(parsed *ptp4lParsed) (*PTPEvent, error) {
 		portID = 0
 	}
 
-	// TODO: Pass port name up if provided
 	return &PTPEvent{
-		PortID:     portID,
-		Role:       role,
-		ClockState: clockState,
-		Raw:        parsed.Raw,
+		PortID:       portID,
+		Iface:        parsed.PortName,
+		Role:         role,
+		PreviousRole: previousRole(parsed.Event),
+		ClockState:   clockState,
+		Raw:          parsed.Raw,
 	}, nil
+}
+
+// previousRole extracts the role the port held immediately before this
+// transition from a "<FROM> to <TO> ..." event string (e.g. "SLAVE to MASTER
+// on ANNOUNCE_RECEIPT_TIMEOUT_EXPIRES" -> PortRoleSlave). Returns
+// constants.PortRoleUnknown when the event has no explicit "X to Y"
+// transition (e.g. FAULT_DETECTED) or the FROM state isn't one of the
+// recognized port roles.
+func previousRole(event string) constants.PTPPortRole {
+	from, _, found := strings.Cut(event, " to ")
+	if !found {
+		return constants.PortRoleUnknown
+	}
+	switch from {
+	case "SLAVE":
+		return constants.PortRoleSlave
+	case "MASTER":
+		return constants.PortRoleMaster
+	case "PASSIVE":
+		return constants.PortRolePassive
+	case "LISTENING":
+		return constants.PortRoleListening
+	default:
+		return constants.PortRoleUnknown
+	}
 }
 
 // ExtractPortName extracts the port name from a PTP4L event log line

--- a/pkg/parser/ptp4l_parser_internal_test.go
+++ b/pkg/parser/ptp4l_parser_internal_test.go
@@ -4,11 +4,52 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/parser/constants"
 	"github.com/stretchr/testify/assert"
 )
 
 func _ptr[T any](x T) *T {
 	return &x
+}
+
+// TestPreviousRole locks in previousRole()'s exact mapping from the "<FROM>
+// to <TO> ..." portion of a ptp4l event string to the FROM role. This is the
+// primitive that lets stateless consumers (e.g. hardwareconfig's
+// DetectStateChange) determine "did this port just leave SLAVE" from a
+// single log line, without needing their own cross-call memory.
+func TestPreviousRole(t *testing.T) {
+	tests := []struct {
+		name     string
+		event    string
+		expected constants.PTPPortRole
+	}{
+		{"from SLAVE", "SLAVE to MASTER on ANNOUNCE_RECEIPT_TIMEOUT_EXPIRES", constants.PortRoleSlave},
+		{"from SLAVE to GRAND_MASTER", "SLAVE to GRAND_MASTER", constants.PortRoleSlave},
+		{"from SLAVE to PASSIVE", "SLAVE to PASSIVE on RS_PASSIVE", constants.PortRoleSlave},
+		{"from SLAVE to LISTENING", "SLAVE to LISTENING", constants.PortRoleSlave},
+		{"from SLAVE to UNCALIBRATED", "SLAVE to UNCALIBRATED", constants.PortRoleSlave},
+		{"from MASTER", "MASTER to PASSIVE on RS_PASSIVE", constants.PortRoleMaster},
+		{"from MASTER to UNCALIBRATED", "MASTER to UNCALIBRATED on RS_SLAVE", constants.PortRoleMaster},
+		{"from PASSIVE", "PASSIVE to MASTER on RS_MASTER", constants.PortRolePassive},
+		{"from LISTENING to MASTER", "LISTENING to MASTER on RS_MASTER", constants.PortRoleListening},
+		{"from LISTENING to MASTER via timeout", "LISTENING to MASTER on ANNOUNCE_RECEIPT_TIMEOUT_EXPIRES", constants.PortRoleListening},
+		{"from LISTENING to PASSIVE", "LISTENING to PASSIVE on RS_PASSIVE", constants.PortRoleListening},
+		{"from LISTENING to UNCALIBRATED", "LISTENING to UNCALIBRATED on RS_SLAVE", constants.PortRoleListening},
+		{"from UNCALIBRATED (not a recognized FROM role)", "UNCALIBRATED to SLAVE on MASTER_CLOCK_SELECTED", constants.PortRoleUnknown},
+		{"from UNCALIBRATED to MASTER", "UNCALIBRATED to MASTER on RS_MASTER", constants.PortRoleUnknown},
+		{"from INITIALIZING (not a recognized FROM role)", "INITIALIZING to LISTENING", constants.PortRoleUnknown},
+		{"from FAULTY (not a recognized FROM role)", "FAULTY to LISTENING", constants.PortRoleUnknown},
+		{"no transition text at all", "FAULT_DETECTED", constants.PortRoleUnknown},
+		{"no transition text (synchronization fault)", "SYNCHRONIZATION_FAULT", constants.PortRoleUnknown},
+		{"unrecognized diagnostic line", "delay timeout", constants.PortRoleUnknown},
+		{"empty string", "", constants.PortRoleUnknown},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, previousRole(tt.event))
+		})
+	}
 }
 
 func TestPTP4LParser(t *testing.T) {

--- a/pkg/parser/ptp4l_parser_internal_test.go
+++ b/pkg/parser/ptp4l_parser_internal_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// _ptr returns a pointer to its argument, used to build expected ptp4lParsed struct literals whose numeric fields are pointers.
 func _ptr[T any](x T) *T {
 	return &x
 }
@@ -52,6 +53,7 @@ func TestPreviousRole(t *testing.T) {
 	}
 }
 
+// TestPTP4LParser verifies the low-level parseLine/Populate behavior for the ptp4l summary, regular, and port-event regexes against valid, invalid, and empty input.
 func TestPTP4LParser(t *testing.T) {
 	tests := []struct {
 		name           string

--- a/pkg/parser/ptp4l_parser_test.go
+++ b/pkg/parser/ptp4l_parser_test.go
@@ -12,6 +12,7 @@ import (
 // PTPEvent test cases below (locked/left-SLAVE/cold-start/benign-diagnostic).
 const testIfaceName = "ens4f0"
 
+// TestPTP4LParser verifies that NewPTP4LExtractor extracts correct parser.Metrics from both the summary and regular ptp4l metric log line formats.
 func TestPTP4LParser(t *testing.T) {
 	tests := []struct {
 		name           string
@@ -90,6 +91,7 @@ func TestPTP4LParser(t *testing.T) {
 	}
 }
 
+// TestPTP4LEventParser verifies that NewPTP4LExtractor derives a correct parser.PTPEvent (PortID, Iface, Role, PreviousRole, ClockState) from every kind of ptp4l port state-change log line.
 func TestPTP4LEventParser(t *testing.T) {
 	tests := []struct {
 		name          string

--- a/pkg/parser/ptp4l_parser_test.go
+++ b/pkg/parser/ptp4l_parser_test.go
@@ -32,6 +32,7 @@ func TestPTP4LParser(t *testing.T) {
 				FreqAdj:    -16642,
 				Delay:      1089,
 				ClockState: "",
+				ServoState: "",
 				Source:     constants.Master,
 			},
 		},
@@ -46,6 +47,7 @@ func TestPTP4LParser(t *testing.T) {
 				FreqAdj:    -6083928,
 				Delay:      2791,
 				ClockState: "",
+				ServoState: "",
 				Source:     constants.Master,
 			},
 		},
@@ -60,6 +62,37 @@ func TestPTP4LParser(t *testing.T) {
 				FreqAdj:    -3972,
 				Delay:      89,
 				ClockState: constants.ClockStateLocked,
+				ServoState: "s2",
+				Source:     constants.Master,
+			},
+		},
+		{
+			name:       "Valid regular metrics carry the raw servo state distinct from the collapsed clock state",
+			configName: "ptp4l.1.config",
+			logLine:    "ptp4l[2330.162]: [ptp4l.1.config:6] master offset         -1 s2 freq      +1 path delay     18481",
+			expectedMetric: &parser.Metrics{
+				Iface:      constants.Master,
+				Offset:     -1,
+				MaxOffset:  -1,
+				FreqAdj:    1,
+				Delay:      18481,
+				ClockState: constants.ClockStateLocked,
+				ServoState: "s2",
+				Source:     constants.Master,
+			},
+		},
+		{
+			name:       "s0 regular metrics report raw servo state s0 while clock state collapses to FREERUN",
+			configName: "ptp4l.0.config",
+			logLine:    "ptp4l[365195.391]: [ptp4l.0.config] master offset -1 s0 freq -3972 path delay 89",
+			expectedMetric: &parser.Metrics{
+				Iface:      constants.Master,
+				Offset:     -1,
+				MaxOffset:  -1,
+				FreqAdj:    -3972,
+				Delay:      89,
+				ClockState: constants.ClockStateFreeRun,
+				ServoState: "s0",
 				Source:     constants.Master,
 			},
 		},
@@ -85,6 +118,7 @@ func TestPTP4LParser(t *testing.T) {
 				assert.Equal(t, tt.expectedMetric.FreqAdj, metric.FreqAdj)
 				assert.Equal(t, tt.expectedMetric.Delay, metric.Delay)
 				assert.Equal(t, tt.expectedMetric.ClockState, metric.ClockState)
+				assert.Equal(t, tt.expectedMetric.ServoState, metric.ServoState)
 				assert.Equal(t, tt.expectedMetric.Source, metric.Source)
 			}
 		})

--- a/pkg/parser/ptp4l_parser_test.go
+++ b/pkg/parser/ptp4l_parser_test.go
@@ -8,6 +8,10 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// testIfaceName is the interface name used across the "with interface name"
+// PTPEvent test cases below (locked/left-SLAVE/cold-start/benign-diagnostic).
+const testIfaceName = "ens4f0"
+
 func TestPTP4LParser(t *testing.T) {
 	tests := []struct {
 		name           string
@@ -99,10 +103,11 @@ func TestPTP4LEventParser(t *testing.T) {
 			configName: "ptp4l.0.config",
 			logLine:    "ptp4l[4268779.809]: [ptp4l.0.config] port 1: UNCALIBRATED to SLAVE on MASTER",
 			expectedEvent: &parser.PTPEvent{
-				PortID:     1,
-				Role:       constants.PortRoleSlave,
-				ClockState: constants.ClockStateFreeRun,
-				Raw:        "ptp4l[4268779.809]: [ptp4l.0.config] port 1: UNCALIBRATED to SLAVE on MASTER",
+				PortID:       1,
+				Role:         constants.PortRoleSlave,
+				PreviousRole: constants.PortRoleUnknown,
+				ClockState:   constants.ClockStateFreeRun,
+				Raw:          "ptp4l[4268779.809]: [ptp4l.0.config] port 1: UNCALIBRATED to SLAVE on MASTER",
 			},
 		},
 		{
@@ -110,10 +115,71 @@ func TestPTP4LEventParser(t *testing.T) {
 			configName: "ptp4l.0.config",
 			logLine:    "ptp4l[412707.219]: [ptp4l.0.config:5] port 11 (ens8f2): LISTENING to MASTER on ANNOUNCE_RECEIPT_TIMEOUT_EXPIRES",
 			expectedEvent: &parser.PTPEvent{
-				PortID:     11,
-				Role:       constants.PortRoleMaster,
-				ClockState: constants.ClockStateFreeRun,
-				Raw:        "ptp4l[412707.219]: [ptp4l.0.config:5] port 11 (ens8f2): LISTENING to MASTER on ANNOUNCE_RECEIPT_TIMEOUT_EXPIRES",
+				PortID:       11,
+				Iface:        "ens8f2",
+				Role:         constants.PortRoleMaster,
+				PreviousRole: constants.PortRoleListening,
+				ClockState:   constants.ClockStateFreeRun,
+				Raw:          "ptp4l[412707.219]: [ptp4l.0.config:5] port 11 (ens8f2): LISTENING to MASTER on ANNOUNCE_RECEIPT_TIMEOUT_EXPIRES",
+			},
+		},
+		{
+			name:       "Port that just locked to SLAVE, with interface name",
+			configName: "ptp4l.0.config",
+			logLine:    "ptp4l[412708.219]: [ptp4l.0.config:5] port 1 (" + testIfaceName + "): UNCALIBRATED to SLAVE on MASTER_CLOCK_SELECTED",
+			expectedEvent: &parser.PTPEvent{
+				PortID: 1,
+				Iface:  testIfaceName,
+				Role:   constants.PortRoleSlave,
+				// UNCALIBRATED has no PortRole equivalent, so PreviousRole
+				// is Unknown here -- this is the expected/documented case,
+				// not a bug: consumers only care about PreviousRole ==
+				// PortRoleSlave (departing SLAVE), not the general case.
+				PreviousRole: constants.PortRoleUnknown,
+				ClockState:   constants.ClockStateFreeRun,
+				Raw:          "ptp4l[412708.219]: [ptp4l.0.config:5] port 1 (" + testIfaceName + "): UNCALIBRATED to SLAVE on MASTER_CLOCK_SELECTED",
+			},
+		},
+		{
+			name:       "Port that just left SLAVE, with interface name",
+			configName: "ptp4l.0.config",
+			logLine:    "ptp4l[412709.219]: [ptp4l.0.config:5] port 1 (" + testIfaceName + "): SLAVE to MASTER on ANNOUNCE_RECEIPT_TIMEOUT_EXPIRES",
+			expectedEvent: &parser.PTPEvent{
+				PortID:       1,
+				Iface:        testIfaceName,
+				Role:         constants.PortRoleMaster,
+				PreviousRole: constants.PortRoleSlave,
+				ClockState:   constants.ClockStateHoldover,
+				Raw:          "ptp4l[412709.219]: [ptp4l.0.config:5] port 1 (" + testIfaceName + "): SLAVE to MASTER on ANNOUNCE_RECEIPT_TIMEOUT_EXPIRES",
+			},
+		},
+		{
+			name:       "Cold-start BMCA self-election, with interface name",
+			configName: "ptp4l.0.config",
+			logLine:    "ptp4l[412710.219]: [ptp4l.0.config:5] port 1 (" + testIfaceName + "): UNCALIBRATED to MASTER on RS_MASTER",
+			expectedEvent: &parser.PTPEvent{
+				PortID:       1,
+				Iface:        testIfaceName,
+				Role:         constants.PortRoleMaster,
+				PreviousRole: constants.PortRoleUnknown,
+				ClockState:   constants.ClockStateFreeRun,
+				Raw:          "ptp4l[412710.219]: [ptp4l.0.config:5] port 1 (" + testIfaceName + "): UNCALIBRATED to MASTER on RS_MASTER",
+			},
+		},
+		{
+			name:       "Benign diagnostic line, with interface name",
+			configName: "ptp4l.0.config",
+			logLine:    "ptp4l[412711.219]: [ptp4l.0.config:5] port 1 (" + testIfaceName + "): delay timeout",
+			expectedEvent: &parser.PTPEvent{
+				// PortID is zeroed for unrecognized/PortRoleUnknown events,
+				// but Iface is still populated -- callers must not assume
+				// PortID == 0 implies Iface == "" too.
+				PortID:       0,
+				Iface:        testIfaceName,
+				Role:         constants.PortRoleUnknown,
+				PreviousRole: constants.PortRoleUnknown,
+				ClockState:   constants.ClockStateFreeRun,
+				Raw:          "ptp4l[412711.219]: [ptp4l.0.config:5] port 1 (" + testIfaceName + "): delay timeout",
 			},
 		},
 		{
@@ -121,10 +187,11 @@ func TestPTP4LEventParser(t *testing.T) {
 			configName: "ptp4l.0.config",
 			logLine:    "ptp4l[4268779.809]: [ptp4l.0.config] port 1: UNCALIBRATED to PASSIVE on RS_PASSIVE",
 			expectedEvent: &parser.PTPEvent{
-				PortID:     1,
-				Role:       constants.PortRolePassive,
-				ClockState: constants.ClockStateFreeRun,
-				Raw:        "ptp4l[4268779.809]: [ptp4l.0.config] port 1: UNCALIBRATED to PASSIVE on RS_PASSIVE",
+				PortID:       1,
+				Role:         constants.PortRolePassive,
+				PreviousRole: constants.PortRoleUnknown,
+				ClockState:   constants.ClockStateFreeRun,
+				Raw:          "ptp4l[4268779.809]: [ptp4l.0.config] port 1: UNCALIBRATED to PASSIVE on RS_PASSIVE",
 			},
 		},
 		{
@@ -132,10 +199,11 @@ func TestPTP4LEventParser(t *testing.T) {
 			configName: "ptp4l.0.config",
 			logLine:    "ptp4l[4268779.809]: [ptp4l.0.config] port 1: UNCALIBRATED to MASTER on RS_MASTER",
 			expectedEvent: &parser.PTPEvent{
-				PortID:     1,
-				Role:       constants.PortRoleMaster,
-				ClockState: constants.ClockStateFreeRun,
-				Raw:        "ptp4l[4268779.809]: [ptp4l.0.config] port 1: UNCALIBRATED to MASTER on RS_MASTER",
+				PortID:       1,
+				Role:         constants.PortRoleMaster,
+				PreviousRole: constants.PortRoleUnknown,
+				ClockState:   constants.ClockStateFreeRun,
+				Raw:          "ptp4l[4268779.809]: [ptp4l.0.config] port 1: UNCALIBRATED to MASTER on RS_MASTER",
 			},
 		},
 		{
@@ -143,10 +211,11 @@ func TestPTP4LEventParser(t *testing.T) {
 			configName: "ptp4l.0.config",
 			logLine:    "ptp4l[4268779.809]: [ptp4l.0.config] port 1: FAULT_DETECTED",
 			expectedEvent: &parser.PTPEvent{
-				PortID:     1,
-				Role:       constants.PortRoleFaulty,
-				ClockState: constants.ClockStateHoldover,
-				Raw:        "ptp4l[4268779.809]: [ptp4l.0.config] port 1: FAULT_DETECTED",
+				PortID:       1,
+				Role:         constants.PortRoleFaulty,
+				PreviousRole: constants.PortRoleUnknown,
+				ClockState:   constants.ClockStateHoldover,
+				Raw:          "ptp4l[4268779.809]: [ptp4l.0.config] port 1: FAULT_DETECTED",
 			},
 		},
 		{
@@ -154,10 +223,11 @@ func TestPTP4LEventParser(t *testing.T) {
 			configName: "ptp4l.0.config",
 			logLine:    "ptp4l[4268779.809]: [ptp4l.0.config] port 1: UNCALIBRATED to LISTENING on RS_LISTENING",
 			expectedEvent: &parser.PTPEvent{
-				PortID:     1,
-				Role:       constants.PortRoleListening,
-				ClockState: constants.ClockStateFreeRun,
-				Raw:        "ptp4l[4268779.809]: [ptp4l.0.config] port 1: UNCALIBRATED to LISTENING on RS_LISTENING",
+				PortID:       1,
+				Role:         constants.PortRoleListening,
+				PreviousRole: constants.PortRoleUnknown,
+				ClockState:   constants.ClockStateFreeRun,
+				Raw:          "ptp4l[4268779.809]: [ptp4l.0.config] port 1: UNCALIBRATED to LISTENING on RS_LISTENING",
 			},
 		},
 		{
@@ -165,10 +235,11 @@ func TestPTP4LEventParser(t *testing.T) {
 			configName: "ptp4l.0.config",
 			logLine:    "ptp4l[5000.000]: [ptp4l.0.config] port 2: SLAVE to PASSIVE on RS_PASSIVE",
 			expectedEvent: &parser.PTPEvent{
-				PortID:     2,
-				Role:       constants.PortRolePassive,
-				ClockState: constants.ClockStateFreeRun,
-				Raw:        "ptp4l[5000.000]: [ptp4l.0.config] port 2: SLAVE to PASSIVE on RS_PASSIVE",
+				PortID:       2,
+				Role:         constants.PortRolePassive,
+				PreviousRole: constants.PortRoleSlave,
+				ClockState:   constants.ClockStateFreeRun,
+				Raw:          "ptp4l[5000.000]: [ptp4l.0.config] port 2: SLAVE to PASSIVE on RS_PASSIVE",
 			},
 		},
 		{
@@ -176,10 +247,11 @@ func TestPTP4LEventParser(t *testing.T) {
 			configName: "ptp4l.0.config",
 			logLine:    "ptp4l[5001.000]: [ptp4l.0.config] port 1: MASTER to PASSIVE on RS_PASSIVE",
 			expectedEvent: &parser.PTPEvent{
-				PortID:     1,
-				Role:       constants.PortRolePassive,
-				ClockState: constants.ClockStateFreeRun,
-				Raw:        "ptp4l[5001.000]: [ptp4l.0.config] port 1: MASTER to PASSIVE on RS_PASSIVE",
+				PortID:       1,
+				Role:         constants.PortRolePassive,
+				PreviousRole: constants.PortRoleMaster,
+				ClockState:   constants.ClockStateFreeRun,
+				Raw:          "ptp4l[5001.000]: [ptp4l.0.config] port 1: MASTER to PASSIVE on RS_PASSIVE",
 			},
 		},
 		{
@@ -187,10 +259,11 @@ func TestPTP4LEventParser(t *testing.T) {
 			configName: "ptp4l.0.config",
 			logLine:    "ptp4l[5002.000]: [ptp4l.0.config] port 1: LISTENING to PASSIVE on RS_PASSIVE",
 			expectedEvent: &parser.PTPEvent{
-				PortID:     1,
-				Role:       constants.PortRolePassive,
-				ClockState: constants.ClockStateFreeRun,
-				Raw:        "ptp4l[5002.000]: [ptp4l.0.config] port 1: LISTENING to PASSIVE on RS_PASSIVE",
+				PortID:       1,
+				Role:         constants.PortRolePassive,
+				PreviousRole: constants.PortRoleListening,
+				ClockState:   constants.ClockStateFreeRun,
+				Raw:          "ptp4l[5002.000]: [ptp4l.0.config] port 1: LISTENING to PASSIVE on RS_PASSIVE",
 			},
 		},
 		{
@@ -198,10 +271,11 @@ func TestPTP4LEventParser(t *testing.T) {
 			configName: "ptp4l.0.config",
 			logLine:    "ptp4l[5003.000]: [ptp4l.0.config] port 1: SYNCHRONIZATION_FAULT",
 			expectedEvent: &parser.PTPEvent{
-				PortID:     1,
-				Role:       constants.PortRoleFaulty,
-				ClockState: constants.ClockStateHoldover,
-				Raw:        "ptp4l[5003.000]: [ptp4l.0.config] port 1: SYNCHRONIZATION_FAULT",
+				PortID:       1,
+				Role:         constants.PortRoleFaulty,
+				PreviousRole: constants.PortRoleUnknown,
+				ClockState:   constants.ClockStateHoldover,
+				Raw:          "ptp4l[5003.000]: [ptp4l.0.config] port 1: SYNCHRONIZATION_FAULT",
 			},
 		},
 		{
@@ -209,10 +283,11 @@ func TestPTP4LEventParser(t *testing.T) {
 			configName: "ptp4l.0.config",
 			logLine:    "ptp4l[5004.000]: [ptp4l.0.config] port 1: SLAVE to UNCALIBRATED",
 			expectedEvent: &parser.PTPEvent{
-				PortID:     1,
-				Role:       constants.PortRoleFaulty,
-				ClockState: constants.ClockStateHoldover,
-				Raw:        "ptp4l[5004.000]: [ptp4l.0.config] port 1: SLAVE to UNCALIBRATED",
+				PortID:       1,
+				Role:         constants.PortRoleFaulty,
+				PreviousRole: constants.PortRoleSlave,
+				ClockState:   constants.ClockStateHoldover,
+				Raw:          "ptp4l[5004.000]: [ptp4l.0.config] port 1: SLAVE to UNCALIBRATED",
 			},
 		},
 		{
@@ -220,10 +295,11 @@ func TestPTP4LEventParser(t *testing.T) {
 			configName: "ptp4l.0.config",
 			logLine:    "ptp4l[5005.000]: [ptp4l.0.config] port 1: MASTER to UNCALIBRATED on RS_SLAVE",
 			expectedEvent: &parser.PTPEvent{
-				PortID:     1,
-				Role:       constants.PortRoleFaulty,
-				ClockState: constants.ClockStateHoldover,
-				Raw:        "ptp4l[5005.000]: [ptp4l.0.config] port 1: MASTER to UNCALIBRATED on RS_SLAVE",
+				PortID:       1,
+				Role:         constants.PortRoleFaulty,
+				PreviousRole: constants.PortRoleMaster,
+				ClockState:   constants.ClockStateHoldover,
+				Raw:          "ptp4l[5005.000]: [ptp4l.0.config] port 1: MASTER to UNCALIBRATED on RS_SLAVE",
 			},
 		},
 		{
@@ -231,10 +307,11 @@ func TestPTP4LEventParser(t *testing.T) {
 			configName: "ptp4l.0.config",
 			logLine:    "ptp4l[5006.000]: [ptp4l.0.config] port 1: LISTENING to UNCALIBRATED on RS_SLAVE",
 			expectedEvent: &parser.PTPEvent{
-				PortID:     1,
-				Role:       constants.PortRoleFaulty,
-				ClockState: constants.ClockStateHoldover,
-				Raw:        "ptp4l[5006.000]: [ptp4l.0.config] port 1: LISTENING to UNCALIBRATED on RS_SLAVE",
+				PortID:       1,
+				Role:         constants.PortRoleFaulty,
+				PreviousRole: constants.PortRoleListening,
+				ClockState:   constants.ClockStateHoldover,
+				Raw:          "ptp4l[5006.000]: [ptp4l.0.config] port 1: LISTENING to UNCALIBRATED on RS_SLAVE",
 			},
 		},
 		{
@@ -242,10 +319,11 @@ func TestPTP4LEventParser(t *testing.T) {
 			configName: "ptp4l.0.config",
 			logLine:    "ptp4l[5007.000]: [ptp4l.0.config] port 1: SLAVE to MASTER",
 			expectedEvent: &parser.PTPEvent{
-				PortID:     1,
-				Role:       constants.PortRoleMaster,
-				ClockState: constants.ClockStateHoldover,
-				Raw:        "ptp4l[5007.000]: [ptp4l.0.config] port 1: SLAVE to MASTER",
+				PortID:       1,
+				Role:         constants.PortRoleMaster,
+				PreviousRole: constants.PortRoleSlave,
+				ClockState:   constants.ClockStateHoldover,
+				Raw:          "ptp4l[5007.000]: [ptp4l.0.config] port 1: SLAVE to MASTER",
 			},
 		},
 		{
@@ -253,10 +331,11 @@ func TestPTP4LEventParser(t *testing.T) {
 			configName: "ptp4l.0.config",
 			logLine:    "ptp4l[5008.000]: [ptp4l.0.config] port 1: SLAVE to GRAND_MASTER",
 			expectedEvent: &parser.PTPEvent{
-				PortID:     1,
-				Role:       constants.PortRoleMaster,
-				ClockState: constants.ClockStateHoldover,
-				Raw:        "ptp4l[5008.000]: [ptp4l.0.config] port 1: SLAVE to GRAND_MASTER",
+				PortID:       1,
+				Role:         constants.PortRoleMaster,
+				PreviousRole: constants.PortRoleSlave,
+				ClockState:   constants.ClockStateHoldover,
+				Raw:          "ptp4l[5008.000]: [ptp4l.0.config] port 1: SLAVE to GRAND_MASTER",
 			},
 		},
 		{
@@ -264,10 +343,11 @@ func TestPTP4LEventParser(t *testing.T) {
 			configName: "ptp4l.0.config",
 			logLine:    "ptp4l[5009.000]: [ptp4l.0.config] port 1: SLAVE to LISTENING",
 			expectedEvent: &parser.PTPEvent{
-				PortID:     1,
-				Role:       constants.PortRoleListening,
-				ClockState: constants.ClockStateHoldover,
-				Raw:        "ptp4l[5009.000]: [ptp4l.0.config] port 1: SLAVE to LISTENING",
+				PortID:       1,
+				Role:         constants.PortRoleListening,
+				PreviousRole: constants.PortRoleSlave,
+				ClockState:   constants.ClockStateHoldover,
+				Raw:          "ptp4l[5009.000]: [ptp4l.0.config] port 1: SLAVE to LISTENING",
 			},
 		},
 		{
@@ -275,10 +355,11 @@ func TestPTP4LEventParser(t *testing.T) {
 			configName: "ptp4l.0.config",
 			logLine:    "ptp4l[5010.000]: [ptp4l.0.config] port 1: FAULTY to LISTENING",
 			expectedEvent: &parser.PTPEvent{
-				PortID:     1,
-				Role:       constants.PortRoleListening,
-				ClockState: constants.ClockStateFreeRun,
-				Raw:        "ptp4l[5010.000]: [ptp4l.0.config] port 1: FAULTY to LISTENING",
+				PortID:       1,
+				Role:         constants.PortRoleListening,
+				PreviousRole: constants.PortRoleUnknown,
+				ClockState:   constants.ClockStateFreeRun,
+				Raw:          "ptp4l[5010.000]: [ptp4l.0.config] port 1: FAULTY to LISTENING",
 			},
 		},
 		{
@@ -286,10 +367,11 @@ func TestPTP4LEventParser(t *testing.T) {
 			configName: "ptp4l.0.config",
 			logLine:    "ptp4l[5011.000]: [ptp4l.0.config] port 1: INITIALIZING to LISTENING",
 			expectedEvent: &parser.PTPEvent{
-				PortID:     1,
-				Role:       constants.PortRoleListening,
-				ClockState: constants.ClockStateFreeRun,
-				Raw:        "ptp4l[5011.000]: [ptp4l.0.config] port 1: INITIALIZING to LISTENING",
+				PortID:       1,
+				Role:         constants.PortRoleListening,
+				PreviousRole: constants.PortRoleUnknown,
+				ClockState:   constants.ClockStateFreeRun,
+				Raw:          "ptp4l[5011.000]: [ptp4l.0.config] port 1: INITIALIZING to LISTENING",
 			},
 		},
 		{
@@ -297,10 +379,11 @@ func TestPTP4LEventParser(t *testing.T) {
 			configName: "ptp4l.0.config",
 			logLine:    "ptp4l[4268779.809]: [ptp4l.0.config] port 1: INVALID_STATE",
 			expectedEvent: &parser.PTPEvent{
-				PortID:     0,
-				Role:       constants.PortRoleUnknown,
-				ClockState: constants.ClockStateFreeRun,
-				Raw:        "ptp4l[4268779.809]: [ptp4l.0.config] port 1: INVALID_STATE",
+				PortID:       0,
+				Role:         constants.PortRoleUnknown,
+				PreviousRole: constants.PortRoleUnknown,
+				ClockState:   constants.ClockStateFreeRun,
+				Raw:          "ptp4l[4268779.809]: [ptp4l.0.config] port 1: INVALID_STATE",
 			},
 		},
 	}
@@ -319,7 +402,10 @@ func TestPTP4LEventParser(t *testing.T) {
 			if tt.expectedEvent != nil {
 				assert.NotNil(t, event)
 				assert.Equal(t, tt.expectedEvent.PortID, event.PortID)
+				assert.Equal(t, tt.expectedEvent.Iface, event.Iface)
 				assert.Equal(t, tt.expectedEvent.Role, event.Role)
+				assert.Equal(t, tt.expectedEvent.PreviousRole, event.PreviousRole)
+				assert.Equal(t, tt.expectedEvent.ClockState, event.ClockState)
 				assert.Equal(t, tt.expectedEvent.Raw, event.Raw)
 			}
 		})

--- a/pkg/parser/ts2phc_parser.go
+++ b/pkg/parser/ts2phc_parser.go
@@ -171,6 +171,7 @@ func extractTS2PHCOffset(parsed *ts2phcParsed) (*Metrics, error) {
 		Offset:     *parsed.Offset,
 		MaxOffset:  *parsed.Offset,
 		ClockState: clockState,
+		ServoState: parsed.ServoState,
 		FreqAdj:    *parsed.FreqAdj,
 		Source:     constants.Master,
 	}, nil
@@ -202,6 +203,7 @@ func extractTS2PHCnmeaStatus(parsed *ts2phcParsed) (*Metrics, error) {
 		Offset:     *parsed.Offset,
 		MaxOffset:  *parsed.Offset,
 		ClockState: clockState,
+		ServoState: parsed.ServoState,
 		Source:     constants.NmeaStatus,
 		Status:     statusMetrics,
 	}, nil

--- a/pkg/parser/ts2phc_parser_test.go
+++ b/pkg/parser/ts2phc_parser_test.go
@@ -24,6 +24,7 @@ func TestTS2PHCParser(t *testing.T) {
 				MaxOffset:  2345,
 				FreqAdj:    -16642,
 				ClockState: constants.ClockStateLocked,
+				ServoState: "s2",
 				Source:     constants.Master,
 			},
 		},
@@ -36,6 +37,7 @@ func TestTS2PHCParser(t *testing.T) {
 				MaxOffset:  3152778,
 				FreqAdj:    -6083928,
 				ClockState: constants.ClockStateLocked,
+				ServoState: "s2",
 				Source:     constants.Master,
 			},
 		},
@@ -48,6 +50,7 @@ func TestTS2PHCParser(t *testing.T) {
 				MaxOffset:  -1,
 				FreqAdj:    -3972,
 				ClockState: constants.ClockStateHoldover,
+				ServoState: "s2",
 				Source:     constants.Master,
 			},
 		},
@@ -59,6 +62,7 @@ func TestTS2PHCParser(t *testing.T) {
 				Offset:     0,
 				MaxOffset:  0,
 				ClockState: constants.ClockStateLocked,
+				ServoState: "s2",
 				Source:     constants.NmeaStatus,
 				Status: []parser.StatusMetric{
 					{Subtype: "nmea_status", Status: 1.0},
@@ -73,6 +77,7 @@ func TestTS2PHCParser(t *testing.T) {
 				Offset:     999999,
 				MaxOffset:  999999,
 				ClockState: constants.ClockStateFreeRun,
+				ServoState: "s0",
 				Source:     constants.NmeaStatus,
 				Status: []parser.StatusMetric{
 					{Subtype: "nmea_status", Status: 0.0},
@@ -88,6 +93,7 @@ func TestTS2PHCParser(t *testing.T) {
 				MaxOffset:  3,
 				FreqAdj:    4,
 				ClockState: constants.ClockStateFreeRun,
+				ServoState: "s0",
 				Source:     constants.Master,
 			},
 		},
@@ -112,6 +118,7 @@ func TestTS2PHCParser(t *testing.T) {
 				assert.Equal(t, tt.expectedMetric.MaxOffset, metric.MaxOffset)
 				assert.Equal(t, tt.expectedMetric.FreqAdj, metric.FreqAdj)
 				assert.Equal(t, tt.expectedMetric.ClockState, metric.ClockState)
+				assert.Equal(t, tt.expectedMetric.ServoState, metric.ServoState)
 				assert.Equal(t, tt.expectedMetric.Source, metric.Source)
 				for _, expectedStatus := range tt.expectedMetric.Status {
 					found := false

--- a/pkg/pmc/pmc.go
+++ b/pkg/pmc/pmc.go
@@ -30,6 +30,7 @@ var (
 	pmcCmdConstPart              = "pmc -u -b 0 -f /var/run/"
 	grandmasterSettingsNPRegExp  = regexp.MustCompile((&protocol.GrandmasterSettings{}).RegEx())
 	parentDataSetRegExp          = regexp.MustCompile((&protocol.ParentDataSet{}).RegEx())
+	portDataSetRegExp            = regexp.MustCompile((&protocol.PortDataSet{}).RegEx())
 	externalGMPropertiesNPRegExp = regexp.MustCompile((&protocol.ExternalGrandmasterProperties{}).RegEx())
 	timePropertiesDSRegExp       = regexp.MustCompile((&protocol.TimePropertiesDS{}).RegEx())
 	currentDSRegExp              = regexp.MustCompile((&protocol.CurrentDS{}).RegEx())
@@ -490,12 +491,24 @@ func GetPMCMontior(configFileName string) (*expect.GExpect, <-chan error, error)
 }
 
 // GetMonitorRegex returns a regex pattern for monitoring PMC events based on configuration.
-func GetMonitorRegex(monitorParentData bool) *regexp.Regexp {
-	parts := make([]string, 0)
-	// TODO: Add other messages
+func GetMonitorRegex(monitorParentData, monitorPortState bool) *regexp.Regexp {
+	parts := make([]string, 0, 2)
 
 	if monitorParentData {
 		parts = append(parts, parentDataSetRegExp.String())
 	}
-	return regexp.MustCompile(`(?m).* seq \d+ RESPONSE MANAGEMENT .*\s*` + strings.Join(parts, `|`))
+	if monitorPortState {
+		parts = append(parts, portDataSetRegExp.String())
+	}
+	return regexp.MustCompile(`(?m).* seq \d+ RESPONSE MANAGEMENT .*\s*(?:` + strings.Join(parts, `|`) + `)`)
+}
+
+// PortDataSetRegExp returns the compiled regex for PORT_DATA_SET parsing.
+func PortDataSetRegExp() *regexp.Regexp {
+	return portDataSetRegExp
+}
+
+// ParentDataSetRegExp returns the compiled regex for PARENT_DATA_SET parsing.
+func ParentDataSetRegExp() *regexp.Regexp {
+	return parentDataSetRegExp
 }

--- a/pkg/pmc/pmc_test.go
+++ b/pkg/pmc/pmc_test.go
@@ -1,0 +1,100 @@
+package pmc
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	portDataSetResponse = "\tb4e9b8.fffe.5ec71a-0 seq 1 RESPONSE MANAGEMENT PORT_DATA_SET \n" +
+		"\t\tportIdentity            b4e9b8.fffe.5ec71a-1\n" +
+		"\t\tportState               SLAVE\n" +
+		"\t\tlogMinDelayReqInterval  0\n" +
+		"\t\tpeerMeanPathDelay       0\n" +
+		"\t\tlogAnnounceInterval     1\n" +
+		"\t\tannounceReceiptTimeout  3\n" +
+		"\t\tlogSyncInterval         0\n" +
+		"\t\tdelayMechanism          1\n" +
+		"\t\tlogMinPdelayReqInterval 0\n" +
+		"\t\tversionNumber           2\n"
+
+	parentDataSetResponse = "\tb4e9b8.fffe.5ec71a-0 seq 0 RESPONSE MANAGEMENT PARENT_DATA_SET \n" +
+		"\t\tparentPortIdentity                    b4e9b8.fffe.5ec71a-0\n" +
+		"\t\tparentStats                           0\n" +
+		"\t\tobservedParentOffsetScaledLogVariance 0xffff\n" +
+		"\t\tobservedParentClockPhaseChangeRate    0x7fffffff\n" +
+		"\t\tgrandmasterPriority1                  128\n" +
+		"\t\tgm.ClockClass                         6\n" +
+		"\t\tgm.ClockAccuracy                      0x21\n" +
+		"\t\tgm.OffsetScaledLogVariance            0x4e5d\n" +
+		"\t\tgrandmasterPriority2                  128\n" +
+		"\t\tgrandmasterIdentity                   507c6f.fffe.1fb16c\n"
+)
+
+func TestGetMonitorRegex_ParentOnly(t *testing.T) {
+	re := GetMonitorRegex(true, false)
+
+	assert.NotNil(t, re.FindStringSubmatch(parentDataSetResponse),
+		"should match PARENT_DATA_SET response")
+	assert.Nil(t, re.FindStringSubmatch(portDataSetResponse),
+		"should NOT match PORT_DATA_SET when monitorPortState=false")
+}
+
+func TestGetMonitorRegex_PortOnly(t *testing.T) {
+	re := GetMonitorRegex(false, true)
+
+	assert.NotNil(t, re.FindStringSubmatch(portDataSetResponse),
+		"should match PORT_DATA_SET response")
+	assert.Nil(t, re.FindStringSubmatch(parentDataSetResponse),
+		"should NOT match PARENT_DATA_SET when monitorParentData=false")
+}
+
+func TestGetMonitorRegex_Both(t *testing.T) {
+	re := GetMonitorRegex(true, true)
+
+	assert.NotNil(t, re.FindStringSubmatch(parentDataSetResponse),
+		"should match PARENT_DATA_SET when both are enabled")
+	assert.NotNil(t, re.FindStringSubmatch(portDataSetResponse),
+		"should match PORT_DATA_SET when both are enabled")
+}
+
+func TestGetMonitorRegex_AlternationBug_RequiresResponsePrefix(t *testing.T) {
+	re := GetMonitorRegex(true, true)
+
+	noPrefixPort := "\t\tportIdentity            b4e9b8.fffe.5ec71a-1\n" +
+		"\t\tportState               SLAVE\n" +
+		"\t\tlogMinDelayReqInterval  0\n" +
+		"\t\tpeerMeanPathDelay       0\n" +
+		"\t\tlogAnnounceInterval     1\n" +
+		"\t\tannounceReceiptTimeout  3\n" +
+		"\t\tlogSyncInterval         0\n" +
+		"\t\tdelayMechanism          1\n" +
+		"\t\tlogMinPdelayReqInterval 0\n" +
+		"\t\tversionNumber           2\n"
+
+	assert.Nil(t, re.FindStringSubmatch(noPrefixPort),
+		"PORT_DATA_SET body without RESPONSE MANAGEMENT prefix must NOT match")
+}
+
+func TestGetMonitorRegex_DoesNotMatchPortDataSetNP(t *testing.T) {
+	re := GetMonitorRegex(false, true)
+
+	portDataSetNPResponse := "\tb4e9b8.fffe.5ec71a-0 seq 1 RESPONSE MANAGEMENT PORT_DATA_SET_NP \n" +
+		"\t\tneighborPropDelayThresh 0\n" +
+		"\t\tasCapable               1\n"
+
+	assert.Nil(t, re.FindStringSubmatch(portDataSetNPResponse),
+		"PORT_DATA_SET_NP must NOT match the PORT_DATA_SET regex")
+}
+
+func TestPortDataSetRegExp_MatchesRealResponse(t *testing.T) {
+	re := PortDataSetRegExp()
+	require.NotNil(t, re)
+
+	matches := re.FindStringSubmatch(portDataSetResponse)
+	require.NotNil(t, matches)
+	assert.Equal(t, "b4e9b8.fffe.5ec71a-1", matches[1])
+	assert.Equal(t, "SLAVE", matches[2])
+}

--- a/pkg/protocol/type.go
+++ b/pkg/protocol/type.go
@@ -29,6 +29,10 @@ const (
 // 507c6f.fffe.1fb16c).
 const clockIdentityPattern = `[0-9a-fA-F]+\.[0-9a-fA-F]+\.[0-9a-fA-F]+`
 
+// signedIntRegEx matches an optionally negative base-10 integer, shared by the
+// several DataSet ValueRegEx maps whose fields may report negative values.
+const signedIntRegEx = `-?\d+`
+
 // DataSet is an interface for PTP data sets that can be parsed from PMC output.
 type DataSet interface {
 	Keys() []string
@@ -248,6 +252,25 @@ func stoi32(s string) int32 {
 		fmt.Printf("%v\n", err)
 	}
 	return int32(int64Value)
+}
+
+// stoi8 parses s as a base-10 integer bounded to the int8 range. Unlike
+// int8(stoi32(s)), it relies on strconv.ParseInt's own bitSize=8 clamping
+// instead of silently wrapping out-of-range int32 values when narrowed.
+func stoi8(s string) int8 {
+	int64Value, err := strconv.ParseInt(s, 10, 8)
+	if err != nil {
+		fmt.Printf("%v\n", err)
+	}
+	return int8(int64Value)
+}
+
+func stoi64(s string) int64 {
+	int64Value, err := strconv.ParseInt(s, 10, 64)
+	if err != nil {
+		fmt.Printf("%v\n", err)
+	}
+	return int64Value
 }
 
 func stof64(s string) float64 {
@@ -533,6 +556,140 @@ func (tp *TimePropertiesDS) String() string {
 	return result
 }
 
+// PortDataSet defines IEEE 1588 PORT_DATA_SET, pushed by ptp4l's NOTIFY_PORT_STATE subscription.
+type PortDataSet struct {
+	PortIdentity            string
+	PortState               string // ps_str value: SLAVE, MASTER, LISTENING, FAULTY, etc.
+	LogMinDelayReqInterval  int8
+	PeerMeanPathDelay       int64
+	LogAnnounceInterval     int8
+	AnnounceReceiptTimeout  uint8
+	LogSyncInterval         int8
+	DelayMechanism          uint8
+	LogMinPdelayReqInterval int8
+	VersionNumber           uint8
+}
+
+// Keys provides the keys method for the PortDataSet values
+func (p *PortDataSet) Keys() []string {
+	return []string{
+		"portIdentity",
+		"portState",
+		"logMinDelayReqInterval",
+		"peerMeanPathDelay",
+		"logAnnounceInterval",
+		"announceReceiptTimeout",
+		"logSyncInterval",
+		"delayMechanism",
+		"logMinPdelayReqInterval",
+		"versionNumber",
+	}
+}
+
+// ValueRegEx provides the regex method for the PortDataSet values matching
+func (p *PortDataSet) ValueRegEx() map[string]string {
+	return map[string]string{
+		"portIdentity":            `.*`,
+		"portState":               `[A-Z_]+`,
+		"logMinDelayReqInterval":  signedIntRegEx,
+		"peerMeanPathDelay":       signedIntRegEx,
+		"logAnnounceInterval":     signedIntRegEx,
+		"announceReceiptTimeout":  `\d+`,
+		"logSyncInterval":         signedIntRegEx,
+		"delayMechanism":          `\d+`,
+		"logMinPdelayReqInterval": signedIntRegEx,
+		"versionNumber":           `\d+`,
+	}
+}
+
+// RegEx generates the PortDataSet command regex
+func (p *PortDataSet) RegEx() string {
+	return buildDataSetRegex(p.Keys(), p.ValueRegEx(), true, []string{})
+}
+
+// MonitorRegEx generates the PortDataSet regex without capture groups.
+func (p *PortDataSet) MonitorRegEx() string {
+	return buildDataSetRegex(p.Keys(), p.ValueRegEx(), false, []string{})
+}
+
+// Update provides the Update method for the PortDataSet values
+func (p *PortDataSet) Update(key string, value string) {
+	switch key {
+	case "portIdentity":
+		p.PortIdentity = value
+	case "portState":
+		p.PortState = value
+	case "logMinDelayReqInterval":
+		p.LogMinDelayReqInterval = stoi8(value)
+	case "peerMeanPathDelay":
+		p.PeerMeanPathDelay = stoi64(value)
+	case "logAnnounceInterval":
+		p.LogAnnounceInterval = stoi8(value)
+	case "announceReceiptTimeout":
+		p.AnnounceReceiptTimeout = stou8(value)
+	case "logSyncInterval":
+		p.LogSyncInterval = stoi8(value)
+	case "delayMechanism":
+		p.DelayMechanism = stou8(value)
+	case "logMinPdelayReqInterval":
+		p.LogMinPdelayReqInterval = stoi8(value)
+	case "versionNumber":
+		p.VersionNumber = stou8(value)
+	}
+}
+
+func (p *PortDataSet) String() string {
+	if p == nil {
+		glog.Error("returned empty PortDataSet")
+		return ""
+	}
+	result := fmt.Sprintf("portIdentity            %s\n", p.PortIdentity)
+	result += fmt.Sprintf("portState               %s\n", p.PortState)
+	result += fmt.Sprintf("logMinDelayReqInterval  %d\n", p.LogMinDelayReqInterval)
+	result += fmt.Sprintf("peerMeanPathDelay       %d\n", p.PeerMeanPathDelay)
+	result += fmt.Sprintf("logAnnounceInterval     %d\n", p.LogAnnounceInterval)
+	result += fmt.Sprintf("announceReceiptTimeout  %d\n", p.AnnounceReceiptTimeout)
+	result += fmt.Sprintf("logSyncInterval         %d\n", p.LogSyncInterval)
+	result += fmt.Sprintf("delayMechanism          %d\n", p.DelayMechanism)
+	result += fmt.Sprintf("logMinPdelayReqInterval %d\n", p.LogMinPdelayReqInterval)
+	result += fmt.Sprintf("versionNumber           %d\n", p.VersionNumber)
+	return result
+}
+
+// Equal compares two PortDataSet instances for equality.
+func (p *PortDataSet) Equal(other *PortDataSet) bool {
+	if p == nil && other == nil {
+		return true
+	}
+	if p == nil || other == nil {
+		return false
+	}
+	return p.PortIdentity == other.PortIdentity &&
+		p.PortState == other.PortState &&
+		p.LogMinDelayReqInterval == other.LogMinDelayReqInterval &&
+		p.PeerMeanPathDelay == other.PeerMeanPathDelay &&
+		p.LogAnnounceInterval == other.LogAnnounceInterval &&
+		p.AnnounceReceiptTimeout == other.AnnounceReceiptTimeout &&
+		p.LogSyncInterval == other.LogSyncInterval &&
+		p.DelayMechanism == other.DelayMechanism &&
+		p.LogMinPdelayReqInterval == other.LogMinPdelayReqInterval &&
+		p.VersionNumber == other.VersionNumber
+}
+
+// PortNumber extracts the port number from the trailing "-N" of PortIdentity
+// (e.g. "b4e9b8.fffe.5ec71a-3" -> 3).
+func (p *PortDataSet) PortNumber() (int, error) {
+	idx := strings.LastIndex(p.PortIdentity, "-")
+	if idx < 0 || idx == len(p.PortIdentity)-1 {
+		return 0, fmt.Errorf("no port number suffix in portIdentity %q", p.PortIdentity)
+	}
+	n, err := strconv.Atoi(p.PortIdentity[idx+1:])
+	if err != nil {
+		return 0, fmt.Errorf("invalid port number in portIdentity %q: %w", p.PortIdentity, err)
+	}
+	return n, nil
+}
+
 // SubscribedEvents represents the subscription events configuration for PTP notifications.
 type SubscribedEvents struct {
 	Duration            int32
@@ -545,7 +702,7 @@ type SubscribedEvents struct {
 // ValueRegEx provides the regex method for the SubscribedEvents values matching
 func (se *SubscribedEvents) ValueRegEx() map[string]string {
 	return map[string]string{
-		"duration":               `-?\d+`,
+		"duration":               signedIntRegEx,
 		"NOTIFY_PORT_STATE":      `on|off`,
 		"NOTIFY_TIME_SYNC":       `on|off`,
 		"NOTIFY_PARENT_DATA_SET": `on|off`,

--- a/pkg/protocol/type.go
+++ b/pkg/protocol/type.go
@@ -28,10 +28,7 @@ const (
 // clock identities are an 8-octet EUI-64 value formatted as three hex groups (e.g.
 // 507c6f.fffe.1fb16c).
 const clockIdentityPattern = `[0-9a-fA-F]+\.[0-9a-fA-F]+\.[0-9a-fA-F]+`
-
-// signedIntRegEx matches an optionally negative base-10 integer, shared by the
-// several DataSet ValueRegEx maps whose fields may report negative values.
-const signedIntRegEx = `-?\d+`
+const signedIntRE = `-?\d+`
 
 // DataSet is an interface for PTP data sets that can be parsed from PMC output.
 type DataSet interface {
@@ -559,6 +556,7 @@ func (tp *TimePropertiesDS) String() string {
 // PortDataSet defines IEEE 1588 PORT_DATA_SET, pushed by ptp4l's NOTIFY_PORT_STATE subscription.
 type PortDataSet struct {
 	PortIdentity            string
+	PortNum                 int    // extracted from the trailing "-N" of PortIdentity during parsing
 	PortState               string // ps_str value: SLAVE, MASTER, LISTENING, FAULTY, etc.
 	LogMinDelayReqInterval  int8
 	PeerMeanPathDelay       int64
@@ -591,13 +589,13 @@ func (p *PortDataSet) ValueRegEx() map[string]string {
 	return map[string]string{
 		"portIdentity":            `.*`,
 		"portState":               `[A-Z_]+`,
-		"logMinDelayReqInterval":  signedIntRegEx,
-		"peerMeanPathDelay":       signedIntRegEx,
-		"logAnnounceInterval":     signedIntRegEx,
+		"logMinDelayReqInterval":  signedIntRE,
+		"peerMeanPathDelay":       signedIntRE,
+		"logAnnounceInterval":     signedIntRE,
 		"announceReceiptTimeout":  `\d+`,
-		"logSyncInterval":         signedIntRegEx,
+		"logSyncInterval":         signedIntRE,
 		"delayMechanism":          `\d+`,
-		"logMinPdelayReqInterval": signedIntRegEx,
+		"logMinPdelayReqInterval": signedIntRE,
 		"versionNumber":           `\d+`,
 	}
 }
@@ -617,6 +615,11 @@ func (p *PortDataSet) Update(key string, value string) {
 	switch key {
 	case "portIdentity":
 		p.PortIdentity = value
+		if idx := strings.LastIndex(value, "-"); idx >= 0 && idx < len(value)-1 {
+			if n, err := strconv.Atoi(value[idx+1:]); err == nil {
+				p.PortNum = n
+			}
+		}
 	case "portState":
 		p.PortState = value
 	case "logMinDelayReqInterval":
@@ -676,20 +679,6 @@ func (p *PortDataSet) Equal(other *PortDataSet) bool {
 		p.VersionNumber == other.VersionNumber
 }
 
-// PortNumber extracts the port number from the trailing "-N" of PortIdentity
-// (e.g. "b4e9b8.fffe.5ec71a-3" -> 3).
-func (p *PortDataSet) PortNumber() (int, error) {
-	idx := strings.LastIndex(p.PortIdentity, "-")
-	if idx < 0 || idx == len(p.PortIdentity)-1 {
-		return 0, fmt.Errorf("no port number suffix in portIdentity %q", p.PortIdentity)
-	}
-	n, err := strconv.Atoi(p.PortIdentity[idx+1:])
-	if err != nil {
-		return 0, fmt.Errorf("invalid port number in portIdentity %q: %w", p.PortIdentity, err)
-	}
-	return n, nil
-}
-
 // SubscribedEvents represents the subscription events configuration for PTP notifications.
 type SubscribedEvents struct {
 	Duration            int32
@@ -702,7 +691,7 @@ type SubscribedEvents struct {
 // ValueRegEx provides the regex method for the SubscribedEvents values matching
 func (se *SubscribedEvents) ValueRegEx() map[string]string {
 	return map[string]string{
-		"duration":               signedIntRegEx,
+		"duration":               signedIntRE,
 		"NOTIFY_PORT_STATE":      `on|off`,
 		"NOTIFY_TIME_SYNC":       `on|off`,
 		"NOTIFY_PARENT_DATA_SET": `on|off`,

--- a/pkg/protocol/type_test.go
+++ b/pkg/protocol/type_test.go
@@ -329,6 +329,7 @@ func TestPortDataSet_RegEx_MatchesRealPmcResponse(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, testPortIdentity, pds.PortIdentity)
+	assert.Equal(t, 1, pds.PortNum)
 	assert.Equal(t, "SLAVE", pds.PortState)
 	assert.Equal(t, int8(0), pds.LogMinDelayReqInterval)
 	assert.Equal(t, int64(0), pds.PeerMeanPathDelay)
@@ -394,31 +395,26 @@ func TestPortDataSet_RegEx_AllPortStates(t *testing.T) {
 	}
 }
 
-func TestPortDataSet_PortNumber(t *testing.T) {
+func TestPortDataSet_PortNum_ParsedFromIdentity(t *testing.T) {
 	tests := []struct {
-		name      string
-		identity  string
-		wantPort  int
-		wantError bool
+		name     string
+		identity string
+		wantPort int
 	}{
-		{"port 1", testPortIdentity, 1, false},
-		{"port 0", "b4e9b8.fffe.5ec71a-0", 0, false},
-		{"port 21", "c45ab1.ffff.545c05-21", 21, false},
-		{"no suffix", "b4e9b8.fffe.5ec71a", 0, true},
-		{"trailing dash", "b4e9b8.fffe.5ec71a-", 0, true},
-		{"non-numeric", "b4e9b8.fffe.5ec71a-abc", 0, true},
+		{"port 1", testPortIdentity, 1},
+		{"port 0", "b4e9b8.fffe.5ec71a-0", 0},
+		{"port 21", "c45ab1.ffff.545c05-21", 21},
+		{"no suffix", "b4e9b8.fffe.5ec71a", 0},
+		{"trailing dash", "b4e9b8.fffe.5ec71a-", 0},
+		{"non-numeric", "b4e9b8.fffe.5ec71a-abc", 0},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			pds := &PortDataSet{PortIdentity: tt.identity}
-			got, err := pds.PortNumber()
-			if tt.wantError {
-				assert.Error(t, err)
-			} else {
-				require.NoError(t, err)
-				assert.Equal(t, tt.wantPort, got)
-			}
+			pds := &PortDataSet{}
+			pds.Update("portIdentity", tt.identity)
+			assert.Equal(t, tt.wantPort, pds.PortNum)
+			assert.Equal(t, tt.identity, pds.PortIdentity)
 		})
 	}
 }

--- a/pkg/protocol/type_test.go
+++ b/pkg/protocol/type_test.go
@@ -304,3 +304,145 @@ func TestParentDataSet_ValueRegEx_ParentPortIdentityShape(t *testing.T) {
 		})
 	}
 }
+
+const testPortIdentity = "b4e9b8.fffe.5ec71a-1"
+
+func TestPortDataSet_RegEx_MatchesRealPmcResponse(t *testing.T) {
+	re := regexp.MustCompile((&PortDataSet{}).RegEx())
+
+	response := "\tb4e9b8.fffe.5ec71a-0 seq 0 RESPONSE MANAGEMENT PORT_DATA_SET \n" +
+		"\t\tportIdentity            " + testPortIdentity + "\n" +
+		"\t\tportState               SLAVE\n" +
+		"\t\tlogMinDelayReqInterval  0\n" +
+		"\t\tpeerMeanPathDelay       0\n" +
+		"\t\tlogAnnounceInterval     1\n" +
+		"\t\tannounceReceiptTimeout  3\n" +
+		"\t\tlogSyncInterval         0\n" +
+		"\t\tdelayMechanism          1\n" +
+		"\t\tlogMinPdelayReqInterval 0\n" +
+		"\t\tversionNumber           2\n"
+
+	matches := re.FindStringSubmatch(response)
+	require.NotNil(t, matches, "regex should match a real pmc RESPONSE MANAGEMENT PORT_DATA_SET body")
+
+	pds, err := ProcessMessage[PortDataSet](matches)
+	require.NoError(t, err)
+
+	assert.Equal(t, testPortIdentity, pds.PortIdentity)
+	assert.Equal(t, "SLAVE", pds.PortState)
+	assert.Equal(t, int8(0), pds.LogMinDelayReqInterval)
+	assert.Equal(t, int64(0), pds.PeerMeanPathDelay)
+	assert.Equal(t, int8(1), pds.LogAnnounceInterval)
+	assert.Equal(t, uint8(3), pds.AnnounceReceiptTimeout)
+	assert.Equal(t, int8(0), pds.LogSyncInterval)
+	assert.Equal(t, uint8(1), pds.DelayMechanism)
+	assert.Equal(t, int8(0), pds.LogMinPdelayReqInterval)
+	assert.Equal(t, uint8(2), pds.VersionNumber)
+}
+
+func TestPortDataSet_RegEx_MatchesNegativeValues(t *testing.T) {
+	re := regexp.MustCompile((&PortDataSet{}).RegEx())
+
+	response := "\t\tportIdentity            c45ab1.ffff.545c05-2\n" +
+		"\t\tportState               MASTER\n" +
+		"\t\tlogMinDelayReqInterval  -3\n" +
+		"\t\tpeerMeanPathDelay       -1234\n" +
+		"\t\tlogAnnounceInterval     -1\n" +
+		"\t\tannounceReceiptTimeout  3\n" +
+		"\t\tlogSyncInterval         -4\n" +
+		"\t\tdelayMechanism          2\n" +
+		"\t\tlogMinPdelayReqInterval -2\n" +
+		"\t\tversionNumber           2\n"
+
+	matches := re.FindStringSubmatch(response)
+	require.NotNil(t, matches)
+
+	pds, err := ProcessMessage[PortDataSet](matches)
+	require.NoError(t, err)
+
+	assert.Equal(t, "c45ab1.ffff.545c05-2", pds.PortIdentity)
+	assert.Equal(t, "MASTER", pds.PortState)
+	assert.Equal(t, int8(-3), pds.LogMinDelayReqInterval)
+	assert.Equal(t, int64(-1234), pds.PeerMeanPathDelay)
+	assert.Equal(t, int8(-1), pds.LogAnnounceInterval)
+	assert.Equal(t, int8(-4), pds.LogSyncInterval)
+	assert.Equal(t, int8(-2), pds.LogMinPdelayReqInterval)
+}
+
+func TestPortDataSet_RegEx_AllPortStates(t *testing.T) {
+	re := regexp.MustCompile((&PortDataSet{}).RegEx())
+
+	states := []string{
+		"NONE", "INITIALIZING", "FAULTY", "DISABLED", "LISTENING",
+		"PRE_MASTER", "MASTER", "PASSIVE", "UNCALIBRATED", "SLAVE",
+		"GRAND_MASTER",
+	}
+	for _, state := range states {
+		input := "\t\tportIdentity            " + testPortIdentity + "\n" +
+			"\t\tportState               " + state + "\n" +
+			"\t\tlogMinDelayReqInterval  0\n" +
+			"\t\tpeerMeanPathDelay       0\n" +
+			"\t\tlogAnnounceInterval     1\n" +
+			"\t\tannounceReceiptTimeout  3\n" +
+			"\t\tlogSyncInterval         0\n" +
+			"\t\tdelayMechanism          1\n" +
+			"\t\tlogMinPdelayReqInterval 0\n" +
+			"\t\tversionNumber           2\n"
+
+		matches := re.FindStringSubmatch(input)
+		assert.NotNilf(t, matches, "portState=%s should match", state)
+	}
+}
+
+func TestPortDataSet_PortNumber(t *testing.T) {
+	tests := []struct {
+		name      string
+		identity  string
+		wantPort  int
+		wantError bool
+	}{
+		{"port 1", testPortIdentity, 1, false},
+		{"port 0", "b4e9b8.fffe.5ec71a-0", 0, false},
+		{"port 21", "c45ab1.ffff.545c05-21", 21, false},
+		{"no suffix", "b4e9b8.fffe.5ec71a", 0, true},
+		{"trailing dash", "b4e9b8.fffe.5ec71a-", 0, true},
+		{"non-numeric", "b4e9b8.fffe.5ec71a-abc", 0, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pds := &PortDataSet{PortIdentity: tt.identity}
+			got, err := pds.PortNumber()
+			if tt.wantError {
+				assert.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.wantPort, got)
+			}
+		})
+	}
+}
+
+func TestPortDataSet_Equal(t *testing.T) {
+	a := &PortDataSet{PortIdentity: testPortIdentity, PortState: "SLAVE"}
+	b := &PortDataSet{PortIdentity: testPortIdentity, PortState: "SLAVE"}
+	c := &PortDataSet{PortIdentity: testPortIdentity, PortState: "MASTER"}
+
+	assert.True(t, a.Equal(b))
+	assert.False(t, a.Equal(c))
+	assert.True(t, (*PortDataSet)(nil).Equal(nil))
+	assert.False(t, a.Equal(nil))
+	assert.False(t, (*PortDataSet)(nil).Equal(a))
+}
+
+func TestPortDataSet_MonitorRegEx_CompilesWithoutCaptureGroups(t *testing.T) {
+	pattern := (&PortDataSet{}).MonitorRegEx()
+	re, err := regexp.Compile(pattern)
+	require.NoError(t, err)
+	assert.Equal(t, 0, re.NumSubexp(), "MonitorRegEx must not declare capture groups")
+}
+
+func TestPortDataSet_String_NilReceiver(t *testing.T) {
+	var p *PortDataSet
+	assert.Equal(t, "", p.String())
+}


### PR DESCRIPTION
Addressing tech-debt : [CNF-25298](https://redhat.atlassian.net/browse/CNF-25298)

## Summary 
Replaces ad hoc strings.Contains matching on raw ptp4l log lines with the shared, structured parser.PTPEvent (adding a new PreviousRole field) across the legacy T-BC path, the metrics fallback extractor, and the hardwareconfig state detector. Fixes a confirmed regression where the legacy path could spuriously re-enter HOLDOVER on benign, non-transition ptp4l log lines, and adds comprehensive test coverage for port role/state transitions to guard against future regressions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new Prometheus `ServoState` gauge (`ptp/servo_state`) and propagated linuxptp/phc2sys/ts2phc `s0–s3` parsing end-to-end.
  * Enhanced PTP event parsing to include interface name and previous role.

* **Bug Fixes**
  * Reduced false “lost sync”/holdover triggers by switching to structured ptp4l event parsing and ignoring malformed/unrelated lines.
  * Improved precision for legacy and hardware-config state-change detection.
  * Ensured servo state resets appropriately when the port transitions to faulty.

* **Tests**
  * Expanded regression and behavior-pinning tests covering holdover precision, previous-role parsing, servo-state updates, and faulty reset behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->