### PR TITLE
T-GM support for v2 API and HardwareConfig

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -25,6 +25,7 @@ import (
 	ptpnetwork "github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/network"
 	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/parser"
 	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/synce"
+	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/ublox"
 	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/utils"
 	ptpv2alpha1 "github.com/k8snetworkplumbingwg/ptp-operator/api/v2alpha1"
 	ptpclient "github.com/k8snetworkplumbingwg/ptp-operator/pkg/client/clientset/versioned"
@@ -1293,6 +1294,21 @@ func (dn *Daemon) applyNodePtpProfile(runID int, nodeProfile *ptpv1.PtpProfile) 
 			glog.Infof("Delaying phc2sys startup: %s", dprocess.skipInitialStartup)
 		} else if pProcess == ts2phcProcessName { //& if the x plugin is enabled
 			if clockType == event.GM {
+				// If a HardwareConfig defines a GNSS source, locate the serial port and any GNSS initialization commands.
+				var gnssInitCmds ublox.CommandList
+				if nodeProfile.Name != nil && dn.hardwareConfigManager.ReadyHardwareConfigForProfile(*nodeProfile.Name) {
+					gnssPort, gnssErr := dn.hardwareConfigManager.GetGNSSSerialPort(nodeProfile)
+					if gnssErr != nil {
+						glog.Warningf("HardwareConfig GNSS device detection failed: %v", gnssErr)
+					} else if gnssPort != "" {
+						glog.Infof("HardwareConfig GNSS device detected: %s (overriding ts2phc config)", gnssPort)
+						output.gnss_serial_port = gnssPort
+					}
+
+					gnssInitCmds = dn.hardwareConfigManager.GetGNSSInitCommands(nodeProfile)
+					glog.Infof("HardwareConfig GNSS initialization added %d additional commands", len(gnssInitCmds))
+				}
+
 				if output.gnss_serial_port == "" {
 					output.gnss_serial_port = GPSDDefaultGNSSSerialPort
 					glog.Warningf("Setting GNSS serial port to %s", output.gnss_serial_port)
@@ -1302,6 +1318,7 @@ func (dn *Daemon) applyNodePtpProfile(runID int, nodeProfile *ptpv1.PtpProfile) 
 
 				// Record ublox init results (MON-HW, etc.) to NodePtpDevice status.
 				// Replaces any previous "gnss" entries to avoid duplicates on re-init.
+				// Additionally store on HardwareConfigManager when that path is active.
 				gnssResultsFn := func(results []string) {
 					dn.hwconfigsMu.Lock()
 					defer dn.hwconfigsMu.Unlock()
@@ -1332,6 +1349,7 @@ func (dn *Daemon) applyNodePtpProfile(runID int, nodeProfile *ptpv1.PtpProfile) 
 					stopped:       false,
 					messageTag:    messageTag,
 					ublxTool:      nil,
+					gnssInitCmds:  gnssInitCmds,
 					gnssResultsFn: gnssResultsFn,
 				}
 				gpsDaemon.CmdInit()

--- a/pkg/hardwareconfig/clockchain_resolution.go
+++ b/pkg/hardwareconfig/clockchain_resolution.go
@@ -93,6 +93,29 @@ func extractUpstreamPortsFromPtpProfile(ptpProfile *ptpv1.PtpProfile) []string {
 	return upstreamPorts
 }
 
+// extractInterfacesFromPtpProfile extracts all interface names from a PTP profile's
+// ptp4l config (any [section] that is not a well-known non-interface section).
+func extractInterfacesFromPtpProfile(ptpProfile *ptpv1.PtpProfile) []string {
+	if ptpProfile == nil || ptpProfile.Ptp4lConf == nil {
+		return nil
+	}
+
+	var interfaces []string
+	for _, line := range strings.Split(*ptpProfile.Ptp4lConf, "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "[") && strings.HasSuffix(line, "]") {
+			section := strings.Trim(line, "[]")
+			switch section {
+			case "global", "nmea", "unicast":
+				continue
+			default:
+				interfaces = append(interfaces, section)
+			}
+		}
+	}
+	return interfaces
+}
+
 // findLeadingInterfaceFromPort finds the leading interface (for DPLL clock ID) from any network port.
 // Steps:
 // 1. Get PHC index from port (ethtool -T)
@@ -320,7 +343,17 @@ func (hcm *HardwareConfigManager) deriveSubsystemStructure(subsystem *ptpv2alpha
 			glog.Infof("Derived NetworkInterface: %s (from upstream port %s)", leadingInterface, upstreamPorts[0])
 		}
 	} else if subsystem.DPLL.NetworkInterface == "" {
-		return fmt.Errorf("networkInterface is required for T-GM subsystem %s (no upstream port to derive it from)", subsystem.Name)
+		// T-GM has no upstream ports; derive from any interface in the PTP config
+		allInterfaces := extractInterfacesFromPtpProfile(ptpProfile)
+		if len(allInterfaces) == 0 {
+			return fmt.Errorf("no interfaces found in ptpconfig for T-GM subsystem %s", subsystem.Name)
+		}
+		leadingInterface, err := findLeadingInterfaceFromPort(allInterfaces[0])
+		if err != nil {
+			return fmt.Errorf("failed to find leading interface from port %s: %w", allInterfaces[0], err)
+		}
+		subsystem.DPLL.NetworkInterface = leadingInterface
+		glog.Infof("Derived NetworkInterface: %s (from T-GM port %s)", leadingInterface, allInterfaces[0])
 	}
 
 	// Load behavior profile to get pin roles

--- a/pkg/hardwareconfig/clockchain_resolution.go
+++ b/pkg/hardwareconfig/clockchain_resolution.go
@@ -93,20 +93,20 @@ func extractUpstreamPortsFromPtpProfile(ptpProfile *ptpv1.PtpProfile) []string {
 	return upstreamPorts
 }
 
-// findLeadingInterfaceFromUpstreamPort finds the leading interface (for DPLL clock ID) from an upstream port.
+// findLeadingInterfaceFromPort finds the leading interface (for DPLL clock ID) from any network port.
 // Steps:
-// 1. Get PHC index from upstream port (ethtool -T)
+// 1. Get PHC index from port (ethtool -T)
 // 2. Find PCI address from PHC symlink (/sys/class/ptp/ptp{N}/device)
 // 3. Find leading interface from PCI address (/sys/bus/pci/devices/{pci}/net/)
-func findLeadingInterfaceFromUpstreamPort(upstreamPort string) (string, error) {
-	return findLeadingInterfaceFromUpstreamPortWithResolver(upstreamPort, leadingInterfaceResolver)
+func findLeadingInterfaceFromPort(port string) (string, error) {
+	return findLeadingInterfaceFromPortWithResolver(port, leadingInterfaceResolver)
 }
 
-// findLeadingInterfaceFromUpstreamPortWithResolver is the internal implementation that accepts a resolver
-// This allows for dependency injection and testing
-func findLeadingInterfaceFromUpstreamPortWithResolver(upstreamPort string, resolver LeadingInterfaceResolver) (string, error) {
-	if upstreamPort == "" {
-		return "", fmt.Errorf("upstreamPort is empty")
+// findLeadingInterfaceFromPortWithResolver is the internal implementation that accepts a resolver.
+// This allows for dependency injection and testing.
+func findLeadingInterfaceFromPortWithResolver(port string, resolver LeadingInterfaceResolver) (string, error) {
+	if port == "" {
+		return "", fmt.Errorf("port is empty")
 	}
 
 	if resolver == nil {
@@ -114,9 +114,9 @@ func findLeadingInterfaceFromUpstreamPortWithResolver(upstreamPort string, resol
 	}
 
 	// Step 1: Get PHC index using resolver
-	phcID := resolver.GetPhcID(upstreamPort)
+	phcID := resolver.GetPhcID(port)
 	if phcID == "" {
-		return "", fmt.Errorf("failed to get PHC ID for upstream port %s", upstreamPort)
+		return "", fmt.Errorf("failed to get PHC ID for port %s", port)
 	}
 
 	// Extract PHC index from /dev/ptp{N} format
@@ -151,8 +151,8 @@ func findLeadingInterfaceFromUpstreamPortWithResolver(upstreamPort string, resol
 
 	// Return the first interface found (there should typically be only one)
 	leadingInterface := entries[0].Name()
-	glog.Infof("Found leading interface %s for upstream port %s (PHC: %s, PCI: %s)",
-		leadingInterface, upstreamPort, phcID, pciAddress)
+	glog.Infof("Found leading interface %s for port %s (PHC: %s, PCI: %s)",
+		leadingInterface, port, phcID, pciAddress)
 
 	return leadingInterface, nil
 }
@@ -305,20 +305,22 @@ func (hcm *HardwareConfigManager) deriveSubsystemStructure(subsystem *ptpv2alpha
 
 	// Extract upstream ports from ptpconfig (PTP time receivers for event detection)
 	upstreamPorts := extractUpstreamPortsFromPtpProfile(ptpProfile)
-	if len(upstreamPorts) == 0 {
-		return fmt.Errorf("no upstream ports found in ptpconfig")
-	}
-
-	// Find leading interface from first upstream port (for DPLL clock ID)
-	var leadingInterface string
-	if subsystem.DPLL.NetworkInterface == "" {
-		var err error
-		leadingInterface, err = findLeadingInterfaceFromUpstreamPort(upstreamPorts[0])
-		if err != nil {
-			return fmt.Errorf("failed to find leading interface from upstream port %s: %w", upstreamPorts[0], err)
+	if clockType != ClockTypeTGM {
+		if len(upstreamPorts) == 0 {
+			return fmt.Errorf("no upstream ports found in ptpconfig")
 		}
-		subsystem.DPLL.NetworkInterface = leadingInterface
-		glog.Infof("Derived NetworkInterface: %s (from upstream port %s)", leadingInterface, upstreamPorts[0])
+
+		// Find leading interface from first upstream port (for DPLL clock ID)
+		if subsystem.DPLL.NetworkInterface == "" {
+			leadingInterface, err := findLeadingInterfaceFromPort(upstreamPorts[0])
+			if err != nil {
+				return fmt.Errorf("failed to find leading interface from upstream port %s: %w", upstreamPorts[0], err)
+			}
+			subsystem.DPLL.NetworkInterface = leadingInterface
+			glog.Infof("Derived NetworkInterface: %s (from upstream port %s)", leadingInterface, upstreamPorts[0])
+		}
+	} else if subsystem.DPLL.NetworkInterface == "" {
+		return fmt.Errorf("networkInterface is required for T-GM subsystem %s (no upstream port to derive it from)", subsystem.Name)
 	}
 
 	// Load behavior profile to get pin roles
@@ -330,32 +332,34 @@ func (hcm *HardwareConfigManager) deriveSubsystemStructure(subsystem *ptpv2alpha
 		return fmt.Errorf("no behavior profile found for %s/%s", hwDefPath, clockType)
 	}
 
-	// Derive PhaseInputs from pinRoles
-	if len(subsystem.DPLL.PhaseInputs) == 0 {
-		ptpInputPin := behaviorTemplate.PinRoles["ptpInputPin"]
-		if ptpInputPin == "" {
-			return fmt.Errorf("ptpInputPin not found in pinRoles for %s/%s", hwDefPath, clockType)
+	if clockType != ClockTypeTGM {
+		// Derive PhaseInputs from pinRoles
+		if len(subsystem.DPLL.PhaseInputs) == 0 {
+			ptpInputPin := behaviorTemplate.PinRoles["ptpInputPin"]
+			if ptpInputPin == "" {
+				return fmt.Errorf("ptpInputPin not found in pinRoles for %s/%s", hwDefPath, clockType)
+			}
+
+			if subsystem.DPLL.PhaseInputs == nil {
+				subsystem.DPLL.PhaseInputs = make(map[string]ptpv2alpha1.PinConfig)
+			}
+			freq := int64(1) // 1 PPS for PTP
+			subsystem.DPLL.PhaseInputs[ptpInputPin] = ptpv2alpha1.PinConfig{
+				Frequency:   &freq,
+				Description: "PTP time receiver input",
+			}
+			glog.Infof("Derived PhaseInputs: %s (frequency: %d Hz)", ptpInputPin, freq)
 		}
 
-		if subsystem.DPLL.PhaseInputs == nil {
-			subsystem.DPLL.PhaseInputs = make(map[string]ptpv2alpha1.PinConfig)
+		// Derive Ethernet ports (all upstream ports)
+		if len(subsystem.Ethernet) == 0 {
+			subsystem.Ethernet = []ptpv2alpha1.Ethernet{
+				{
+					Ports: upstreamPorts,
+				},
+			}
+			glog.Infof("Derived Ethernet ports: %v", upstreamPorts)
 		}
-		freq := int64(1) // 1 PPS for PTP
-		subsystem.DPLL.PhaseInputs[ptpInputPin] = ptpv2alpha1.PinConfig{
-			Frequency:   &freq,
-			Description: "PTP time receiver input",
-		}
-		glog.Infof("Derived PhaseInputs: %s (frequency: %d Hz)", ptpInputPin, freq)
-	}
-
-	// Derive Ethernet ports (all upstream ports)
-	if len(subsystem.Ethernet) == 0 {
-		subsystem.Ethernet = []ptpv2alpha1.Ethernet{
-			{
-				Ports: upstreamPorts,
-			},
-		}
-		glog.Infof("Derived Ethernet ports: %v", upstreamPorts)
 	}
 
 	return nil

--- a/pkg/hardwareconfig/clockchain_resolution.go
+++ b/pkg/hardwareconfig/clockchain_resolution.go
@@ -261,11 +261,11 @@ func (hcm *HardwareConfigManager) ResolveClockChain(hwConfig *ptpv2alpha1.Hardwa
 		}
 	}
 
-	// Derive behavior from templates if not explicitly provided
-	if resolvedConfig.Spec.Profile.ClockChain.Behavior == nil {
-		if err := hcm.deriveBehavior(resolvedConfig, clockType); err != nil {
-			return nil, fmt.Errorf("failed to derive behavior: %w", err)
-		}
+	// Derive behavior from templates, merging any user-provided sources.
+	// Always run even when the user supplies Behavior.Sources (e.g. gnssConfig)
+	// so the template's DPLL pin details and conditions are still applied.
+	if err := hcm.deriveBehavior(resolvedConfig, clockType); err != nil {
+		return nil, fmt.Errorf("failed to derive behavior: %w", err)
 	}
 
 	// Print resolved configuration for debugging/verification
@@ -495,17 +495,19 @@ func deepCopyAndResolveCondition(cond ptpv2alpha1.Condition, vars templateVariab
 func (hcm *HardwareConfigManager) deriveBehavior(hwConfig *ptpv2alpha1.HardwareConfig, clockType string) error {
 	clockChain := hwConfig.Spec.Profile.ClockChain
 
-	// If behavior is already provided, merge with templates (future enhancement)
-	// For now, if behavior exists, skip derivation
-	if clockChain.Behavior != nil && (len(clockChain.Behavior.Sources) > 0 || len(clockChain.Behavior.Conditions) > 0) {
-		glog.Infof("Behavior already provided, skipping template derivation")
-		return nil
+	// Save any user-provided sources for merging after template instantiation.
+	// User sources can provide fields like gnssConfig that the template can't
+	// know ahead of time, while the template provides the DPLL pin details
+	// and conditions that the user shouldn't need to specify.
+	var userSources []ptpv2alpha1.SourceConfig
+	var userConditions []ptpv2alpha1.Condition
+	if clockChain.Behavior != nil {
+		userSources = clockChain.Behavior.Sources
+		userConditions = clockChain.Behavior.Conditions
 	}
 
-	// Initialize behavior if nil
-	if clockChain.Behavior == nil {
-		clockChain.Behavior = &ptpv2alpha1.Behavior{}
-	}
+	// Initialize/reset behavior for template derivation
+	clockChain.Behavior = &ptpv2alpha1.Behavior{}
 
 	// Process each subsystem to derive behavior
 	for _, subsystem := range clockChain.Structure {
@@ -561,8 +563,66 @@ func (hcm *HardwareConfigManager) deriveBehavior(hwConfig *ptpv2alpha1.HardwareC
 		}
 	}
 
+	// Merge user-provided source fields onto template-derived sources.
+	// Match by Name first, then by SourceType. User fields (e.g., gnssConfig)
+	// overlay template defaults without replacing DPLL/pin details.
+	for _, userSource := range userSources {
+		merged := false
+		for i := range clockChain.Behavior.Sources {
+			tplSource := &clockChain.Behavior.Sources[i]
+			if (userSource.Name != "" && tplSource.Name == userSource.Name) ||
+				(userSource.Name == "" && tplSource.SourceType == userSource.SourceType) {
+				mergeSourceConfig(tplSource, &userSource)
+				glog.Infof("Merged user source %q onto template source %q", userSource.Name, tplSource.Name)
+				merged = true
+				break
+			}
+		}
+		if !merged {
+			// User source doesn't match any template source — add it as-is
+			clockChain.Behavior.Sources = append(clockChain.Behavior.Sources, userSource)
+			glog.Infof("Added user source %q (no matching template)", userSource.Name)
+		}
+	}
+
+	// Merge user-provided conditions onto template-derived conditions.
+	// Match by name: user conditions override same-named template conditions.
+	// Unmatched user conditions are appended.
+	for _, userCond := range userConditions {
+		merged := false
+		for i := range clockChain.Behavior.Conditions {
+			if clockChain.Behavior.Conditions[i].Name == userCond.Name {
+				clockChain.Behavior.Conditions[i] = userCond
+				glog.Infof("User condition %q overrides template condition", userCond.Name)
+				merged = true
+				break
+			}
+		}
+		if !merged {
+			clockChain.Behavior.Conditions = append(clockChain.Behavior.Conditions, userCond)
+			glog.Infof("Added user condition %q (no matching template)", userCond.Name)
+		}
+	}
+
 	glog.Infof("Derived behavior: %d sources, %d conditions",
 		len(clockChain.Behavior.Sources), len(clockChain.Behavior.Conditions))
 
 	return nil
+}
+
+// mergeSourceConfig overlays user-provided fields onto a template source.
+// Only non-zero user fields are applied, preserving template defaults.
+func mergeSourceConfig(tpl, user *ptpv2alpha1.SourceConfig) {
+	if user.Subsystem != "" {
+		tpl.Subsystem = user.Subsystem
+	}
+	if user.BoardLabel != "" {
+		tpl.BoardLabel = user.BoardLabel
+	}
+	if len(user.PTPTimeReceivers) > 0 {
+		tpl.PTPTimeReceivers = user.PTPTimeReceivers
+	}
+	if user.GNSSConfig != nil {
+		tpl.GNSSConfig = user.GNSSConfig
+	}
 }

--- a/pkg/hardwareconfig/clockchain_resolution_test.go
+++ b/pkg/hardwareconfig/clockchain_resolution_test.go
@@ -132,7 +132,7 @@ func TestClockChainResolution(t *testing.T) {
 			assert.Len(t, hwConfig.Spec.Profile.ClockChain.Structure, 1)
 
 			subsystem := hwConfig.Spec.Profile.ClockChain.Structure[0]
-			assert.Equal(t, "leader", subsystem.Name)
+			assert.Equal(t, testSubsystemLeader, subsystem.Name)
 			assert.Equal(t, tc.hwDefPath, subsystem.HardwareSpecificDefinitions)
 
 			// Before resolution: DPLL and Ethernet should be empty/omitted
@@ -191,7 +191,7 @@ func TestClockChainResolution(t *testing.T) {
 			// Set up mock leading interface resolver
 			mockResolver := newMockLeadingInterfaceResolver()
 			// Mock: eno2 -> PHC 0 -> PCI 0000:13:00.0 -> eno5
-			mockResolver.phcIDs["eno2"] = "/dev/ptp0"
+			mockResolver.phcIDs["eno2"] = testDevPtp0
 			mockResolver.symlinks["/sys/class/ptp/ptp0/device"] = "../../../0000:13:00.0"
 			mockResolver.dirEntries["/sys/bus/pci/devices/0000:13:00.0/net"] = []os.DirEntry{
 				&mockDirEntry{name: "eno5", isDir: false},
@@ -237,13 +237,13 @@ func TestClockChainResolution(t *testing.T) {
 
 			// Sources should be instantiated with resolved variables
 			assert.NotEmpty(t, behavior.Sources)
-			ptpSource := findSourceByName(behavior.Sources, "PTP")
+			ptpSource := findSourceByName(behavior.Sources, testSourcePTP)
 			assert.NotNil(t, ptpSource, "PTP source should be present")
 			if ptpSource == nil {
 				t.Fatal("PTP source should be present")
 			}
 			assert.Equal(t, ptpv2alpha1.SourceTypePTP, ptpSource.SourceType)
-			assert.Equal(t, "leader", ptpSource.Subsystem, "Subsystem should be resolved")
+			assert.Equal(t, testSubsystemLeader, ptpSource.Subsystem, "Subsystem should be resolved")
 			assert.Equal(t, tc.expectedPtpInput, ptpSource.BoardLabel, "BoardLabel should be resolved from pinRoles")
 			assert.Equal(t, upstreamPorts, ptpSource.PTPTimeReceivers,
 				"PTPTimeReceivers should match upstream ports")
@@ -337,7 +337,7 @@ func TestClockChainResolution_DualUpstream(t *testing.T) {
 	// Set up mock leading interface resolver:
 	// eno8703 -> PHC 0 -> PCI 0000:87:00.0 -> eno8703 (leading interface)
 	mockResolver := newMockLeadingInterfaceResolver()
-	mockResolver.phcIDs["eno8703"] = "/dev/ptp0"
+	mockResolver.phcIDs["eno8703"] = testDevPtp0
 	mockResolver.symlinks["/sys/class/ptp/ptp0/device"] = "../../../0000:87:00.0"
 	mockResolver.dirEntries["/sys/bus/pci/devices/0000:87:00.0/net"] = []os.DirEntry{
 		&mockDirEntry{name: "eno8703", isDir: false},
@@ -376,12 +376,12 @@ func TestClockChainResolution_DualUpstream(t *testing.T) {
 	}
 
 	// PTP source should have both ports as PTPTimeReceivers
-	ptpSource := findSourceByName(behavior.Sources, "PTP")
+	ptpSource := findSourceByName(behavior.Sources, testSourcePTP)
 	if !assert.NotNil(t, ptpSource, "PTP source should exist") {
 		t.Fatal()
 	}
 	assert.Equal(t, ptpv2alpha1.SourceTypePTP, ptpSource.SourceType)
-	assert.Equal(t, "leader", ptpSource.Subsystem)
+	assert.Equal(t, testSubsystemLeader, ptpSource.Subsystem)
 	assert.Equal(t, "ETH01_SDP_TIMESYNC_0", ptpSource.BoardLabel)
 	assert.Equal(t, upstreamPorts, ptpSource.PTPTimeReceivers,
 		"PTPTimeReceivers should contain both upstream ports derived from PTP config")
@@ -391,7 +391,7 @@ func TestClockChainResolution_DualUpstream(t *testing.T) {
 	assert.NotNil(t, initCond, "Initialize T-BC condition should be present")
 	if initCond != nil && len(initCond.DesiredStates) > 0 && initCond.DesiredStates[0].DPLL != nil {
 		assert.Equal(t, "GNSS_1PPS_IN", initCond.DesiredStates[0].DPLL.BoardLabel)
-		assert.Equal(t, "leader", initCond.DesiredStates[0].DPLL.Subsystem)
+		assert.Equal(t, testSubsystemLeader, initCond.DesiredStates[0].DPLL.Subsystem)
 	}
 
 	lockedCond := findConditionByName(behavior.Conditions, "PTP Source Locked")
@@ -507,7 +507,7 @@ func TestClockChainResolutionWithE830(t *testing.T) {
 
 	// Set up mock leading interface resolver for the leader subsystem
 	mockResolver := newMockLeadingInterfaceResolver()
-	mockResolver.phcIDs["eno2"] = "/dev/ptp0"
+	mockResolver.phcIDs["eno2"] = testDevPtp0
 	mockResolver.symlinks["/sys/class/ptp/ptp0/device"] = "../../../0000:13:00.0"
 	mockResolver.dirEntries["/sys/bus/pci/devices/0000:13:00.0/net"] = []os.DirEntry{
 		&mockDirEntry{name: "eno5", isDir: false},
@@ -554,4 +554,209 @@ func TestClockChainResolutionWithE830(t *testing.T) {
 	}
 
 	t.Logf("ResolveClockChain succeeded: leader derived, %d E830 subsystems skipped", len(e830Before))
+}
+
+func TestMergeSourceConfig(t *testing.T) {
+	t.Run("merges gnssConfig onto template", func(t *testing.T) {
+		tpl := ptpv2alpha1.SourceConfig{
+			Name:       testSourceGNSS,
+			SourceType: ptpv2alpha1.SourceTypeGNSS,
+			Subsystem:  testSubsystemLeader,
+			BoardLabel: "GNSS_1PPS_IN",
+		}
+		user := ptpv2alpha1.SourceConfig{
+			Name:       testSourceGNSS,
+			SourceType: ptpv2alpha1.SourceTypeGNSS,
+			GNSSConfig: &ptpv2alpha1.GNSSConfig{
+				Init: ptpv2alpha1.GNSSInit{AntennaVoltage: true},
+			},
+		}
+		mergeSourceConfig(&tpl, &user)
+
+		assert.Equal(t, testSubsystemLeader, tpl.Subsystem, "template subsystem preserved")
+		assert.Equal(t, "GNSS_1PPS_IN", tpl.BoardLabel, "template boardLabel preserved")
+		assert.NotNil(t, tpl.GNSSConfig, "user gnssConfig merged")
+		assert.True(t, tpl.GNSSConfig.Init.AntennaVoltage)
+	})
+
+	t.Run("user overrides subsystem and boardLabel", func(t *testing.T) {
+		tpl := ptpv2alpha1.SourceConfig{
+			Name:       testSourcePTP,
+			Subsystem:  testSubsystemLeader,
+			BoardLabel: "DEFAULT_PIN",
+		}
+		user := ptpv2alpha1.SourceConfig{
+			Name:       testSourcePTP,
+			Subsystem:  "custom-sub",
+			BoardLabel: "CUSTOM_PIN",
+		}
+		mergeSourceConfig(&tpl, &user)
+
+		assert.Equal(t, "custom-sub", tpl.Subsystem)
+		assert.Equal(t, "CUSTOM_PIN", tpl.BoardLabel)
+	})
+
+	t.Run("empty user fields do not overwrite template", func(t *testing.T) {
+		tpl := ptpv2alpha1.SourceConfig{
+			Name:             testSourcePTP,
+			Subsystem:        testSubsystemLeader,
+			BoardLabel:       "TEMPLATE_PIN",
+			PTPTimeReceivers: []string{testIfaceE810},
+		}
+		user := ptpv2alpha1.SourceConfig{
+			Name: testSourcePTP,
+			// All other fields empty/nil
+		}
+		mergeSourceConfig(&tpl, &user)
+
+		assert.Equal(t, testSubsystemLeader, tpl.Subsystem)
+		assert.Equal(t, "TEMPLATE_PIN", tpl.BoardLabel)
+		assert.Equal(t, []string{testIfaceE810}, tpl.PTPTimeReceivers)
+		assert.Nil(t, tpl.GNSSConfig)
+	})
+
+	t.Run("user ptpTimeReceivers override template", func(t *testing.T) {
+		tpl := ptpv2alpha1.SourceConfig{
+			Name:             testSourcePTP,
+			PTPTimeReceivers: []string{"old-port"},
+		}
+		user := ptpv2alpha1.SourceConfig{
+			Name:             testSourcePTP,
+			PTPTimeReceivers: []string{"new-port1", "new-port2"},
+		}
+		mergeSourceConfig(&tpl, &user)
+
+		assert.Equal(t, []string{"new-port1", "new-port2"}, tpl.PTPTimeReceivers)
+	})
+}
+
+func TestDeriveBehavior_UnmatchedUserSourceAdded(t *testing.T) {
+	fakeClient := fake.NewClientset()
+	hcm := NewHardwareConfigManager(fakeClient, "default", nil)
+
+	clockType := testClockTypeTGM
+	hwConfig := &ptpv2alpha1.HardwareConfig{
+		Spec: ptpv2alpha1.HardwareConfigSpec{
+			Profile: ptpv2alpha1.HardwareProfile{
+				ClockType: &clockType,
+				ClockChain: &ptpv2alpha1.ClockChain{
+					Structure: []ptpv2alpha1.Subsystem{
+						{
+							Name:                        testSubsystemLeader,
+							HardwareSpecificDefinitions: HwDefIntelE825,
+							DPLL: ptpv2alpha1.DPLL{
+								NetworkInterface: testIfaceEns7f0,
+							},
+							Ethernet: []ptpv2alpha1.Ethernet{
+								{Ports: []string{testIfaceEns7f0}},
+							},
+						},
+					},
+					Behavior: &ptpv2alpha1.Behavior{
+						Sources: []ptpv2alpha1.SourceConfig{
+							{
+								Name:       "CustomSource",
+								SourceType: ptpv2alpha1.SourceTypeDPLL,
+								Subsystem:  testSubsystemLeader,
+								BoardLabel: "CUSTOM_PIN",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	err := hcm.deriveBehavior(hwConfig, clockType)
+	assert.NoError(t, err)
+
+	behavior := hwConfig.Spec.Profile.ClockChain.Behavior
+	assert.NotNil(t, behavior)
+
+	// Should have the template GNSS source + the unmatched custom source
+	var foundGNSS, foundCustom bool
+	for _, s := range behavior.Sources {
+		if s.Name == testSourceGNSS {
+			foundGNSS = true
+		}
+		if s.Name == "CustomSource" {
+			foundCustom = true
+			assert.Equal(t, ptpv2alpha1.SourceTypeDPLL, s.SourceType)
+			assert.Equal(t, "CUSTOM_PIN", s.BoardLabel)
+		}
+	}
+	assert.True(t, foundGNSS, "template GNSS source should be present")
+	assert.True(t, foundCustom, "unmatched user source should be added")
+}
+
+func TestDeriveBehavior_UserConditionsPreserved(t *testing.T) {
+	fakeClient := fake.NewClientset()
+	hcm := NewHardwareConfigManager(fakeClient, "default", nil)
+
+	clockType := testClockTypeTGM
+	hwConfig := &ptpv2alpha1.HardwareConfig{
+		Spec: ptpv2alpha1.HardwareConfigSpec{
+			Profile: ptpv2alpha1.HardwareProfile{
+				ClockType: &clockType,
+				ClockChain: &ptpv2alpha1.ClockChain{
+					Structure: []ptpv2alpha1.Subsystem{
+						{
+							Name:                        testSubsystemLeader,
+							HardwareSpecificDefinitions: HwDefIntelE825,
+							DPLL: ptpv2alpha1.DPLL{
+								NetworkInterface: testIfaceEns7f0,
+							},
+							Ethernet: []ptpv2alpha1.Ethernet{
+								{Ports: []string{testIfaceEns7f0}},
+							},
+						},
+					},
+					Behavior: &ptpv2alpha1.Behavior{
+						// User overrides "Initialize T-GM" with custom desired states
+						Conditions: []ptpv2alpha1.Condition{
+							{
+								Name: "Initialize T-GM",
+								DesiredStates: []ptpv2alpha1.DesiredState{
+									{DPLL: &ptpv2alpha1.DPLLDesiredState{
+										Subsystem:  testSubsystemLeader,
+										BoardLabel: "USER_OVERRIDE_PIN",
+									}},
+								},
+							},
+							{
+								Name: "Custom User Condition",
+								DesiredStates: []ptpv2alpha1.DesiredState{
+									{DPLL: &ptpv2alpha1.DPLLDesiredState{
+										Subsystem:  testSubsystemLeader,
+										BoardLabel: "USER_PIN",
+									}},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	err := hcm.deriveBehavior(hwConfig, clockType)
+	assert.NoError(t, err)
+
+	behavior := hwConfig.Spec.Profile.ClockChain.Behavior
+	require.NotNil(t, behavior)
+
+	// "Initialize T-GM" should be the user's version (overrides template)
+	initCond := findConditionByName(behavior.Conditions, "Initialize T-GM")
+	require.NotNil(t, initCond, "Initialize T-GM should be present")
+	require.Len(t, initCond.DesiredStates, 1)
+	assert.Equal(t, "USER_OVERRIDE_PIN", initCond.DesiredStates[0].DPLL.BoardLabel,
+		"User condition should override template condition")
+
+	// "Custom User Condition" should be preserved (unmatched, appended)
+	customCond := findConditionByName(behavior.Conditions, "Custom User Condition")
+	require.NotNil(t, customCond, "Unmatched user condition should be appended")
+	assert.Equal(t, "USER_PIN", customCond.DesiredStates[0].DPLL.BoardLabel)
+
+	// Template sources should still be present
+	assert.NotEmpty(t, behavior.Sources, "Template sources should be derived")
 }

--- a/pkg/hardwareconfig/clockchain_resolution_test.go
+++ b/pkg/hardwareconfig/clockchain_resolution_test.go
@@ -293,6 +293,104 @@ func TestClockChainResolution(t *testing.T) {
 	}
 }
 
+// TestClockChainResolution_TGM verifies that a T-GM HardwareConfig skips
+// upstream port derivation (no PTP time receivers), PhaseInputs derivation,
+// and Ethernet derivation — none of which apply for grandmaster operation.
+func TestClockChainResolution_TGM(t *testing.T) {
+	hwConfig, err := loadHardwareConfigFromFile("testdata/gnrd-hwconfig-minimal-tgm.yaml")
+	require.NoError(t, err)
+	require.NotNil(t, hwConfig)
+
+	assert.Equal(t, ClockTypeTGM, *hwConfig.Spec.Profile.ClockType)
+	subsystem := hwConfig.Spec.Profile.ClockChain.Structure[0]
+	assert.Equal(t, testSubsystemLeader, subsystem.Name)
+	assert.Equal(t, HwDefIntelE825, subsystem.HardwareSpecificDefinitions)
+
+	// T-GM provides networkInterface directly (no upstream port derivation)
+	assert.Equal(t, testIfaceEns7f0, subsystem.DPLL.NetworkInterface)
+
+	ptpConfig, err := loadPtpConfigFromFile("testdata/tgm-gnrd.yaml")
+	require.NoError(t, err)
+	require.NotNil(t, ptpConfig)
+
+	// T-GM ptpconfig should have no upstream ports (all masterOnly=1)
+	var ptpProfile *ptpv1.PtpProfile
+	for i := range ptpConfig.Spec.Profile {
+		if ptpConfig.Spec.Profile[i].Name != nil &&
+			ProfileNamesMatch(*ptpConfig.Spec.Profile[i].Name, hwConfig.Spec.RelatedPtpProfileName) {
+			ptpProfile = &ptpConfig.Spec.Profile[i]
+			break
+		}
+	}
+	require.NotNil(t, ptpProfile)
+	upstreamPorts := extractUpstreamPortsFromPtpProfile(ptpProfile)
+	assert.Empty(t, upstreamPorts, "T-GM should have no upstream ports")
+
+	fakeClient := fake.NewClientset()
+	hcm := NewHardwareConfigManager(fakeClient, "default", nil)
+	resolvedConfig, err := hcm.ResolveClockChain(hwConfig, ptpConfig)
+	require.NoError(t, err)
+	require.NotNil(t, resolvedConfig)
+
+	resolved := resolvedConfig.Spec.Profile.ClockChain.Structure[0]
+
+	// NetworkInterface should be preserved (not derived from upstream)
+	assert.Equal(t, testIfaceEns7f0, resolved.DPLL.NetworkInterface)
+
+	// T-GM should NOT derive PTP-related PhaseInputs or Ethernet from upstream ports.
+	// (PhaseInputs may still contain pins from delay compensation injection.)
+	if len(resolved.DPLL.PhaseInputs) > 0 {
+		_, hasPtpInput := resolved.DPLL.PhaseInputs["GNR-D_SDP0"]
+		assert.False(t, hasPtpInput, "T-GM should not derive PTP input pin GNR-D_SDP0")
+	}
+	assert.Empty(t, resolved.Ethernet, "T-GM should not derive Ethernet ports")
+
+	// Behavior should still be derived from template
+	assert.NotNil(t, resolvedConfig.Spec.Profile.ClockChain.Behavior)
+	behavior := resolvedConfig.Spec.Profile.ClockChain.Behavior
+	assert.NotEmpty(t, behavior.Sources)
+
+	// Should have GNSS source (not PTP)
+	var gnssSource *ptpv2alpha1.SourceConfig
+	for i, s := range behavior.Sources {
+		if s.SourceType == ptpv2alpha1.SourceTypeGNSS {
+			gnssSource = &behavior.Sources[i]
+			break
+		}
+	}
+	assert.NotNil(t, gnssSource, "T-GM should have GNSS source")
+	if gnssSource != nil {
+		assert.Equal(t, "GNSS_1PPS_IN", gnssSource.BoardLabel)
+	}
+
+	// Should have Initialize T-GM condition
+	initCondition := findConditionByName(behavior.Conditions, "Initialize T-GM")
+	assert.NotNil(t, initCondition, "T-GM should have Initialize T-GM condition")
+}
+
+// TestClockChainResolution_TGM_DeriveNetworkInterface verifies that a T-GM
+// config without networkInterface auto-derives it from any interface in the
+// PTP config, using the same leading-interface resolution as T-BC.
+// TestClockChainResolution_TGM_MissingNetworkInterface verifies that a T-GM
+// config without networkInterface returns a clear error, since T-GM cannot
+// derive it from upstream ports.
+func TestClockChainResolution_TGM_MissingNetworkInterface(t *testing.T) {
+	hwConfig, err := loadHardwareConfigFromFile("testdata/gnrd-hwconfig-minimal-tgm.yaml")
+	require.NoError(t, err)
+
+	// Remove networkInterface to trigger the validation
+	hwConfig.Spec.Profile.ClockChain.Structure[0].DPLL.NetworkInterface = ""
+
+	ptpConfig, err := loadPtpConfigFromFile("testdata/tgm-gnrd.yaml")
+	require.NoError(t, err)
+
+	fakeClient := fake.NewClientset()
+	hcm := NewHardwareConfigManager(fakeClient, "default", nil)
+	_, err = hcm.ResolveClockChain(hwConfig, ptpConfig)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "networkInterface is required for T-GM subsystem")
+}
+
 // TestClockChainResolution_DualUpstream verifies that a minimal HardwareConfig
 // paired with a PTP config containing two masterOnly=0 ports correctly derives
 // both upstream ports into PTPTimeReceivers and Ethernet.

--- a/pkg/hardwareconfig/clockchain_resolution_test.go
+++ b/pkg/hardwareconfig/clockchain_resolution_test.go
@@ -371,24 +371,62 @@ func TestClockChainResolution_TGM(t *testing.T) {
 // TestClockChainResolution_TGM_DeriveNetworkInterface verifies that a T-GM
 // config without networkInterface auto-derives it from any interface in the
 // PTP config, using the same leading-interface resolution as T-BC.
-// TestClockChainResolution_TGM_MissingNetworkInterface verifies that a T-GM
-// config without networkInterface returns a clear error, since T-GM cannot
-// derive it from upstream ports.
-func TestClockChainResolution_TGM_MissingNetworkInterface(t *testing.T) {
+// TestClockChainResolution_TGM_DeriveNetworkInterface verifies that a T-GM
+// config without networkInterface auto-derives it from any interface in the
+// PTP config, using the same leading-interface resolution as T-BC.
+func TestClockChainResolution_TGM_DeriveNetworkInterface(t *testing.T) {
 	hwConfig, err := loadHardwareConfigFromFile("testdata/gnrd-hwconfig-minimal-tgm.yaml")
 	require.NoError(t, err)
 
-	// Remove networkInterface to trigger the validation
+	// Remove networkInterface to trigger auto-derive
 	hwConfig.Spec.Profile.ClockChain.Structure[0].DPLL.NetworkInterface = ""
 
 	ptpConfig, err := loadPtpConfigFromFile("testdata/tgm-gnrd.yaml")
 	require.NoError(t, err)
 
+	// T-GM ptpconfig has ens7f0 with masterOnly=1; auto-derive should use it
+	allIfaces := extractInterfacesFromPtpProfile(&ptpConfig.Spec.Profile[0])
+	require.NotEmpty(t, allIfaces, "PTP config should have at least one interface")
+	assert.Equal(t, testIfaceEns7f0, allIfaces[0])
+
+	// Mock leading interface resolver: ens7f0 -> ptp0 -> PCI -> ens7f0
+	mockResolver := newMockLeadingInterfaceResolver()
+	mockResolver.phcIDs[testIfaceEns7f0] = testDevPtp0
+	mockResolver.symlinks["/sys/class/ptp/ptp0/device"] = "../../../0000:51:00.0"
+	mockResolver.dirEntries["/sys/bus/pci/devices/0000:51:00.0/net"] = []os.DirEntry{
+		&mockDirEntry{name: testIfaceEns7f0, isDir: false},
+	}
+	SetLeadingInterfaceResolver(mockResolver)
+	defer ResetLeadingInterfaceResolver()
+
+	fakeClient := fake.NewClientset()
+	hcm := NewHardwareConfigManager(fakeClient, "default", nil)
+	resolved, err := hcm.ResolveClockChain(hwConfig, ptpConfig)
+	require.NoError(t, err)
+
+	assert.Equal(t, testIfaceEns7f0, resolved.Spec.Profile.ClockChain.Structure[0].DPLL.NetworkInterface,
+		"NetworkInterface should be auto-derived from T-GM PTP config interface")
+}
+
+// TestClockChainResolution_TGM_NoInterfaces verifies that a T-GM config
+// with no interfaces in the PTP config returns a clear error.
+func TestClockChainResolution_TGM_NoInterfaces(t *testing.T) {
+	hwConfig, err := loadHardwareConfigFromFile("testdata/gnrd-hwconfig-minimal-tgm.yaml")
+	require.NoError(t, err)
+
+	hwConfig.Spec.Profile.ClockChain.Structure[0].DPLL.NetworkInterface = ""
+
+	// Create a PTP config with no interface sections (only [global])
+	emptyConf := "[global]\nmasterOnly 1\n"
+	ptpConfig, err := loadPtpConfigFromFile("testdata/tgm-gnrd.yaml")
+	require.NoError(t, err)
+	ptpConfig.Spec.Profile[0].Ptp4lConf = &emptyConf
+
 	fakeClient := fake.NewClientset()
 	hcm := NewHardwareConfigManager(fakeClient, "default", nil)
 	_, err = hcm.ResolveClockChain(hwConfig, ptpConfig)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "networkInterface is required for T-GM subsystem")
+	assert.Contains(t, err.Error(), "no interfaces found in ptpconfig for T-GM subsystem")
 }
 
 // TestClockChainResolution_DualUpstream verifies that a minimal HardwareConfig

--- a/pkg/hardwareconfig/gnss.go
+++ b/pkg/hardwareconfig/gnss.go
@@ -1,0 +1,163 @@
+package hardwareconfig
+
+import (
+	"fmt"
+	"slices"
+
+	"github.com/golang/glog"
+	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/ublox"
+	ptpv1 "github.com/k8snetworkplumbingwg/ptp-operator/api/v1"
+	ptpv2alpha1 "github.com/k8snetworkplumbingwg/ptp-operator/api/v2alpha1"
+)
+
+const (
+	surveyInWait = "5"
+)
+
+// ubxtoolConstellationName maps ConstellationID to the name used by ubxtool -e / -d.
+// Most names match directly; GLONAS is the API spelling while ubxtool uses GLONASS.
+var ubxtoolConstellationName = map[ptpv2alpha1.ConstellationID]string{
+	ptpv2alpha1.ConstellationGPS:     "GPS",
+	ptpv2alpha1.ConstellationGalileo: "GALILEO",
+	ptpv2alpha1.ConstellationGLONASS: "GLONASS",
+	ptpv2alpha1.ConstellationBeiDou:  "BEIDOU",
+	ptpv2alpha1.ConstellationSBAS:    "SBAS",
+}
+
+// allConstellationIDs lists all known ConstellationIDs in a stable order for
+// deterministic enable/disable command generation.
+var allConstellationIDs = []ptpv2alpha1.ConstellationID{
+	ptpv2alpha1.ConstellationGPS,
+	ptpv2alpha1.ConstellationGalileo,
+	ptpv2alpha1.ConstellationGLONASS,
+	ptpv2alpha1.ConstellationBeiDou,
+	ptpv2alpha1.ConstellationSBAS,
+}
+
+// antennaVoltageCommand returns the command to enable or disable antenna voltage
+// (CFG-HW-ANT_CFG_VOLTCTRL).
+func antennaVoltageCommand(enabled bool) ublox.Command {
+	val := "0"
+	if enabled {
+		val = "1"
+	}
+	return ublox.Command{
+		Args: []string{"-z", fmt.Sprintf("CFG-HW-ANT_CFG_VOLTCTRL,%s", val)},
+	}
+}
+
+// constellationCommand returns a single batched command that enables the
+// requested constellations and disables any known constellations not in the list.
+// Uses ubxtool's -e (enable) and -d (disable) flags with constellation names.
+func constellationCommand(enabled []ptpv2alpha1.ConstellationID) ublox.Command {
+	cmd := ublox.Command{}
+	for _, id := range allConstellationIDs {
+		name := ubxtoolConstellationName[id]
+		if slices.Contains(enabled, id) {
+			cmd.Args = append(cmd.Args, "-e", name)
+		} else {
+			cmd.Args = append(cmd.Args, "-d", name)
+		}
+	}
+	return cmd
+}
+
+// surveyInCommand returns the command to start a GNSS survey-in operation.
+// Uses ubxtool's -e SURVEYIN,<duration_s>,<accuracy_0.1mm> syntax with the
+// appropriate wait time and verbosity for survey acknowledgment.
+func surveyInCommand(survey ptpv2alpha1.GNSSSurveyParameters) ublox.Command {
+	// GNSSSurveyParameters.Accuracy is in meters; ubxtool wants 0.1mm units
+	accLimit := survey.Accuracy * 10000
+
+	return ublox.Command{
+		Args: []string{
+			"-t", "-w", surveyInWait, "-v", "1",
+			"-e", fmt.Sprintf("SURVEYIN,%d,%d", survey.ObservationTime, accLimit),
+		},
+		ReportOutput: true,
+	}
+}
+
+// GetGNSSSerialPort finds the GNSS source in the hardware config for the given
+// profile and resolves its TTY device path. Returns empty string if no GNSS
+// source is configured or the profile has no hardware config.
+func (hcm *HardwareConfigManager) GetGNSSSerialPort(nodeProfile *ptpv1.PtpProfile) (string, error) {
+	source, _ := hcm.findGNSSSource(nodeProfile)
+	if source == nil {
+		return "", nil
+	}
+	return FindGNSSDevice(source.GNSSConfig.Match)
+}
+
+// GetGNSSInitCommands returns the ublox initialization commands for the GNSS
+// source in the hardware config for the given profile. Returns nil if no GNSS
+// source is configured. The returned commands should be passed to ublox.NewUblox()
+// to run as part of the standard initialization sequence.
+func (hcm *HardwareConfigManager) GetGNSSInitCommands(nodeProfile *ptpv1.PtpProfile) ublox.CommandList {
+	source, gnssConfig := hcm.findGNSSSource(nodeProfile)
+	if source == nil {
+		return nil
+	}
+
+	glog.Infof("Building GNSS init commands for source %q", source.Name)
+	return buildGNSSInitCommands(gnssConfig)
+}
+
+// buildGNSSInitCommands converts a GNSSConfig into the ordered list of ubxtool commands.
+func buildGNSSInitCommands(config *ptpv2alpha1.GNSSConfig) ublox.CommandList {
+	var cmds ublox.CommandList
+
+	// 1. Antenna voltage control
+	cmds = append(cmds, antennaVoltageCommand(config.Init.AntennaVoltage))
+
+	// 2. Constellation enable/disable
+	cmds = append(cmds, constellationCommand(config.Init.Constellations))
+
+	// 3. Survey-in parameters (skip if observation time is zero)
+	if config.Init.SurveyIn.ObservationTime > 0 {
+		cmds = append(cmds, surveyInCommand(config.Init.SurveyIn))
+	}
+
+	// 4. User-supplied extra commands
+	for _, extra := range config.Init.ExtraCommands {
+		cmds = append(cmds, ublox.Command{
+			Args:         extra.Args,
+			ReportOutput: extra.Record,
+		})
+	}
+
+	return cmds
+}
+
+// findGNSSSource locates the first GNSS source in the hardware configs for the
+// given profile. Returns the source config and its GNSSConfig, or nil if none found.
+func (hcm *HardwareConfigManager) findGNSSSource(nodeProfile *ptpv1.PtpProfile) (*ptpv2alpha1.SourceConfig, *ptpv2alpha1.GNSSConfig) {
+	for _, profile := range hcm.GetHardwareConfigsForProfile(nodeProfile) {
+		if profile.ClockChain == nil || profile.ClockChain.Behavior == nil {
+			continue
+		}
+		for i, source := range profile.ClockChain.Behavior.Sources {
+			if source.SourceType == ptpv2alpha1.SourceTypeGNSS && source.GNSSConfig != nil {
+				return &profile.ClockChain.Behavior.Sources[i], source.GNSSConfig
+			}
+		}
+	}
+	return nil, nil
+}
+
+// FindGNSSDevice resolves the GNSS TTY device path from a GNSSMatcher.
+// If matcher specifies a TTYDevice, it is returned directly.
+// If matcher specifies an EthernetInterface, the device is looked up via sysfs.
+// If matcher is nil, returns empty string (caller should auto-detect).
+func FindGNSSDevice(matcher *ptpv2alpha1.GNSSMatcher) (string, error) {
+	if matcher == nil {
+		return "", nil
+	}
+	if matcher.TTYDevice != "" {
+		return matcher.TTYDevice, nil
+	}
+	if matcher.EthernetInterface != "" {
+		return ublox.GNSSDeviceFromInterface(matcher.EthernetInterface)
+	}
+	return "", fmt.Errorf("GNSSMatcher has neither ttyDevice nor ethernetInterface set")
+}

--- a/pkg/hardwareconfig/gnss_test.go
+++ b/pkg/hardwareconfig/gnss_test.go
@@ -26,7 +26,7 @@ const (
 	testIfaceEns7f0     = "ens7f0"
 	testSubsystemLeader = "leader"
 	testDevPtp0         = "/dev/ptp0"
-	testClockTypeTGM    = "T-GM"
+	testClockTypeTGM    = ClockTypeTGM
 	testSurveyInArgs    = "SURVEYIN,600,50000"
 	testMonHW           = "MON-HW"
 	testCfgMsg          = "CFG-MSG,1,38,248"

--- a/pkg/hardwareconfig/gnss_test.go
+++ b/pkg/hardwareconfig/gnss_test.go
@@ -1,0 +1,627 @@
+package hardwareconfig
+
+import (
+	"errors"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/ublox"
+	ptpv1 "github.com/k8snetworkplumbingwg/ptp-operator/api/v1"
+	ptpv2alpha1 "github.com/k8snetworkplumbingwg/ptp-operator/api/v2alpha1"
+)
+
+// Test constants to avoid goconst warnings
+const (
+	testProtoVersion    = "29.20"
+	testProtoVersion2   = "29.25"
+	testAntVoltEnable   = "CFG-HW-ANT_CFG_VOLTCTRL,1"
+	testProfileName     = "tgm_grandmaster" // stored name with clock-type prefix
+	testHWConfigName    = "grandmaster"     // plain relatedPtpProfileName
+	testSourcePTP       = "PTP"
+	testSourceGNSS      = "GNSS"
+	testIfaceEno8703    = "eno8703"
+	testIfaceEns7f0     = "ens7f0"
+	testSubsystemLeader = "leader"
+	testDevPtp0         = "/dev/ptp0"
+	testClockTypeTGM    = "T-GM"
+	testSurveyInArgs    = "SURVEYIN,600,50000"
+	testMonHW           = "MON-HW"
+	testCfgMsg          = "CFG-MSG,1,38,248"
+)
+
+// --- Mock helpers ---
+
+// mockRunner implements ublox.Runner for testing, recording all commands.
+type mockRunner struct {
+	commands      []ublox.Command
+	defaultOutput string
+	defaultErr    error
+}
+
+func (m *mockRunner) Run(cmd ublox.Command) (string, error) {
+	m.commands = append(m.commands, cmd)
+	return m.defaultOutput, m.defaultErr
+}
+
+func (m *mockRunner) RunAll(cmds ublox.CommandList, withSave bool) []string {
+	var results []string
+	for _, cmd := range cmds {
+		output, err := m.Run(cmd)
+		if cmd.ReportOutput {
+			if err != nil {
+				results = append(results, err.Error())
+			} else {
+				results = append(results, output)
+			}
+		}
+	}
+	if withSave {
+		m.Run(ublox.SaveCommand) //nolint:errcheck
+	}
+	return results
+}
+
+func (m *mockRunner) Save() error {
+	_, err := m.Run(ublox.SaveCommand)
+	return err
+}
+
+func (m *mockRunner) containsCommand(substrs ...string) bool {
+	for _, cmd := range m.commands {
+		joined := strings.Join(cmd.Args, " ")
+		allFound := true
+		for _, s := range substrs {
+			if !strings.Contains(joined, s) {
+				allFound = false
+				break
+			}
+		}
+		if allFound {
+			return true
+		}
+	}
+	return false
+}
+
+func setupRunnerMock() (*mockRunner, func()) {
+	orig := ublox.NewCommandRunnerFn
+	mock := &mockRunner{defaultOutput: "OK"}
+	ublox.NewCommandRunnerFn = func() (ublox.Runner, error) {
+		return mock, nil
+	}
+	return mock, func() { ublox.NewCommandRunnerFn = orig }
+}
+
+// Reuses mockDirEntry from clockchain_resolution_test.go (pointer receiver, same package)
+
+func setupReadDirMock(entries map[string][]os.DirEntry, errs map[string]error) func() {
+	orig := ublox.ReadDir
+	ublox.ReadDir = func(name string) ([]os.DirEntry, error) {
+		if errs != nil {
+			if err, ok := errs[name]; ok {
+				return nil, err
+			}
+		}
+		if entries != nil {
+			if e, ok := entries[name]; ok {
+				return e, nil
+			}
+		}
+		return nil, errors.New("not found")
+	}
+	return func() { ublox.ReadDir = orig }
+}
+
+// --- Tests ---
+
+func TestAntennaVoltageCommand(t *testing.T) {
+	t.Run("enabled", func(t *testing.T) {
+		cmd := antennaVoltageCommand(true)
+		assert.Equal(t, []string{"-z", testAntVoltEnable}, cmd.Args)
+		assert.False(t, cmd.ReportOutput)
+	})
+
+	t.Run("disabled", func(t *testing.T) {
+		cmd := antennaVoltageCommand(false)
+		assert.Equal(t, []string{"-z", "CFG-HW-ANT_CFG_VOLTCTRL,0"}, cmd.Args)
+	})
+}
+
+// extractConstellationFlags parses the batched args of a constellation command,
+// returning the names following -e and -d flags separately.
+func extractConstellationFlags(cmd ublox.Command) (enabled, disabled []string) {
+	for i := 0; i < len(cmd.Args)-1; i += 2 {
+		switch cmd.Args[i] {
+		case "-e":
+			enabled = append(enabled, cmd.Args[i+1])
+		case "-d":
+			disabled = append(disabled, cmd.Args[i+1])
+		}
+	}
+	return
+}
+
+func TestConstellationCommand(t *testing.T) {
+	t.Run("GPS only", func(t *testing.T) {
+		cmd := constellationCommand([]ptpv2alpha1.ConstellationID{ptpv2alpha1.ConstellationGPS})
+		enabled, disabled := extractConstellationFlags(cmd)
+
+		assert.Equal(t, []string{ubxtoolConstellationName[ptpv2alpha1.ConstellationGPS]}, enabled)
+		assert.ElementsMatch(t, []string{
+			ubxtoolConstellationName[ptpv2alpha1.ConstellationGalileo],
+			ubxtoolConstellationName[ptpv2alpha1.ConstellationGLONASS],
+			ubxtoolConstellationName[ptpv2alpha1.ConstellationBeiDou],
+			ubxtoolConstellationName[ptpv2alpha1.ConstellationSBAS],
+		}, disabled)
+	})
+
+	t.Run("multiple constellations", func(t *testing.T) {
+		cmd := constellationCommand([]ptpv2alpha1.ConstellationID{
+			ptpv2alpha1.ConstellationGPS,
+			ptpv2alpha1.ConstellationGalileo,
+			ptpv2alpha1.ConstellationBeiDou,
+		})
+		enabled, disabled := extractConstellationFlags(cmd)
+
+		assert.ElementsMatch(t, []string{
+			ubxtoolConstellationName[ptpv2alpha1.ConstellationGPS],
+			ubxtoolConstellationName[ptpv2alpha1.ConstellationGalileo],
+			ubxtoolConstellationName[ptpv2alpha1.ConstellationBeiDou],
+		}, enabled)
+		assert.ElementsMatch(t, []string{
+			ubxtoolConstellationName[ptpv2alpha1.ConstellationGLONASS],
+			ubxtoolConstellationName[ptpv2alpha1.ConstellationSBAS],
+		}, disabled)
+	})
+
+	t.Run("GLONASS maps to GLONASS for ubxtool", func(t *testing.T) {
+		cmd := constellationCommand([]ptpv2alpha1.ConstellationID{ptpv2alpha1.ConstellationGLONASS})
+		enabled, _ := extractConstellationFlags(cmd)
+
+		assert.Contains(t, enabled, ubxtoolConstellationName[ptpv2alpha1.ConstellationGLONASS],
+			"GLONASS should map to GLONASS for ubxtool")
+	})
+
+	t.Run("empty list disables all", func(t *testing.T) {
+		cmd := constellationCommand(nil)
+		enabled, disabled := extractConstellationFlags(cmd)
+
+		assert.Empty(t, enabled, "no constellations should be enabled")
+		assert.Equal(t, len(allConstellationIDs), len(disabled), "all constellations should be disabled")
+	})
+}
+
+func TestSurveyInCommand(t *testing.T) {
+	t.Run("standard parameters", func(t *testing.T) {
+		cmd := surveyInCommand(ptpv2alpha1.GNSSSurveyParameters{
+			ObservationTime: 600,
+			Accuracy:        5,
+		})
+
+		assert.Equal(t, []string{
+			"-t", "-w", "5", "-v", "1",
+			"-e", testSurveyInArgs,
+		}, cmd.Args)
+		assert.True(t, cmd.ReportOutput)
+	})
+
+	t.Run("1 meter accuracy", func(t *testing.T) {
+		cmd := surveyInCommand(ptpv2alpha1.GNSSSurveyParameters{
+			ObservationTime: 300,
+			Accuracy:        1,
+		})
+		assert.Contains(t, cmd.Args, "SURVEYIN,300,10000")
+	})
+}
+
+func TestBuildGNSSInitCommands(t *testing.T) {
+	config := &ptpv2alpha1.GNSSConfig{
+		Init: ptpv2alpha1.GNSSInit{
+			AntennaVoltage: true,
+			Constellations: []ptpv2alpha1.ConstellationID{ptpv2alpha1.ConstellationGPS},
+			SurveyIn: ptpv2alpha1.GNSSSurveyParameters{
+				ObservationTime: 600,
+				Accuracy:        5,
+			},
+			ExtraCommands: []ptpv2alpha1.UBLXCommand{
+				{Args: []string{"-p", testMonHW}, Record: true},
+				{Args: []string{"-p", testCfgMsg}, Record: true},
+			},
+		},
+	}
+
+	cmds := buildGNSSInitCommands(config)
+
+	// 1 antenna + 1 constellation (batched) + 1 survey + 2 extras = 5
+	assert.Equal(t, 5, len(cmds))
+
+	// First: antenna voltage
+	assert.Equal(t, []string{"-z", testAntVoltEnable}, cmds[0].Args)
+
+	// Second: batched constellation command
+	enabledConst, disabledConst := extractConstellationFlags(cmds[1])
+	assert.Equal(t, []string{ubxtoolConstellationName[ptpv2alpha1.ConstellationGPS]}, enabledConst)
+	assert.ElementsMatch(t, []string{
+		ubxtoolConstellationName[ptpv2alpha1.ConstellationGalileo],
+		ubxtoolConstellationName[ptpv2alpha1.ConstellationGLONASS],
+		ubxtoolConstellationName[ptpv2alpha1.ConstellationBeiDou],
+		ubxtoolConstellationName[ptpv2alpha1.ConstellationSBAS],
+	}, disabledConst)
+
+	// Survey-in
+	assert.Contains(t, cmds[2].Args, testSurveyInArgs)
+	assert.True(t, cmds[2].ReportOutput)
+
+	// Extra commands
+	assert.Equal(t, []string{"-p", testMonHW}, cmds[3].Args)
+	assert.True(t, cmds[3].ReportOutput)
+	assert.Equal(t, []string{"-p", testCfgMsg}, cmds[4].Args)
+	assert.True(t, cmds[4].ReportOutput)
+}
+
+func TestBuildGNSSInitCommands_NoSurvey(t *testing.T) {
+	config := &ptpv2alpha1.GNSSConfig{
+		Init: ptpv2alpha1.GNSSInit{
+			AntennaVoltage: true,
+			Constellations: []ptpv2alpha1.ConstellationID{ptpv2alpha1.ConstellationGPS},
+			SurveyIn: ptpv2alpha1.GNSSSurveyParameters{
+				ObservationTime: 0,
+				Accuracy:        5,
+			},
+		},
+	}
+
+	cmds := buildGNSSInitCommands(config)
+
+	// 1 antenna + 1 constellation = 2 (no survey-in)
+	assert.Equal(t, 2, len(cmds))
+
+	// Verify no SURVEYIN command
+	for _, cmd := range cmds {
+		for _, arg := range cmd.Args {
+			assert.NotContains(t, arg, "SURVEYIN", "should not contain SURVEYIN when ObservationTime is 0")
+		}
+	}
+}
+
+// TestBuildGNSSInitCommands_MatchesOldPluginPattern verifies that the commands
+// from buildGNSSInitCommands match what cnfdg60-tgm.yaml expressed via ublxCmds.
+func TestBuildGNSSInitCommands_MatchesOldPluginPattern(t *testing.T) {
+	mock, restore := setupRunnerMock()
+	defer restore()
+
+	config := &ptpv2alpha1.GNSSConfig{
+		Init: ptpv2alpha1.GNSSInit{
+			AntennaVoltage: true,
+			Constellations: []ptpv2alpha1.ConstellationID{ptpv2alpha1.ConstellationGPS},
+			SurveyIn: ptpv2alpha1.GNSSSurveyParameters{
+				ObservationTime: 600,
+				Accuracy:        5,
+			},
+			ExtraCommands: []ptpv2alpha1.UBLXCommand{
+				{Args: []string{"-p", testMonHW}, Record: true},
+				{Args: []string{"-p", testCfgMsg}, Record: true},
+			},
+		},
+	}
+
+	cmds := buildGNSSInitCommands(config)
+	_ = cmds.RunAll(true) // uses mock runner
+
+	// Verify the old-style commands are all present
+	expectedPatterns := []string{
+		testAntVoltEnable, // antenna voltage on
+		"-e GPS",          // enable GPS
+		"-d GALILEO",      // disable Galileo
+		"-d GLONASS",      // disable GLONASS
+		"-d BEIDOU",       // disable BeiDou
+		"-d SBAS",         // disable SBAS
+		testSurveyInArgs,  // survey-in 600s, 5m accuracy
+		testMonHW,         // extra: hardware status
+		testCfgMsg,        // extra: message rate
+		"SAVE",            // save (always last)
+	}
+
+	for _, pattern := range expectedPatterns {
+		assert.True(t, mock.containsCommand(pattern),
+			"expected command containing %q", pattern)
+	}
+}
+
+func TestFindGNSSDevice(t *testing.T) {
+	t.Run("nil matcher returns empty", func(t *testing.T) {
+		device, err := FindGNSSDevice(nil)
+		assert.NoError(t, err)
+		assert.Empty(t, device)
+	})
+
+	t.Run("ttyDevice returned directly", func(t *testing.T) {
+		device, err := FindGNSSDevice(&ptpv2alpha1.GNSSMatcher{
+			TTYDevice: "/dev/ttyACM0",
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, "/dev/ttyACM0", device)
+	})
+
+	t.Run("ethernetInterface resolves via sysfs", func(t *testing.T) {
+		restoreDir := setupReadDirMock(
+			map[string][]os.DirEntry{
+				"/sys/class/net/eno8703/device/gnss": {&mockDirEntry{name: "gnss0"}},
+			},
+			nil,
+		)
+		defer restoreDir()
+
+		device, err := FindGNSSDevice(&ptpv2alpha1.GNSSMatcher{
+			EthernetInterface: testIfaceEno8703,
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, "/dev/gnss0", device)
+	})
+
+	t.Run("ethernetInterface with no gnss device", func(t *testing.T) {
+		restoreDir := setupReadDirMock(
+			nil,
+			map[string]error{
+				"/sys/class/net/eno8703/device/gnss": errors.New("no such directory"),
+			},
+		)
+		defer restoreDir()
+
+		_, err := FindGNSSDevice(&ptpv2alpha1.GNSSMatcher{
+			EthernetInterface: testIfaceEno8703,
+		})
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "no GNSS device found")
+	})
+
+	t.Run("empty matcher returns error", func(t *testing.T) {
+		_, err := FindGNSSDevice(&ptpv2alpha1.GNSSMatcher{})
+		assert.Error(t, err)
+	})
+}
+
+// --- HardwareConfigManager integration tests ---
+
+func testProfile(name string) *ptpv1.PtpProfile {
+	return &ptpv1.PtpProfile{Name: &name}
+}
+
+func makeTestHCM(configs ...ptpv2alpha1.HardwareConfig) *HardwareConfigManager {
+	hcm := &HardwareConfigManager{
+		hardwareConfigs: make([]enrichedHardwareConfig, len(configs)),
+		hwDefaultsCache: make(map[string]*HardwareDefaults),
+		clockIDCache:    make(map[string]uint64),
+	}
+	for i, c := range configs {
+		hcm.hardwareConfigs[i] = enrichedHardwareConfig{HardwareConfig: c}
+	}
+	return hcm
+}
+
+func TestFindGNSSSource(t *testing.T) {
+	gnssConfig := &ptpv2alpha1.GNSSConfig{
+		Init: ptpv2alpha1.GNSSInit{
+			AntennaVoltage: true,
+			Constellations: []ptpv2alpha1.ConstellationID{ptpv2alpha1.ConstellationGPS},
+			SurveyIn:       ptpv2alpha1.GNSSSurveyParameters{ObservationTime: 600, Accuracy: 5},
+		},
+		Match: &ptpv2alpha1.GNSSMatcher{TTYDevice: "/dev/ttyACM0"},
+	}
+
+	hwConfig := ptpv2alpha1.HardwareConfig{
+		Spec: ptpv2alpha1.HardwareConfigSpec{
+			RelatedPtpProfileName: testHWConfigName,
+			Profile: ptpv2alpha1.HardwareProfile{
+				ClockChain: &ptpv2alpha1.ClockChain{
+					Behavior: &ptpv2alpha1.Behavior{
+						Sources: []ptpv2alpha1.SourceConfig{
+							{Name: testSourcePTP, SourceType: ptpv2alpha1.SourceTypePTP},
+							{Name: testSourceGNSS, SourceType: ptpv2alpha1.SourceTypeGNSS, GNSSConfig: gnssConfig},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	t.Run("finds GNSS source for matching profile", func(t *testing.T) {
+		hcm := makeTestHCM(hwConfig)
+		source, config := hcm.findGNSSSource(testProfile(testProfileName))
+		assert.NotNil(t, source)
+		assert.NotNil(t, config)
+		assert.Equal(t, testSourceGNSS, source.Name)
+		assert.True(t, config.Init.AntennaVoltage)
+	})
+
+	t.Run("returns nil for non-matching profile", func(t *testing.T) {
+		hcm := makeTestHCM(hwConfig)
+		source, config := hcm.findGNSSSource(testProfile("other-profile"))
+		assert.Nil(t, source)
+		assert.Nil(t, config)
+	})
+
+	t.Run("returns nil when no GNSS source", func(t *testing.T) {
+		noGNSS := ptpv2alpha1.HardwareConfig{
+			Spec: ptpv2alpha1.HardwareConfigSpec{
+				RelatedPtpProfileName: testHWConfigName,
+				Profile: ptpv2alpha1.HardwareProfile{
+					ClockChain: &ptpv2alpha1.ClockChain{
+						Behavior: &ptpv2alpha1.Behavior{
+							Sources: []ptpv2alpha1.SourceConfig{
+								{Name: testSourcePTP, SourceType: ptpv2alpha1.SourceTypePTP},
+							},
+						},
+					},
+				},
+			},
+		}
+		hcm := makeTestHCM(noGNSS)
+		source, config := hcm.findGNSSSource(testProfile(testProfileName))
+		assert.Nil(t, source)
+		assert.Nil(t, config)
+	})
+
+	t.Run("returns nil when no behavior", func(t *testing.T) {
+		noBehavior := ptpv2alpha1.HardwareConfig{
+			Spec: ptpv2alpha1.HardwareConfigSpec{
+				RelatedPtpProfileName: testHWConfigName,
+			},
+		}
+		hcm := makeTestHCM(noBehavior)
+		source, config := hcm.findGNSSSource(testProfile(testProfileName))
+		assert.Nil(t, source)
+		assert.Nil(t, config)
+	})
+}
+
+func TestGetGNSSSerialPort(t *testing.T) {
+	t.Run("returns ttyDevice from matcher", func(t *testing.T) {
+		hwConfig := ptpv2alpha1.HardwareConfig{
+			Spec: ptpv2alpha1.HardwareConfigSpec{
+				RelatedPtpProfileName: testHWConfigName,
+				Profile: ptpv2alpha1.HardwareProfile{
+					ClockChain: &ptpv2alpha1.ClockChain{
+						Behavior: &ptpv2alpha1.Behavior{
+							Sources: []ptpv2alpha1.SourceConfig{
+								{
+									Name:       testSourceGNSS,
+									SourceType: ptpv2alpha1.SourceTypeGNSS,
+									GNSSConfig: &ptpv2alpha1.GNSSConfig{
+										Init:  ptpv2alpha1.GNSSInit{},
+										Match: &ptpv2alpha1.GNSSMatcher{TTYDevice: "/dev/ttyACM0"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+		hcm := makeTestHCM(hwConfig)
+		port, err := hcm.GetGNSSSerialPort(testProfile(testProfileName))
+		assert.NoError(t, err)
+		assert.Equal(t, "/dev/ttyACM0", port)
+	})
+
+	t.Run("returns empty when no GNSS source", func(t *testing.T) {
+		hwConfig := ptpv2alpha1.HardwareConfig{
+			Spec: ptpv2alpha1.HardwareConfigSpec{
+				RelatedPtpProfileName: testHWConfigName,
+				Profile: ptpv2alpha1.HardwareProfile{
+					ClockChain: &ptpv2alpha1.ClockChain{
+						Behavior: &ptpv2alpha1.Behavior{
+							Sources: []ptpv2alpha1.SourceConfig{
+								{Name: testSourcePTP, SourceType: ptpv2alpha1.SourceTypePTP},
+							},
+						},
+					},
+				},
+			},
+		}
+		hcm := makeTestHCM(hwConfig)
+		port, err := hcm.GetGNSSSerialPort(testProfile(testProfileName))
+		assert.NoError(t, err)
+		assert.Empty(t, port)
+	})
+
+	t.Run("resolves ethernetInterface via sysfs", func(t *testing.T) {
+		restoreDir := setupReadDirMock(
+			map[string][]os.DirEntry{
+				"/sys/class/net/eno8703/device/gnss": {&mockDirEntry{name: "gnss0"}},
+			}, nil,
+		)
+		defer restoreDir()
+
+		hwConfig := ptpv2alpha1.HardwareConfig{
+			Spec: ptpv2alpha1.HardwareConfigSpec{
+				RelatedPtpProfileName: testHWConfigName,
+				Profile: ptpv2alpha1.HardwareProfile{
+					ClockChain: &ptpv2alpha1.ClockChain{
+						Behavior: &ptpv2alpha1.Behavior{
+							Sources: []ptpv2alpha1.SourceConfig{
+								{
+									Name:       testSourceGNSS,
+									SourceType: ptpv2alpha1.SourceTypeGNSS,
+									GNSSConfig: &ptpv2alpha1.GNSSConfig{
+										Init:  ptpv2alpha1.GNSSInit{},
+										Match: &ptpv2alpha1.GNSSMatcher{EthernetInterface: testIfaceEno8703},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+		hcm := makeTestHCM(hwConfig)
+		port, err := hcm.GetGNSSSerialPort(testProfile(testProfileName))
+		assert.NoError(t, err)
+		assert.Equal(t, "/dev/gnss0", port)
+	})
+}
+
+func TestGetGNSSInitCommands(t *testing.T) {
+	t.Run("returns commands for GNSS source", func(t *testing.T) {
+		hwConfig := ptpv2alpha1.HardwareConfig{
+			Spec: ptpv2alpha1.HardwareConfigSpec{
+				RelatedPtpProfileName: testHWConfigName,
+				Profile: ptpv2alpha1.HardwareProfile{
+					ClockChain: &ptpv2alpha1.ClockChain{
+						Behavior: &ptpv2alpha1.Behavior{
+							Sources: []ptpv2alpha1.SourceConfig{
+								{
+									Name:       testSourceGNSS,
+									SourceType: ptpv2alpha1.SourceTypeGNSS,
+									GNSSConfig: &ptpv2alpha1.GNSSConfig{
+										Init: ptpv2alpha1.GNSSInit{
+											AntennaVoltage: true,
+											Constellations: []ptpv2alpha1.ConstellationID{ptpv2alpha1.ConstellationGPS},
+											SurveyIn:       ptpv2alpha1.GNSSSurveyParameters{ObservationTime: 600, Accuracy: 5},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+		hcm := makeTestHCM(hwConfig)
+
+		cmds := hcm.GetGNSSInitCommands(testProfile(testProfileName))
+		// 1 antenna + 1 constellation (batched) + 1 survey = 3
+		assert.Equal(t, 3, len(cmds))
+
+		// Verify antenna voltage is first
+		assert.Equal(t, []string{"-z", testAntVoltEnable}, cmds[0].Args)
+
+		// Verify survey-in is last with ReportOutput
+		assert.True(t, cmds[2].ReportOutput)
+		assert.Contains(t, cmds[2].Args, testSurveyInArgs)
+	})
+
+	t.Run("returns nil when no GNSS source", func(t *testing.T) {
+		hwConfig := ptpv2alpha1.HardwareConfig{
+			Spec: ptpv2alpha1.HardwareConfigSpec{
+				RelatedPtpProfileName: testHWConfigName,
+				Profile: ptpv2alpha1.HardwareProfile{
+					ClockChain: &ptpv2alpha1.ClockChain{
+						Behavior: &ptpv2alpha1.Behavior{
+							Sources: []ptpv2alpha1.SourceConfig{
+								{Name: testSourcePTP, SourceType: ptpv2alpha1.SourceTypePTP},
+							},
+						},
+					},
+				},
+			},
+		}
+		hcm := makeTestHCM(hwConfig)
+
+		cmds := hcm.GetGNSSInitCommands(testProfile(testProfileName))
+		assert.Nil(t, cmds)
+	})
+}

--- a/pkg/hardwareconfig/hardware-vendor/dell/XR8720t/behavior-profiles.yaml
+++ b/pkg/hardwareconfig/hardware-vendor/dell/XR8720t/behavior-profiles.yaml
@@ -4,6 +4,44 @@
 # Hardware-specific pins (SDP2, SDP0) are hardcoded in the template
 
 behaviorProfiles:
+  t-gm:
+    sources:
+      - name: GNSS
+        sourceType: gnss
+        subsystem: "{subsystem}"
+        boardLabel: GNSS_1PPS_IN
+
+    conditions:
+      - name: "Initialize T-GM"
+        triggers:
+          - conditionType: init
+            sourceName: GNSS
+        desiredStates:
+          - dpll:
+              subsystem: "{subsystem}"
+              boardLabel: GNSS_1PPS_IN
+              eec:
+                state: selectable
+              pps:
+                state: selectable
+          - dpll:
+              subsystem: "{subsystem}"
+              boardLabel: GNSS_10M_IN
+              eec:
+                state: selectable
+              pps:
+                state: selectable
+          - ptpPin:
+              name: SDP2
+              func: Disabled
+              chan: 0
+              sourceName: GNSS
+          - ptpPin:
+              name: SDP0
+              func: Disabled
+              chan: 0
+              sourceName: GNSS
+
   t-bc:
     # Pin role mappings - defines which pins serve which roles
     pinRoles:

--- a/pkg/hardwareconfig/hardware-vendor/hpe/EL140-Gen12/behavior-profiles.yaml
+++ b/pkg/hardwareconfig/hardware-vendor/hpe/EL140-Gen12/behavior-profiles.yaml
@@ -4,6 +4,44 @@
 # Hardware-specific pins (SDP2, SDP0) are hardcoded in the template
 
 behaviorProfiles:
+  t-gm:
+    sources:
+      - name: GNSS
+        sourceType: gnss
+        subsystem: "{subsystem}"
+        boardLabel: GNSS_1PPS_IN
+
+    conditions:
+      - name: "Initialize T-GM"
+        triggers:
+          - conditionType: init
+            sourceName: GNSS
+        desiredStates:
+          - dpll:
+              subsystem: "{subsystem}"
+              boardLabel: GNSS_1PPS_IN
+              eec:
+                state: selectable
+              pps:
+                state: selectable
+          - dpll:
+              subsystem: "{subsystem}"
+              boardLabel: GNSS_10M_IN
+              eec:
+                state: selectable
+              pps:
+                state: selectable
+          - ptpPin:
+              name: SDP2
+              func: Disabled
+              chan: 0
+              sourceName: GNSS
+          - ptpPin:
+              name: SDP0
+              func: Disabled
+              chan: 0
+              sourceName: GNSS
+
   t-bc:
     # Pin role mappings - defines which pins serve which roles
     pinRoles:

--- a/pkg/hardwareconfig/hardware-vendor/intel/e810/behavior-profiles.yaml
+++ b/pkg/hardwareconfig/hardware-vendor/intel/e810/behavior-profiles.yaml
@@ -1,0 +1,53 @@
+# Behavior profiles for Intel E810 hardware
+# Pin names use E810 conventions (GNSS-1PPS, SMA1, SMA2, U.FL1, U.FL2)
+
+behaviorProfiles:
+  t-gm:
+    sources:
+      - name: GNSS
+        sourceType: gnss
+        subsystem: "{subsystem}"
+        boardLabel: GNSS-1PPS
+    conditions:
+      - name: "Initialize T-GM"
+        triggers:
+          - conditionType: init
+            sourceName: GNSS
+        desiredStates:
+          # Connect GNSS to DPLL
+          - dpll:
+              subsystem: "{subsystem}"
+              boardLabel: GNSS-1PPS
+              eec:
+                state: selectable
+              pps:
+                state: selectable
+          # Disable all SMA/U.FL outputs
+          - dpll:
+              subsystem: "{subsystem}"
+              boardLabel: SMA1
+              eec:
+                state: disconnected
+              pps:
+                state: disconnected
+          - dpll:
+              subsystem: "{subsystem}"
+              boardLabel: SMA2
+              eec:
+                state: disconnected
+              pps:
+                state: disconnected
+          - dpll:
+              subsystem: "{subsystem}"
+              boardLabel: U.FL1
+              eec:
+                state: disconnected
+              pps:
+                state: disconnected
+          - dpll:
+              subsystem: "{subsystem}"
+              boardLabel: U.FL2
+              eec:
+                state: disconnected
+              pps:
+                state: disconnected

--- a/pkg/hardwareconfig/hardware-vendor/intel/e810/defaults.yaml
+++ b/pkg/hardwareconfig/hardware-vendor/intel/e810/defaults.yaml
@@ -41,44 +41,6 @@ pinDefaults:
     pps:
       priority: 9
 
-connectorCommands:
-  outputs:
-    SMA1:
-      commands:
-      - type: FSWrite
-        path: /sys/class/net/{interface}/device/ptp/ptp*/pins/SMA1
-        value: "2 1"
-    SMA2:
-      commands:
-      - type: FSWrite
-        path: /sys/class/net/{interface}/device/ptp/ptp*/pins/SMA2
-        value: "2 2"
-        description: Enable SMA2 output
-  inputs:
-    SMA1:
-      commands:
-      - type: FSWrite
-        path: /sys/class/net/{interface}/device/ptp/ptp*/pins/SMA1
-        value: "1 1"
-    SMA2:
-      commands:
-      - type: FSWrite
-        path: /sys/class/net/{interface}/device/ptp/ptp*/pins/SMA2
-        value: "1 2"
-        description: Enable SMA2 input
-  disable:
-    SMA1:
-      commands:
-      - type: FSWrite
-        path: /sys/class/net/{interface}/device/ptp/ptp*/pins/SMA1
-        value: "0 1"
-    SMA2:
-      commands:
-      - type: FSWrite
-        path: /sys/class/net/{interface}/device/ptp/ptp*/pins/SMA2
-        value: "0 2"
-
-
 internalDelays:
   partType: E810-XXVDA4T
   externalInputs:
@@ -132,3 +94,4 @@ pinEsyncCommands:
       type: DPLLWrite
       arguments:
         - eSyncFrequency
+

--- a/pkg/hardwareconfig/hardware-vendor/intel/e825/behavior-profiles.yaml
+++ b/pkg/hardwareconfig/hardware-vendor/intel/e825/behavior-profiles.yaml
@@ -4,6 +4,44 @@
 # Hardware-specific pins (SDP2, SDP0) are hardcoded in the template
 
 behaviorProfiles:
+  t-gm:
+    sources:
+      - name: GNSS
+        sourceType: gnss
+        subsystem: "{subsystem}"
+        boardLabel: GNSS_1PPS_IN
+
+    conditions:
+      - name: "Initialize T-GM"
+        triggers:
+          - conditionType: init
+            sourceName: GNSS
+        desiredStates:
+          - dpll:
+              subsystem: "{subsystem}"
+              boardLabel: GNSS_1PPS_IN
+              eec:
+                state: selectable
+              pps:
+                state: selectable
+          - dpll:
+              subsystem: "{subsystem}"
+              boardLabel: GNSS_10M_IN
+              eec:
+                state: selectable
+              pps:
+                state: selectable
+          - ptpPin:
+              name: SDP2
+              func: Disabled
+              chan: 0
+              sourceName: GNSS
+          - ptpPin:
+              name: SDP0
+              func: Disabled
+              chan: 0
+              sourceName: GNSS
+
   t-bc:
     # Pin role mappings - defines which pins serve which roles
     pinRoles:

--- a/pkg/hardwareconfig/hardwareconfig.go
+++ b/pkg/hardwareconfig/hardwareconfig.go
@@ -630,14 +630,18 @@ func (hcm *HardwareConfigManager) resolveClockChainBehavior(hwConfig ptpv2alpha1
 			return nil, nil, fmt.Errorf("failed to resolve DPLL pin commands for condition %s: %w", condition.Name, err)
 		}
 		glog.Infof("    Condition '%s': resolved %d DPLL commands", condition.Name, len(pinCommands))
-		pinCommandsPerCondition[condition.Name] = pinCommands
+		if len(pinCommands) > 0 {
+			pinCommandsPerCondition[condition.Name] = pinCommands
+		}
 
 		sysFSCommands, err := hcm.resolveSysFSCommands(condition, clockChain)
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to resolve sysFS commands for condition %s: %w", condition.Name, err)
 		}
 		glog.Infof("    Condition '%s': resolved %d sysfs commands", condition.Name, len(sysFSCommands))
-		sysFSCommandsPerCondition[condition.Name] = sysFSCommands
+		if len(sysFSCommands) > 0 {
+			sysFSCommandsPerCondition[condition.Name] = sysFSCommands
+		}
 	}
 	return pinCommandsPerCondition, sysFSCommandsPerCondition, nil
 }

--- a/pkg/hardwareconfig/hardwareconfig.go
+++ b/pkg/hardwareconfig/hardwareconfig.go
@@ -432,14 +432,13 @@ func (hcm *HardwareConfigManager) GetHardwareConfigsForProfile(nodeProfile *ptpv
 	if nodeProfile.Name == nil {
 		return nil
 	}
-
-	var relevantConfigs []ptpv2alpha1.HardwareProfile
+	var profiles []ptpv2alpha1.HardwareProfile
 	for _, hwConfig := range hcm.hardwareConfigs {
 		if ProfileNamesMatch(*nodeProfile.Name, hwConfig.Spec.RelatedPtpProfileName) {
-			relevantConfigs = append(relevantConfigs, hwConfig.Spec.Profile)
+			profiles = append(profiles, hwConfig.Spec.Profile)
 		}
 	}
-	return relevantConfigs
+	return profiles
 }
 
 // ApplyHardwareConfigsForProfile applies hardware configurations for a PTP profile
@@ -1762,10 +1761,12 @@ func (hcm *HardwareConfigManager) getInterfaceNameFromSources(sourceName string,
 		}
 	}
 
-	// For DPLL sources, use the subsystem's network interface from structure
-	if source.SourceType == "dpllPhaseLocked" {
+	// For DPLL and GNSS sources, use the subsystem's network interface from structure.
+	// These source types don't have ptpTimeReceivers; they resolve the interface
+	// from the subsystem's DPLL.NetworkInterface or first Ethernet port.
+	if source.SourceType == ptpv2alpha1.SourceTypeDPLL || source.SourceType == ptpv2alpha1.SourceTypeGNSS {
 		if source.Subsystem == "" {
-			return nil, fmt.Errorf("DPLL source %s has no subsystem specified", sourceName)
+			return nil, fmt.Errorf("%s source %s has no subsystem specified", source.SourceType, sourceName)
 		}
 		// Find the subsystem in the structure section
 		for _, subsystem := range clockChain.Structure {

--- a/pkg/hardwareconfig/hardwareconfig_gnrd_test.go
+++ b/pkg/hardwareconfig/hardwareconfig_gnrd_test.go
@@ -887,12 +887,14 @@ func TestLoadBehaviorProfile_TGM(t *testing.T) {
 	loader := NewBoardLabelMapLoader(fakeClient, "default")
 
 	tests := []struct {
-		name  string
-		hwDef string
+		name           string
+		hwDef          string
+		gnssBoardLabel string
 	}{
-		{"intel/e825", HwDefIntelE825},
-		{"dell/XR8720t", HwDefDellXR8720t},
-		{"hpe/EL140-Gen12", HwDefHPEEL140Gen12},
+		{HwDefIntelE810, HwDefIntelE810, "GNSS-1PPS"},
+		{HwDefIntelE825, HwDefIntelE825, "GNSS_1PPS_IN"},
+		{HwDefDellXR8720t, HwDefDellXR8720t, "GNSS_1PPS_IN"},
+		{HwDefHPEEL140Gen12, HwDefHPEEL140Gen12, "GNSS_1PPS_IN"},
 	}
 
 	for _, tt := range tests {
@@ -907,9 +909,7 @@ func TestLoadBehaviorProfile_TGM(t *testing.T) {
 			assert.NotEmpty(t, template.Sources)
 			assert.Equal(t, testSourceGNSS, template.Sources[0].Name)
 			assert.Equal(t, ptpv2alpha1.SourceTypeGNSS, template.Sources[0].SourceType)
-
-			// GNSS boardLabel should be hardcoded (no pinRoles indirection for T-GM)
-			assert.Equal(t, "GNSS_1PPS_IN", template.Sources[0].BoardLabel)
+			assert.Equal(t, tt.gnssBoardLabel, template.Sources[0].BoardLabel)
 
 			// Should have init condition
 			assert.NotEmpty(t, template.Conditions)

--- a/pkg/hardwareconfig/hardwareconfig_gnrd_test.go
+++ b/pkg/hardwareconfig/hardwareconfig_gnrd_test.go
@@ -680,7 +680,7 @@ func TestLoadBehaviorProfile_DellXR8720t(t *testing.T) {
 	fakeClient := fake.NewClientset()
 	loader := NewBoardLabelMapLoader(fakeClient, "default")
 
-	template, err := LoadBehaviorProfile("dell/XR8720t", "T-BC", loader)
+	template, err := LoadBehaviorProfile("dell/XR8720t", ClockTypeTBC, loader)
 	assert.NoError(t, err, "Should load dell/XR8720t T-BC behavior profile")
 	assert.NotNil(t, template, "Behavior template should not be nil")
 	if template == nil {
@@ -734,13 +734,13 @@ func TestLoadBehaviorProfile_MultiVendor(t *testing.T) {
 	}{
 		{
 			hwDefPath:         HwDefIntelE825,
-			clockType:         "T-BC",
+			clockType:         ClockTypeTBC,
 			expectedPtpInput:  "GNR-D_SDP0",
 			expectedGnssInput: "GNSS_1PPS_IN",
 		},
 		{
 			hwDefPath:         "dell/XR8720t",
-			clockType:         "T-BC",
+			clockType:         ClockTypeTBC,
 			expectedPtpInput:  "ETH01_SDP_TIMESYNC_0",
 			expectedGnssInput: "GNSS_1PPS_IN",
 		},
@@ -897,7 +897,7 @@ func TestLoadBehaviorProfile_TGM(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			template, err := LoadBehaviorProfile(tt.hwDef, "T-GM", loader)
+			template, err := LoadBehaviorProfile(tt.hwDef, testClockTypeTGM, loader)
 			assert.NoError(t, err)
 			if !assert.NotNil(t, template, "T-GM behavior template should exist for %s", tt.name) {
 				return
@@ -925,7 +925,7 @@ func TestDeriveBehavior_MergesUserGNSSConfig(t *testing.T) {
 	fakeClient := fake.NewClientset()
 	hcm := NewHardwareConfigManager(fakeClient, "default", nil)
 
-	clockType := "T-GM"
+	clockType := testClockTypeTGM
 	subsystemName := testSubsystemLeader
 
 	// User provides only gnssConfig on the GNSS source — the template
@@ -1082,7 +1082,7 @@ func TestDeriveBehavior_NoUserBehavior(t *testing.T) {
 	fakeClient := fake.NewClientset()
 	hcm := NewHardwareConfigManager(fakeClient, "default", nil)
 
-	clockType := "T-GM"
+	clockType := testClockTypeTGM
 
 	// No user behavior — everything from template
 	hwConfig := &ptpv2alpha1.HardwareConfig{

--- a/pkg/hardwareconfig/hardwareconfig_gnrd_test.go
+++ b/pkg/hardwareconfig/hardwareconfig_gnrd_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	dpll "github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/dpll-netlink"
 	ptpv1 "github.com/k8snetworkplumbingwg/ptp-operator/api/v1"
@@ -879,4 +880,249 @@ func TestClockIDResolution(t *testing.T) {
 
 	assert.Equal(t, expectedClockID, clockID, "Clock ID should match perla2-pins.json")
 	t.Logf("✓ Clock ID resolved correctly: %#x", clockID)
+}
+
+func TestLoadBehaviorProfile_TGM(t *testing.T) {
+	fakeClient := fake.NewClientset()
+	loader := NewBoardLabelMapLoader(fakeClient, "default")
+
+	tests := []struct {
+		name  string
+		hwDef string
+	}{
+		{"intel/e825", HwDefIntelE825},
+		{"dell/XR8720t", HwDefDellXR8720t},
+		{"hpe/EL140-Gen12", HwDefHPEEL140Gen12},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			template, err := LoadBehaviorProfile(tt.hwDef, "T-GM", loader)
+			assert.NoError(t, err)
+			if !assert.NotNil(t, template, "T-GM behavior template should exist for %s", tt.name) {
+				return
+			}
+
+			// Should have GNSS source
+			assert.NotEmpty(t, template.Sources)
+			assert.Equal(t, testSourceGNSS, template.Sources[0].Name)
+			assert.Equal(t, ptpv2alpha1.SourceTypeGNSS, template.Sources[0].SourceType)
+
+			// GNSS boardLabel should be hardcoded (no pinRoles indirection for T-GM)
+			assert.Equal(t, "GNSS_1PPS_IN", template.Sources[0].BoardLabel)
+
+			// Should have init condition
+			assert.NotEmpty(t, template.Conditions)
+			assert.Equal(t, "Initialize T-GM", template.Conditions[0].Name)
+
+			t.Logf("✓ %s T-GM profile: %d sources, %d conditions",
+				tt.name, len(template.Sources), len(template.Conditions))
+		})
+	}
+}
+
+func TestDeriveBehavior_MergesUserGNSSConfig(t *testing.T) {
+	fakeClient := fake.NewClientset()
+	hcm := NewHardwareConfigManager(fakeClient, "default", nil)
+
+	clockType := "T-GM"
+	subsystemName := testSubsystemLeader
+
+	// User provides only gnssConfig on the GNSS source — the template
+	// provides the DPLL pin details and conditions.
+	hwConfig := &ptpv2alpha1.HardwareConfig{
+		Spec: ptpv2alpha1.HardwareConfigSpec{
+			Profile: ptpv2alpha1.HardwareProfile{
+				ClockType: &clockType,
+				ClockChain: &ptpv2alpha1.ClockChain{
+					Structure: []ptpv2alpha1.Subsystem{
+						{
+							Name:                        subsystemName,
+							HardwareSpecificDefinitions: HwDefDellXR8720t,
+							DPLL: ptpv2alpha1.DPLL{
+								NetworkInterface: testIfaceEno8703,
+							},
+							Ethernet: []ptpv2alpha1.Ethernet{
+								{Ports: []string{testIfaceEno8703}},
+							},
+						},
+					},
+					Behavior: &ptpv2alpha1.Behavior{
+						Sources: []ptpv2alpha1.SourceConfig{
+							{
+								Name:       testSourceGNSS,
+								SourceType: ptpv2alpha1.SourceTypeGNSS,
+								GNSSConfig: &ptpv2alpha1.GNSSConfig{
+									Init: ptpv2alpha1.GNSSInit{
+										AntennaVoltage: true,
+										Constellations: []ptpv2alpha1.ConstellationID{ptpv2alpha1.ConstellationGPS},
+										SurveyIn: ptpv2alpha1.GNSSSurveyParameters{
+											ObservationTime: 600,
+											Accuracy:        5,
+										},
+									},
+									Match: &ptpv2alpha1.GNSSMatcher{
+										EthernetInterface: testIfaceEno8703,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	err := hcm.deriveBehavior(hwConfig, clockType)
+	assert.NoError(t, err)
+
+	behavior := hwConfig.Spec.Profile.ClockChain.Behavior
+	assert.NotNil(t, behavior)
+
+	// Should have the GNSS source from template with user's gnssConfig merged
+	var gnssSource *ptpv2alpha1.SourceConfig
+	for i, s := range behavior.Sources {
+		if s.SourceType == ptpv2alpha1.SourceTypeGNSS {
+			gnssSource = &behavior.Sources[i]
+			break
+		}
+	}
+	if !assert.NotNil(t, gnssSource, "GNSS source should exist") {
+		return
+	}
+
+	// Template fields should be resolved
+	assert.Equal(t, subsystemName, gnssSource.Subsystem, "subsystem should come from template resolution")
+	assert.Equal(t, "GNSS_1PPS_IN", gnssSource.BoardLabel, "boardLabel should come from template")
+
+	// User fields should be merged
+	assert.NotNil(t, gnssSource.GNSSConfig, "gnssConfig should be merged from user")
+	assert.True(t, gnssSource.GNSSConfig.Init.AntennaVoltage, "antennaVoltage should be user's value")
+	assert.Equal(t, 600, gnssSource.GNSSConfig.Init.SurveyIn.ObservationTime)
+	assert.NotNil(t, gnssSource.GNSSConfig.Match)
+	assert.Equal(t, testIfaceEno8703, gnssSource.GNSSConfig.Match.EthernetInterface)
+
+	// Conditions should come from template
+	assert.NotEmpty(t, behavior.Conditions)
+	assert.Equal(t, "Initialize T-GM", behavior.Conditions[0].Name)
+
+	t.Logf("✓ Merge successful: GNSS source has template pin details + user gnssConfig")
+	t.Logf("  Sources: %d, Conditions: %d", len(behavior.Sources), len(behavior.Conditions))
+}
+
+// TestResolveClockChain_MergesUserBehavior verifies that ResolveClockChain
+// merges user-provided sources onto template-derived sources even when the
+// user supplies a Behavior section (i.e. Behavior is non-nil).
+func TestResolveClockChain_MergesUserBehavior(t *testing.T) {
+	// Use the T-BC minimal config so deriveSubsystemStructure succeeds
+	// (T-BC has upstream ports available from the PTP config).
+	hwConfig, err := loadHardwareConfigFromFile("testdata/gnrd-hwconfig-minimal.yaml")
+	require.NoError(t, err)
+	require.NotNil(t, hwConfig)
+
+	// Attach user-provided Behavior with a custom source — Behavior is now non-nil.
+	// deriveBehavior should still run, merging template sources/conditions.
+	hwConfig.Spec.Profile.ClockChain.Behavior = &ptpv2alpha1.Behavior{
+		Sources: []ptpv2alpha1.SourceConfig{
+			{
+				Name:       "CustomDPLL",
+				SourceType: ptpv2alpha1.SourceTypeDPLL,
+				Subsystem:  testSubsystemLeader,
+				BoardLabel: "CUSTOM_PIN",
+			},
+		},
+	}
+
+	ptpConfig, err := loadPtpConfigFromFile("testdata/tbc-gnrd.yaml")
+	require.NoError(t, err)
+
+	// Mock leading interface resolver for T-BC
+	mockResolver := newMockLeadingInterfaceResolver()
+	mockResolver.phcIDs["eno2"] = testDevPtp0
+	mockResolver.symlinks["/sys/class/ptp/ptp0/device"] = "../../../0000:13:00.0"
+	mockResolver.dirEntries["/sys/bus/pci/devices/0000:13:00.0/net"] = []os.DirEntry{
+		&mockDirEntry{name: "eno5", isDir: false},
+	}
+	SetLeadingInterfaceResolver(mockResolver)
+	defer ResetLeadingInterfaceResolver()
+
+	fakeClient := fake.NewClientset()
+	hcm := NewHardwareConfigManager(fakeClient, "default", nil)
+	resolved, err := hcm.ResolveClockChain(hwConfig, ptpConfig)
+	require.NoError(t, err)
+	require.NotNil(t, resolved)
+
+	behavior := resolved.Spec.Profile.ClockChain.Behavior
+	require.NotNil(t, behavior, "Behavior should be derived even when user provides sources")
+
+	// Template conditions should be present (not skipped because Behavior was non-nil)
+	assert.NotEmpty(t, behavior.Conditions, "Template conditions should be derived")
+	initCond := findConditionByName(behavior.Conditions, "Initialize T-BC")
+	assert.NotNil(t, initCond, "Initialize T-BC condition should come from template")
+
+	// Template PTP source should be present
+	ptpSource := findSourceByName(behavior.Sources, testSourcePTP)
+	assert.NotNil(t, ptpSource, "Template PTP source should be derived")
+
+	// User's custom source should also be present (unmatched, added as-is)
+	var customSource *ptpv2alpha1.SourceConfig
+	for i, s := range behavior.Sources {
+		if s.Name == "CustomDPLL" {
+			customSource = &behavior.Sources[i]
+			break
+		}
+	}
+	assert.NotNil(t, customSource, "User custom source should be preserved")
+	if customSource != nil {
+		assert.Equal(t, "CUSTOM_PIN", customSource.BoardLabel)
+	}
+}
+
+func TestDeriveBehavior_NoUserBehavior(t *testing.T) {
+	fakeClient := fake.NewClientset()
+	hcm := NewHardwareConfigManager(fakeClient, "default", nil)
+
+	clockType := "T-GM"
+
+	// No user behavior — everything from template
+	hwConfig := &ptpv2alpha1.HardwareConfig{
+		Spec: ptpv2alpha1.HardwareConfigSpec{
+			Profile: ptpv2alpha1.HardwareProfile{
+				ClockType: &clockType,
+				ClockChain: &ptpv2alpha1.ClockChain{
+					Structure: []ptpv2alpha1.Subsystem{
+						{
+							Name:                        testSubsystemLeader,
+							HardwareSpecificDefinitions: HwDefIntelE825,
+							DPLL: ptpv2alpha1.DPLL{
+								NetworkInterface: testIfaceEns7f0,
+							},
+							Ethernet: []ptpv2alpha1.Ethernet{
+								{Ports: []string{testIfaceEns7f0}},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	err := hcm.deriveBehavior(hwConfig, clockType)
+	assert.NoError(t, err)
+
+	behavior := hwConfig.Spec.Profile.ClockChain.Behavior
+	assert.NotNil(t, behavior)
+	assert.NotEmpty(t, behavior.Sources, "should have template-derived sources")
+	assert.NotEmpty(t, behavior.Conditions, "should have template-derived conditions")
+
+	// GNSS source should exist but without gnssConfig (no user input)
+	var gnssSource *ptpv2alpha1.SourceConfig
+	for i, s := range behavior.Sources {
+		if s.SourceType == ptpv2alpha1.SourceTypeGNSS {
+			gnssSource = &behavior.Sources[i]
+			break
+		}
+	}
+	assert.NotNil(t, gnssSource, "GNSS source should come from template")
+	assert.Nil(t, gnssSource.GNSSConfig, "gnssConfig should be nil without user input")
 }

--- a/pkg/hardwareconfig/hardwareconfig_test.go
+++ b/pkg/hardwareconfig/hardwareconfig_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	dpllcfg "github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/dpll"
 	dpll "github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/dpll-netlink"
@@ -2049,4 +2050,54 @@ func TestE830HardwareConfigFromTestdata(t *testing.T) {
 
 	t.Logf("Loaded gnrd-hwconfig-e830.yaml: %d subsystems, %d with DPLL flags",
 		len(chain.Structure), e830Count)
+}
+
+func TestGetInterfaceNameFromSources_GNSSSource(t *testing.T) {
+	const testGNSSBoardLabel = "GNSS_1PPS_IN"
+	hcm := newHardwareConfigManagerForTests()
+
+	clockChain := &ptpv2alpha1.ClockChain{
+		Structure: []ptpv2alpha1.Subsystem{
+			{
+				Name: testSubsystemLeader,
+				DPLL: ptpv2alpha1.DPLL{
+					NetworkInterface: testIfaceEns7f0,
+				},
+			},
+		},
+		Behavior: &ptpv2alpha1.Behavior{
+			Sources: []ptpv2alpha1.SourceConfig{
+				{
+					Name:       testSourceGNSS,
+					SourceType: ptpv2alpha1.SourceTypeGNSS,
+					Subsystem:  testSubsystemLeader,
+					BoardLabel: testGNSSBoardLabel,
+				},
+				{
+					Name:       "DPLL",
+					SourceType: ptpv2alpha1.SourceTypeDPLL,
+					Subsystem:  testSubsystemLeader,
+				},
+			},
+		},
+	}
+
+	t.Run("gnss_source", func(t *testing.T) {
+		iface, err := hcm.getInterfaceNameFromSources(testSourceGNSS, clockChain)
+		require.NoError(t, err)
+		require.NotNil(t, iface)
+		assert.Equal(t, testIfaceEns7f0, *iface)
+	})
+
+	t.Run("dpll_source", func(t *testing.T) {
+		iface, err := hcm.getInterfaceNameFromSources("DPLL", clockChain)
+		require.NoError(t, err)
+		require.NotNil(t, iface)
+		assert.Equal(t, testIfaceEns7f0, *iface)
+	})
+
+	t.Run("unknown_source", func(t *testing.T) {
+		_, err := hcm.getInterfaceNameFromSources("nonexistent", clockChain)
+		assert.Error(t, err)
+	})
 }

--- a/pkg/hardwareconfig/hardwareconfig_test.go
+++ b/pkg/hardwareconfig/hardwareconfig_test.go
@@ -2101,3 +2101,108 @@ func TestGetInterfaceNameFromSources_GNSSSource(t *testing.T) {
 		assert.Error(t, err)
 	})
 }
+
+func TestTranslateConnectorCommands(t *testing.T) {
+	const (
+		connSMA1    = "SMA1"
+		connSMA2    = "SMA2"
+		cmdFSWrite  = "FSWrite"
+		sma1PinPath = "/sys/class/net/{interface}/device/ptp/ptp*/pins/SMA1"
+		sma2PinPath = "/sys/class/net/{interface}/device/ptp/ptp*/pins/SMA2"
+		testIfaceCC = "ens7f0"
+	)
+
+	// Set up mock PTP device resolver so ptp* glob paths resolve
+	mockDevices := map[string][]string{
+		"/sys/class/net/" + testIfaceCC + "/device/ptp/ptp*/pins/SMA1": {
+			"/sys/class/net/" + testIfaceCC + "/device/ptp/ptp0/pins/SMA1",
+		},
+		"/sys/class/net/" + testIfaceCC + "/device/ptp/ptp*/pins/SMA2": {
+			"/sys/class/net/" + testIfaceCC + "/device/ptp/ptp0/pins/SMA2",
+		},
+	}
+	SetupMockPtpDeviceResolverWithDevices(mockDevices)
+	defer TeardownMockPtpDeviceResolver()
+
+	hcm := newHardwareConfigManagerForTests()
+
+	commands := &ConnectorCommands{
+		Outputs: map[string]ConnectorAction{
+			connSMA1: {Commands: []ConnectorCommand{
+				{Type: cmdFSWrite, Path: sma1PinPath, Value: "2 1"},
+			}},
+			connSMA2: {Commands: []ConnectorCommand{
+				{Type: cmdFSWrite, Path: sma2PinPath, Value: "2 2", Description: "Enable SMA2 output"},
+			}},
+		},
+		Inputs: map[string]ConnectorAction{
+			connSMA1: {Commands: []ConnectorCommand{
+				{Type: cmdFSWrite, Path: sma1PinPath, Value: "1 1"},
+			}},
+		},
+		Disable: map[string]ConnectorAction{
+			connSMA1: {Commands: []ConnectorCommand{
+				{Type: cmdFSWrite, Path: sma1PinPath, Value: "0 1"},
+			}},
+			connSMA2: {Commands: []ConnectorCommand{
+				{Type: cmdFSWrite, Path: sma2PinPath, Value: "0 2"},
+			}},
+		},
+	}
+
+	t.Run("output_connectors", func(t *testing.T) {
+		outputMap := map[string]struct{}{connSMA1: {}, connSMA2: {}}
+		result, err := hcm.translateConnectorCommands(commands, testIfaceCC, "leader", nil, outputMap)
+		assert.NoError(t, err)
+		// SMA1 + SMA2 as outputs; neither used as input so no disable
+		assert.Len(t, result, 2, "Should have 2 output commands")
+		for _, cmd := range result {
+			assert.Contains(t, cmd.Path, "ptp0", "ptp* should be resolved")
+			assert.NotContains(t, cmd.Path, "{interface}", "interface should be substituted")
+		}
+	})
+
+	t.Run("input_connectors", func(t *testing.T) {
+		inputMap := map[string]struct{}{connSMA1: {}}
+		result, err := hcm.translateConnectorCommands(commands, testIfaceCC, "leader", inputMap, nil)
+		assert.NoError(t, err)
+		// SMA1 as input + SMA2 disabled (unused connector with disable command)
+		assert.Len(t, result, 2, "Should have input + disable commands")
+	})
+
+	t.Run("disable_unused_connectors", func(t *testing.T) {
+		// No connectors used at all → both SMA1 and SMA2 get disabled
+		result, err := hcm.translateConnectorCommands(commands, testIfaceCC, "leader", nil, nil)
+		assert.NoError(t, err)
+		assert.Len(t, result, 2, "Should disable both unused connectors")
+		for _, cmd := range result {
+			assert.Contains(t, cmd.Value, "0 ", "Should be disable value")
+		}
+	})
+
+	t.Run("nil_commands", func(t *testing.T) {
+		result, err := hcm.translateConnectorCommands(nil, testIfaceCC, "leader", nil, nil)
+		assert.NoError(t, err)
+		assert.Nil(t, result)
+	})
+
+	t.Run("empty_interface", func(t *testing.T) {
+		result, err := hcm.translateConnectorCommands(commands, "", "leader", nil, nil)
+		assert.NoError(t, err)
+		assert.Nil(t, result, "Should skip when no interface")
+	})
+
+	t.Run("unsupported_command_type", func(t *testing.T) {
+		badCmds := &ConnectorCommands{
+			Outputs: map[string]ConnectorAction{
+				connSMA1: {Commands: []ConnectorCommand{
+					{Type: "ExecCmd", Path: "/bin/echo", Value: "hello"},
+				}},
+			},
+		}
+		outputMap := map[string]struct{}{connSMA1: {}}
+		result, err := hcm.translateConnectorCommands(badCmds, testIfaceCC, "leader", nil, outputMap)
+		assert.NoError(t, err)
+		assert.Empty(t, result, "Unsupported command types should be skipped")
+	})
+}

--- a/pkg/hardwareconfig/testdata/gnrd-hwconfig-minimal-tgm.yaml
+++ b/pkg/hardwareconfig/testdata/gnrd-hwconfig-minimal-tgm.yaml
@@ -1,0 +1,15 @@
+apiVersion: ptp.openshift.io/v2alpha1
+kind: HardwareConfig
+metadata:
+  name: t-gm-minimal
+spec:
+  profile:
+    name: GNR-D-T-GM-MINIMAL
+    clockType: T-GM
+    clockChain:
+      structure:
+      - name: leader
+        hardwareSpecificDefinitions: intel/e825
+        dpll:
+          networkInterface: ens7f0
+  relatedPtpProfileName: 01-tgm

--- a/pkg/hardwareconfig/testdata/tgm-gnrd.yaml
+++ b/pkg/hardwareconfig/testdata/tgm-gnrd.yaml
@@ -1,0 +1,56 @@
+apiVersion: ptp.openshift.io/v1
+kind: PtpConfig
+metadata:
+  name: t-gm
+  namespace: openshift-ptp
+spec:
+  profile:
+  - name: t-gm_01-tgm
+    ptp4lConf: |
+      [ens7f0]
+      masterOnly 1
+      [global]
+      twoStepFlag 1
+      slaveOnly 0
+      priority1 128
+      priority2 128
+      domainNumber 24
+      clockClass 6
+      clockAccuracy 0x21
+      dataset_comparison G.8275.x
+      G.8275.defaultDS.localPriority 128
+      logAnnounceInterval -3
+      logSyncInterval -4
+      logMinDelayReqInterval -4
+      announceReceiptTimeout 3
+      clock_type OC
+      network_transport L2
+      delay_mechanism E2E
+      time_stamping hardware
+      boundary_clock_jbod 1
+      timeSource 0x20
+    ptp4lOpts: -2 --summary_interval -4
+    ptpSchedulingPolicy: SCHED_FIFO
+    ptpSchedulingPriority: 10
+    ptpSettings:
+      clockType: T-GM
+      logReduce: "false"
+    ts2phcConf: |
+      [global]
+      use_syslog  0
+      verbose 1
+      logging_level 7
+      ts2phc.pulsewidth 500000000
+      leapfile  /usr/share/zoneinfo/leap-seconds.list
+      domainNumber 24
+      [ens7f0]
+      ts2phc.extts_correction 0
+      ts2phc.master 0
+      ts2phc.channel 0
+      ts2phc.pin_index 1
+    ts2phcOpts: -s nmea -a
+  recommend:
+  - match:
+    - nodeLabel: node-role.kubernetes.io/master
+    priority: 4
+    profile: 01-tgm

--- a/pkg/hardwareconfig/vendor_embedded.go
+++ b/pkg/hardwareconfig/vendor_embedded.go
@@ -37,6 +37,9 @@ var hpeEL140Gen12DefaultsYAML []byte
 //go:embed hardware-vendor/intel/e830/defaults.yaml
 var intelE830DefaultsYAML []byte
 
+//go:embed hardware-vendor/intel/e810/behavior-profiles.yaml
+var intelE810BehaviorProfilesYAML []byte
+
 //go:embed hardware-vendor/intel/e825/behavior-profiles.yaml
 var intelE825BehaviorProfilesYAML []byte
 
@@ -67,6 +70,7 @@ var embeddedDefaults = map[string][]byte{
 
 // embeddedBehaviorProfiles maps hwDefPath -> raw YAML contents for behavior profiles.
 var embeddedBehaviorProfiles = map[string][]byte{
+	HwDefIntelE810:     intelE810BehaviorProfilesYAML,
 	HwDefIntelE825:     intelE825BehaviorProfilesYAML,
 	HwDefDellXR8720t:   dellXR8720tBehaviorProfilesYAML,
 	HwDefHPEEL140Gen12: hpeEL140Gen12BehaviorProfilesYAML,

--- a/pkg/hardwareconfig/vendor_embedded.go
+++ b/pkg/hardwareconfig/vendor_embedded.go
@@ -13,6 +13,12 @@ const (
 	HwDefHPEEL140Gen12 = "hpe/EL140-Gen12"
 )
 
+// Clock type constants matching the values defined in the ptp-operator API.
+const (
+	ClockTypeTGM = "T-GM"
+	ClockTypeTBC = "T-BC"
+)
+
 // Embedded hardware-vendor defaults baked into the binary.
 // Add new hardware models here as needed.
 


### PR DESCRIPTION
- **Add GNSS source initialization and T-GM behavior templates**
- **Skip storing empty command slices in resolveClockChainBehavior**
- **Skip upstream port derivation for T-GM clock type**
- **Add intel/e810 T-GM behavior profile template**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added T-GM clock profile support with updated vendor behavior templates (GNSS time source + “Initialize T-GM” trigger).
  * Added HardwareConfig-driven GNSS discovery and automatic GPSD GNSS init command generation (antenna voltage, batched constellation enable/disable, optional survey-in).
* **Bug Fixes**
  * Improved clock-chain resolution and template/user behavior merging to always derive template behavior and correctly compute interface/DPLL details.
  * When GNSS serial can’t be resolved, continues using the default GPSD GNSS serial port.
* **Tests**
  * Expanded unit tests for T-GM resolution, behavior merging, and GNSS init command ordering.
* **Configuration**
  * Refreshed Intel E810 defaults and updated pin behavior in vendor templates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->