### PR TITLE
Switch to Infof to fix log message formatting

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -2510,7 +2510,7 @@ func (dn *Daemon) stopAllProcesses() {
 				for i := len(p.depProcess) - 1; i >= 0; i-- {
 					d := p.depProcess[i]
 					if d != nil {
-						glog.Info("Stopping %s", d.Name())
+						glog.Infof("Stopping %s", d.Name())
 						d.CmdStop()
 						d = nil
 					}
@@ -2518,7 +2518,7 @@ func (dn *Daemon) stopAllProcesses() {
 			}
 
 			// Stop parent process
-			glog.Info("Stopping %s", p.name)
+			glog.Infof("Stopping %s", p.name)
 			p.cmdStop()
 			p.depProcess = nil
 			p.hasCollectedMetrics = false
@@ -2530,7 +2530,7 @@ func (dn *Daemon) stopAllProcesses() {
 				deleteSyncEMetrics(p.name, p.configName, p.syncERelations)
 			}
 
-			glog.Info("Stopped %s ", p.name)
+			glog.Infof("Stopped %s", p.name)
 			p = nil
 		}
 	}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected shutdown log messages so process names display properly.
  * Improved formatting of final process-stop messages and removed an extra trailing space.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->