### PR TITLE
OCPBUGS-95587: Fix clock_state metric: HOLDOVER mapped to 0, stale when CEP enabled

### DIFF
--- a/pkg/daemon/daemon_internal_test.go
+++ b/pkg/daemon/daemon_internal_test.go
@@ -27,6 +27,8 @@ import (
 	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/utils"
 	ptpv1 "github.com/k8snetworkplumbingwg/ptp-operator/api/v1"
 	ptpv2alpha1 "github.com/k8snetworkplumbingwg/ptp-operator/api/v2alpha1"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
@@ -41,6 +43,9 @@ const (
 	testDUTUpstream1    = "ens2f1"
 	testDUTUpstream2    = "ens2f3"
 	testDUTClockIDKey   = "clockId[ens2f0]"
+	labelIface          = "iface"
+	labelNode           = "node"
+	labelProcess        = "process"
 )
 
 // vendor defaults are embedded; no filesystem setup needed
@@ -3732,4 +3737,35 @@ func TestPtp4lConf_ResolveInterfaceNames(t *testing.T) {
 		}
 		assert.True(t, found["[ens5f0]"], "should keep [ens5f0] unchanged")
 	})
+}
+
+func TestUpdateClockStateMetrics(t *testing.T) {
+	origNodeName := NodeName
+	defer func() { NodeName = origNodeName }()
+
+	NodeName = "test-node"
+	RegisterMetrics(NodeName)
+	ClockState.Reset()
+
+	tests := []struct {
+		state    string
+		expected float64
+	}{
+		{FREERUN, event.ClockStateFreerun},
+		{LOCKED, event.ClockStateLocked},
+		{HOLDOVER, event.ClockStateHoldover},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.state, func(t *testing.T) {
+			updateClockStateMetrics(ptp4lProcessName, testDUTLeadingIface, tt.state)
+			gauge, err := ClockState.GetMetricWith(prometheus.Labels{
+				labelProcess: ptp4lProcessName, labelNode: NodeName, labelIface: testDUTLeadingIface,
+			})
+			assert.NoError(t, err)
+			actual := testutil.ToFloat64(gauge)
+			assert.Equal(t, tt.expected, actual,
+				"clock_state for %s should be %v", tt.state, tt.expected)
+		})
+	}
 }

--- a/pkg/daemon/metrics.go
+++ b/pkg/daemon/metrics.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/alias"
+	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/event"
 	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/synce"
 
 	"github.com/golang/glog"
@@ -48,12 +49,10 @@ const (
 	sys = "sys"
 )
 
+// Clock state string values used in log parsing and state transitions.
 const (
-	//LOCKED ...
-	LOCKED string = "LOCKED"
-	//FREERUN ...
-	FREERUN = "FREERUN"
-	// HOLDOVER
+	LOCKED   = "LOCKED"
+	FREERUN  = "FREERUN"
 	HOLDOVER = "HOLDOVER"
 )
 
@@ -529,12 +528,14 @@ func updateClockStateMetrics(process, iface string, state string) {
 		return
 	}
 	glog.V(14).Infof("updateClockStateMetrics: process=%s iface=%s state=%s", process, iface, state)
-	if state == LOCKED {
-		ClockState.With(prometheus.Labels{
-			"process": process, "node": NodeName, "iface": iface}).Set(1)
-	} else {
-		ClockState.With(prometheus.Labels{
-			"process": process, "node": NodeName, "iface": iface}).Set(0)
+	labels := prometheus.Labels{"process": process, "node": NodeName, "iface": iface}
+	switch state {
+	case LOCKED:
+		ClockState.With(labels).Set(event.ClockStateLocked)
+	case HOLDOVER:
+		ClockState.With(labels).Set(event.ClockStateHoldover)
+	default:
+		ClockState.With(labels).Set(event.ClockStateFreerun)
 	}
 }
 

--- a/pkg/event/event.go
+++ b/pkg/event/event.go
@@ -137,6 +137,13 @@ const (
 	PTP_NOTSET PTPState = "-2"
 )
 
+// Clock state metric values for openshift_ptp_clock_state gauge.
+const (
+	ClockStateFreerun  float64 = 0
+	ClockStateLocked   float64 = 1
+	ClockStateHoldover float64 = 2
+)
+
 const (
 	// socketDialTimeout is the maximum time to wait for a single dial attempt to the event socket.
 	socketDialTimeout = 5 * time.Second
@@ -1153,19 +1160,15 @@ func (e *EventHandler) UpdateClockStateMetrics(state PTPState, process, iFace st
 	if !utils.CheckMetricSanity("ClockState", process, iFace) {
 		return
 	}
-	if e.stdoutToSocket {
-		return
-	}
 	labels := prometheus.Labels{
 		"process": process, "node": e.nodeName, "iface": iFace}
-	if state == PTP_LOCKED {
-		e.clockMetric.With(labels).Set(1)
-	} else if state == PTP_FREERUN {
-		e.clockMetric.With(labels).Set(0)
-	} else if state == PTP_HOLDOVER {
-		e.clockMetric.With(labels).Set(2)
-	} else {
-		e.clockMetric.With(labels).Set(3)
+	switch state {
+	case PTP_LOCKED:
+		e.clockMetric.With(labels).Set(ClockStateLocked)
+	case PTP_HOLDOVER:
+		e.clockMetric.With(labels).Set(ClockStateHoldover)
+	default:
+		e.clockMetric.With(labels).Set(ClockStateFreerun)
 	}
 }
 


### PR DESCRIPTION
## Summary

Two fixes for the `openshift_ptp_clock_state` Prometheus metric:

1. **HOLDOVER mapped to 0 instead of 2** — `updateClockStateMetrics` in `metrics.go` only distinguished LOCKED (1) from everything else (0). HOLDOVER was indistinguishable from FREERUN despite the help text declaring `0 = FREERUN, 1 = LOCKED, 2 = HOLDOVER`. Replaced the if/else with a switch using typed constants (`event.ClockStateFreerun`, `event.ClockStateLocked`, `event.ClockStateHoldover`) shared between `metrics.go` and `event.go`, matching the pattern in cloud-event-proxy's `UpdateSyncStateMetrics`.

2. **Metric stale when CEP enabled** — `EventHandler.UpdateClockStateMetrics` in `event.go` was guarded by `if e.stdoutToSocket { return }`, skipping Prometheus updates when cloud-event-proxy was enabled. Since CEP does not register its own `openshift_ptp_clock_state` gauge (it only proxies CloudEvents), this left the metric stale. Removed the guard so the metric is always updated regardless of CEP mode.

Fixes: OCPBUGS-95587

## Test plan

- [x] `TestUpdateClockStateMetrics` — verifies FREERUN→0, LOCKED→1, HOLDOVER→2 using shared `event.ClockState*` constants
- [x] `golangci-lint run ./pkg/daemon/ ./pkg/event/` — 0 issues
- [x] Lab test on cnfdg32 (OCP 4.22): verified clock_state=1 (LOCKED) in both CEP-enabled and CEP-disabled modes with T-GM config

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected clock-state Prometheus metrics to report distinct values for `LOCKED`, `FREERUN`, and `HOLDOVER` states.
  * Updated handling of unrecognized clock states to use the `FREERUN` metric value consistently.
  * Improved metric label handling for process, node, and interface details.

* **Tests**
  * Added coverage verifying reported metric values for each supported clock state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->