### PR TITLE
Potential fix for code scanning alert no. 10: Incorrect conversion between integer types

### DIFF
--- a/pkg/dpll/dpll.go
+++ b/pkg/dpll/dpll.go
@@ -354,7 +354,7 @@ func NewDpll(clockId uint64, localMaxHoldoverOffSet, localHoldoverTimeout, maxIn
 	// time to reach maxnInSpecOffset
 	d.timer = int64(math.Round(float64(d.MaxInSpecOffset) / d.slope))
 	glog.Infof("slope %f ns/s, in spec offset %f ns, in spec timer %d /sec Max timer %d /s",
-		d.slope, float64(d.MaxInSpecOffset), d.timer, int64(d.LocalHoldoverTimeout))
+		d.slope, float64(d.MaxInSpecOffset), d.timer, d.LocalHoldoverTimeout)
 	return d
 }
 


### PR DESCRIPTION
Potential fix for [https://github.com/k8snetworkplumbingwg/linuxptp-daemon/security/code-scanning/10](https://github.com/k8snetworkplumbingwg/linuxptp-daemon/security/code-scanning/10)

Use a safe, non-lossy representation for `LocalHoldoverTimeout` in the log statement and avoid converting `uint64` to `int64`.

Best fix with no functional change: in `pkg/dpll/dpll.go` inside `NewDpll` (around lines 356–357), replace `int64(d.LocalHoldoverTimeout)` with `d.LocalHoldoverTimeout` and keep `%d` formatting (which supports `uint64`). This removes the problematic conversion entirely while preserving existing behavior and output intent.

No new methods or imports are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
