### PR TITLE
CNF-25885: Widen PTP clock thresholds when NTP failover is enabled

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -3,6 +3,7 @@ package daemon
 import (
 	"bufio"
 	"cmp"
+	"encoding/json"
 	"fmt"
 	"io"
 	"math"
@@ -2078,13 +2079,33 @@ func getPTPThreshold(nodeProfile *ptpv1.PtpProfile) *ptpv1.PtpClockThreshold {
 			MaxOffsetThreshold: nodeProfile.PtpClockThreshold.MaxOffsetThreshold,
 			MinOffsetThreshold: nodeProfile.PtpClockThreshold.MinOffsetThreshold,
 		}
-	} else {
+	}
+	if isNtpFailoverEnabled(nodeProfile) {
 		return &ptpv1.PtpClockThreshold{
 			HoldOverTimeout:    5,
-			MaxOffsetThreshold: 100,
-			MinOffsetThreshold: -100,
+			MaxOffsetThreshold: 1000,
+			MinOffsetThreshold: -1000,
 		}
 	}
+	return &ptpv1.PtpClockThreshold{
+		HoldOverTimeout:    5,
+		MaxOffsetThreshold: 100,
+		MinOffsetThreshold: -100,
+	}
+}
+
+func isNtpFailoverEnabled(nodeProfile *ptpv1.PtpProfile) bool {
+	pluginOpts, ok := nodeProfile.Plugins["ntpfailover"]
+	if !ok || pluginOpts == nil {
+		return false
+	}
+	var opts struct {
+		GnssFailover bool `json:"gnssFailover"`
+	}
+	if err := json.Unmarshal(pluginOpts.Raw, &opts); err != nil {
+		return false
+	}
+	return opts.GnssFailover
 }
 
 func (p *ptpProcess) MonitorEvent(offset float64, clockState string) {

--- a/pkg/daemon/daemon_internal_test.go
+++ b/pkg/daemon/daemon_internal_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
+	apiextensions "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 	"sigs.k8s.io/yaml"
@@ -3766,6 +3767,78 @@ func TestUpdateClockStateMetrics(t *testing.T) {
 			actual := testutil.ToFloat64(gauge)
 			assert.Equal(t, tt.expected, actual,
 				"clock_state for %s should be %v", tt.state, tt.expected)
+		})
+	}
+}
+
+func TestGetPTPThreshold(t *testing.T) {
+	profileName := "test-profile"
+
+	tests := []struct {
+		name             string
+		profile          ptpv1.PtpProfile
+		expectedMax      int64
+		expectedMin      int64
+		expectedHoldover int64
+	}{
+		{
+			name: "default threshold without ntpfailover",
+			profile: ptpv1.PtpProfile{
+				Name: &profileName,
+			},
+			expectedMax:      100,
+			expectedMin:      -100,
+			expectedHoldover: 5,
+		},
+		{
+			name: "ntpfailover with gnssFailover enabled uses looser threshold",
+			profile: ptpv1.PtpProfile{
+				Name: &profileName,
+				Plugins: map[string]*apiextensions.JSON{
+					"ntpfailover": {Raw: []byte(`{"gnssFailover": true}`)},
+				},
+			},
+			expectedMax:      1000,
+			expectedMin:      -1000,
+			expectedHoldover: 5,
+		},
+		{
+			name: "ntpfailover with gnssFailover disabled uses standard threshold",
+			profile: ptpv1.PtpProfile{
+				Name: &profileName,
+				Plugins: map[string]*apiextensions.JSON{
+					"ntpfailover": {Raw: []byte(`{"gnssFailover": false}`)},
+				},
+			},
+			expectedMax:      100,
+			expectedMin:      -100,
+			expectedHoldover: 5,
+		},
+		{
+			name: "explicit PtpClockThreshold takes precedence over ntpfailover",
+			profile: ptpv1.PtpProfile{
+				Name: &profileName,
+				PtpClockThreshold: &ptpv1.PtpClockThreshold{
+					HoldOverTimeout:    10,
+					MaxOffsetThreshold: 500,
+					MinOffsetThreshold: -500,
+				},
+				Plugins: map[string]*apiextensions.JSON{
+					"ntpfailover": {Raw: []byte(`{"gnssFailover": true}`)},
+				},
+			},
+			expectedMax:      500,
+			expectedMin:      -500,
+			expectedHoldover: 10,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := getPTPThreshold(&tt.profile)
+			assert.Equal(t, tt.expectedMax, result.MaxOffsetThreshold)
+			assert.Equal(t, tt.expectedMin, result.MinOffsetThreshold)
+			assert.Equal(t, tt.expectedHoldover, result.HoldOverTimeout)
 		})
 	}
 }


### PR DESCRIPTION
When a profile has the ntpfailover plugin with gnssFailover: true, the user has accepted NTP-level accuracy as a fallback. The default +/-100ns offset threshold is too strict for that tolerance — it would declare FREERUN on minor drift that the user considers acceptable.

Widen the default threshold to +/-1000ns when NTP failover is enabled. Explicit PtpClockThreshold on the profile still takes precedence.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for GNSS failover configuration, allowing more tolerant PTP clock thresholds during failover.
  * Explicitly configured PTP thresholds continue to take precedence over failover settings.

* **Bug Fixes**
  * Improved handling of missing, invalid, or disabled failover configuration by safely using standard thresholds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->