### PR TITLE
Fix AnnounceClockClass passing ClockClass as accuracy argument

### DIFF
--- a/pkg/daemon/pmc.go
+++ b/pkg/daemon/pmc.go
@@ -293,7 +293,7 @@ func (pmc *PMCProcess) handleParentDS(parentDS protocol.ParentDataSet) {
 	} else if oldParentDS == nil || oldParentDS.GrandmasterClockClass != parentDS.GrandmasterClockClass {
 		pmc.eventHandler.AnnounceClockClass(
 			fbprotocol.ClockClass(parentDS.GrandmasterClockClass),
-			fbprotocol.ClockAccuracy(parentDS.GrandmasterClockClass),
+			fbprotocol.ClockAccuracy(parentDS.GrandmasterClockAccuracy),
 			pmc.configFileName,
 			event.ClockType(pmc.clockType),
 		)


### PR DESCRIPTION
handleParentDS was passing GrandmasterClockClass for both the clockClass and clockAccuracy parameters causing an accuracy value equal to the clock class, instead of the actual value

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected clock announcement data so clock accuracy is now reported from the proper source, improving the accuracy of clock-class updates sent to the system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->