### PR TITLE
Cleanup GNR-D Hwconfig documentation and defaults

### DIFF
--- a/doc/t-gm-dell-XR8720t.md
+++ b/doc/t-gm-dell-XR8720t.md
@@ -43,7 +43,7 @@ spec:
         verbose 1
         logging_level 7
         ts2phc.pulsewidth 100000000
-        ts2phc.nmea_serialport /dev/ttyACM0
+        ts2phc.nmea_serialport autodetect
         [eno8703]
         ts2phc.extts_polarity rising
         ts2phc.extts_correction 0
@@ -243,8 +243,6 @@ spec:
             sourceType: gnss
             subsystem: leader
             gnssConfig:
-              match:
-                ttyDevice: "/dev/ttyACM0"
               init:
                 antennaVoltage: true
                 constellations:

--- a/doc/t-gm-dell-XR8720t.md
+++ b/doc/t-gm-dell-XR8720t.md
@@ -1,0 +1,283 @@
+# Configuring T-GM on Dell XR8720t platform
+
+This document describes how to configure and operate T-GM with holdover support on the Dell XR8720t platform.
+
+## How it works
+
+In the T-GM configuration linuxptp-daemon will launch a `ptp4l` instance for all the TT ports. The internal NAC that receives the GNSS signal leads the timing of the entire system. With two add-on follower cards, this configuration supports up to 24 TT ports.
+
+The `ts2phc` will synchronize the physical hardware clocks (PHCs) to the GNSS time source using NMEA and 1PPS signals. If the GNSS signal is lost, the system will enter holdover.
+
+## Configure
+
+A Triple-NIC T-GM configuration example is shown below.
+The `PtpConfig` resource contains a single profile (`grandmaster`) configuring the TT ports, `ts2phc`, and `phc2sys`.
+
+In addition, a `HardwareConfig` resource is required to configure the hardware.
+
+The system also requires a `MachineConfig` resource to configure the network interface names according to the `path` name policy.
+
+### PtpConfig
+
+```yaml
+apiVersion: ptp.openshift.io/v1
+kind: PtpConfig
+metadata:
+  name: gnrd-tgm
+  namespace: openshift-ptp
+spec:
+  profile:
+    - name: "grandmaster"
+      ptp4lOpts: "-2 --summary_interval -4"
+      phc2sysOpts: ""-r -u 0 -m -w -N 8 -R 16 -n 24 -s eno8703"
+      ptpSchedulingPolicy: SCHED_FIFO
+      ptpSchedulingPriority: 10
+      ptpSettings:
+        logReduce: "enhanced"
+      ts2phcOpts: "-m"
+      ts2phcConf: |
+        [nmea]
+        ts2phc.master 1
+        [global]
+        use_syslog  0
+        verbose 1
+        logging_level 7
+        ts2phc.pulsewidth 100000000
+        ts2phc.nmea_serialport /dev/ttyACM0
+        [eno8703]
+        ts2phc.extts_polarity rising
+        ts2phc.extts_correction 0
+        ts2phc.master  0
+        ts2phc.channel 0
+        ts2phc.pin_index 1
+        [enp108s0f0]
+        ts2phc.extts_polarity   rising
+        ts2phc.extts_correction 0
+        ts2phc.master   0
+        ts2phc.channel 0
+        ts2phc.pin_index 1
+        [enp110s0f0]
+        ts2phc.extts_polarity   rising
+        ts2phc.extts_correction 0
+        ts2phc.master   0
+        ts2phc.channel 0
+        ts2phc.pin_index 1
+      ptp4lConf: |
+        #[eno8303]
+        # ** Host management interface
+        [eno8403]
+        masterOnly 1
+        [eno8503]
+        masterOnly 1
+        [eno8603]
+        masterOnly 1
+        [eno8703]
+        masterOnly 1
+        [eno8803]
+        masterOnly 1
+        [eno8903]
+        masterOnly 1
+        [eno9003]
+        masterOnly 1
+        [enp108s0f0]
+        masterOnly 1
+        [enp108s0f1]
+        masterOnly 1
+        [enp108s0f2]
+        masterOnly 1
+        [enp108s0f3]
+        masterOnly 1
+        [enp108s0f4]
+        masterOnly 1
+        [enp108s0f5]
+        masterOnly 1
+        [enp108s0f6]
+        masterOnly 1
+        [enp108s0f7]
+        masterOnly 1
+        [enp110s0f0]
+        masterOnly 1
+        [enp110s0f1]
+        masterOnly 1
+        [enp110s0f2]
+        masterOnly 1
+        [enp110s0f3]
+        masterOnly 1
+        [enp110s0f4]
+        masterOnly 1
+        [enp110s0f5]
+        masterOnly 1
+        [enp110s0f6]
+        masterOnly 1
+        [enp110s0f7]
+        masterOnly 1
+        [global]
+        #
+        # Default Data Set
+        #
+        twoStepFlag 1
+        priority1 128
+        priority2 128
+        domainNumber 24
+        #utc_offset 37
+        clockClass 6
+        clockAccuracy 0x27
+        offsetScaledLogVariance 0xFFFF
+        free_running 0
+        freq_est_interval 1
+        dscp_event 0
+        dscp_general 0
+        dataset_comparison G.8275.x
+        G.8275.defaultDS.localPriority 128
+        #
+        # Port Data Set
+        #
+        logAnnounceInterval -3
+        logSyncInterval -4
+        logMinDelayReqInterval -4
+        logMinPdelayReqInterval 0
+        announceReceiptTimeout 3
+        syncReceiptTimeout 0
+        delayAsymmetry 0
+        fault_reset_interval 4
+        neighborPropDelayThresh 20000000
+        masterOnly 0
+        G.8275.portDS.localPriority 128
+        #
+        # Run time options
+        #
+        assume_two_step 0
+        logging_level 6
+        path_trace_enabled 0
+        follow_up_info 0
+        hybrid_e2e 0
+        inhibit_multicast_service 0
+        net_sync_monitor 0
+        tc_spanning_tree 0
+        tx_timestamp_timeout 50
+        unicast_listen 0
+        unicast_master_table 0
+        unicast_req_duration 3600
+        use_syslog 1
+        verbose 0
+        summary_interval -4
+        kernel_leap 1
+        check_fup_sync 0
+        #
+        # Servo Options
+        #
+        pi_proportional_const 0.0
+        pi_integral_const 0.0
+        pi_proportional_scale 0.0
+        pi_proportional_exponent -0.3
+        pi_proportional_norm_max 0.7
+        pi_integral_scale 0.0
+        pi_integral_exponent 0.4
+        pi_integral_norm_max 0.3
+        step_threshold 0.0
+        first_step_threshold 0.00002
+        clock_servo pi
+        sanity_freq_limit  200000000
+        ntpshm_segment 0
+        #
+        # Transport options
+        #
+        transportSpecific 0x0
+        ptp_dst_mac 01:1B:19:00:00:00
+        p2p_dst_mac 01:80:C2:00:00:0E
+        udp_ttl 1
+        udp6_scope 0x0E
+        uds_address /var/run/ptp4l
+        #
+        # Default interface options
+        #
+        clock_type BC
+        network_transport L2
+        delay_mechanism E2E
+        time_stamping hardware
+        tsproc_mode filter
+        delay_filter moving_median
+        delay_filter_length 10
+        egressLatency 0
+        ingressLatency 0
+        boundary_clock_jbod 1
+        #
+        # Clock description
+        #
+        productDescription ;;
+        revisionData ;;
+        manufacturerIdentity 00:00:00
+        userDescription ;
+        timeSource 0x20
+  recommend:
+    - profile: "grandmaster"
+      priority: 4
+      match:
+        - nodeLabel: "node-role.kubernetes.io/worker"
+```
+
+### HardwareConfig
+
+```yaml
+apiVersion: ptp.openshift.io/v2alpha1
+kind: HardwareConfig
+metadata:
+  name: gnrd-tgm
+  namespace: openshift-ptp
+spec:
+  profile:
+    name: gnrd-tgm
+    clockType: T-GM
+    clockChain:
+      structure:
+        - name: leader
+          hardwareSpecificDefinitions: dell/XR8720t
+          dpll:
+            holdoverParameters:
+              maxInSpecOffset: 14400
+              localMaxHoldoverOffset: 1500
+              localHoldoverTimeout: 1500
+      behavior:
+        sources:
+          - name: GNSS
+            sourceType: gnss
+            subsystem: leader
+            gnssConfig:
+              match:
+                ttyDevice: "/dev/ttyACM0"
+              init:
+                antennaVoltage: true
+                constellations:
+                  - GPS
+                survey:
+                  observationTime: 600
+                  accuracy: 50000
+  relatedPtpProfileName: grandmaster
+```
+
+### Network interface names
+
+```yaml
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  name: 10-rename-gnrd-interfaces-master
+  labels:
+    machineconfiguration.openshift.io/role: master
+spec:
+  config:
+    ignition:
+      version: 3.2.0
+    storage:
+      files:
+        - path: /etc/systemd/network/10-interface-8086-12d3.link
+          # [Match]
+          # Property=ID_VENDOR_ID=0x8086
+          # Property=ID_MODEL_ID=0x12d3
+          # [Link]
+          # NamePolicy=path
+          mode: 420
+          overwrite: true
+          contents:
+            source: data:text/plain,%5BMatch%5D%0AProperty%3DID_VENDOR_ID%3D0x8086%0AProperty%3DID_MODEL_ID%3D0x12d3%0A%0A%5BLink%5D%0ANamePolicy%3Dpath%0A
+```

--- a/pkg/hardwareconfig/clockchain_resolution.go
+++ b/pkg/hardwareconfig/clockchain_resolution.go
@@ -660,6 +660,17 @@ func mergeSourceConfig(tpl, user *ptpv2alpha1.SourceConfig) {
 		tpl.PTPTimeReceivers = user.PTPTimeReceivers
 	}
 	if user.GNSSConfig != nil {
-		tpl.GNSSConfig = user.GNSSConfig
+		// Explicitly shallow-copy the user GNSS config
+		gnss := *user.GNSSConfig
+		if user.GNSSConfig.Match != nil {
+			// Prefer: shallow-copy the user GNSS matcher (if set)
+			match := *user.GNSSConfig.Match
+			gnss.Match = &match
+		} else if tpl.GNSSConfig != nil && tpl.GNSSConfig.Match != nil {
+			// Fallback: shallow-copy the original template matcher (if set)
+			match := *tpl.GNSSConfig.Match
+			gnss.Match = &match
+		}
+		tpl.GNSSConfig = &gnss
 	}
 }

--- a/pkg/hardwareconfig/clockchain_resolution_test.go
+++ b/pkg/hardwareconfig/clockchain_resolution_test.go
@@ -896,3 +896,188 @@ func TestDeriveBehavior_UserConditionsPreserved(t *testing.T) {
 	// Template sources should still be present
 	assert.NotEmpty(t, behavior.Sources, "Template sources should be derived")
 }
+
+func Test_mergeSourceConfig(t *testing.T) {
+	const ttyTpl = "/dev/tty-tpl"
+	const ttyUser = "/dev/tty-user"
+
+	tests := []struct {
+		name     string
+		tpl      *ptpv2alpha1.SourceConfig
+		user     *ptpv2alpha1.SourceConfig
+		expected *ptpv2alpha1.SourceConfig
+	}{
+		{
+			name:     "all empty",
+			tpl:      &ptpv2alpha1.SourceConfig{},
+			user:     &ptpv2alpha1.SourceConfig{},
+			expected: &ptpv2alpha1.SourceConfig{},
+		},
+		{
+			name: "update simple fields",
+			tpl: &ptpv2alpha1.SourceConfig{
+				Subsystem:  "tpl-sub",
+				BoardLabel: "tpl-board",
+			},
+			user: &ptpv2alpha1.SourceConfig{
+				Subsystem:        "user-sub",
+				BoardLabel:       "user-board",
+				PTPTimeReceivers: []string{"user-ptp"},
+			},
+			expected: &ptpv2alpha1.SourceConfig{
+				Subsystem:        "user-sub",
+				BoardLabel:       "user-board",
+				PTPTimeReceivers: []string{"user-ptp"},
+			},
+		},
+		{
+			name: "empty user fields do not override tpl fields",
+			tpl: &ptpv2alpha1.SourceConfig{
+				Subsystem:        "tpl-sub",
+				BoardLabel:       "tpl-board",
+				PTPTimeReceivers: []string{"tpl-ptp"},
+			},
+			user: &ptpv2alpha1.SourceConfig{
+				Subsystem:        "",
+				BoardLabel:       "",
+				PTPTimeReceivers: []string{},
+			},
+			expected: &ptpv2alpha1.SourceConfig{
+				Subsystem:        "tpl-sub",
+				BoardLabel:       "tpl-board",
+				PTPTimeReceivers: []string{"tpl-ptp"},
+			},
+		},
+		{
+			name: "user GNSS config nil, tpl GNSS config untouched",
+			tpl: &ptpv2alpha1.SourceConfig{
+				GNSSConfig: &ptpv2alpha1.GNSSConfig{
+					Match: &ptpv2alpha1.GNSSMatcher{
+						TTYDevice: ttyTpl,
+					},
+				},
+			},
+			user: &ptpv2alpha1.SourceConfig{},
+			expected: &ptpv2alpha1.SourceConfig{
+				GNSSConfig: &ptpv2alpha1.GNSSConfig{
+					Match: &ptpv2alpha1.GNSSMatcher{
+						TTYDevice: ttyTpl,
+					},
+				},
+			},
+		},
+		{
+			name: "user GNSS config set, no matches in either",
+			tpl:  &ptpv2alpha1.SourceConfig{},
+			user: &ptpv2alpha1.SourceConfig{
+				GNSSConfig: &ptpv2alpha1.GNSSConfig{},
+			},
+			expected: &ptpv2alpha1.SourceConfig{
+				GNSSConfig: &ptpv2alpha1.GNSSConfig{},
+			},
+		},
+		{
+			name: "user GNSS config set, user match set, tpl GNSS config nil",
+			tpl:  &ptpv2alpha1.SourceConfig{},
+			user: &ptpv2alpha1.SourceConfig{
+				GNSSConfig: &ptpv2alpha1.GNSSConfig{
+					Match: &ptpv2alpha1.GNSSMatcher{
+						TTYDevice: ttyUser,
+					},
+				},
+			},
+			expected: &ptpv2alpha1.SourceConfig{
+				GNSSConfig: &ptpv2alpha1.GNSSConfig{
+					Match: &ptpv2alpha1.GNSSMatcher{
+						TTYDevice: ttyUser,
+					},
+				},
+			},
+		},
+		{
+			name: "user GNSS config set with init, tpl match preserved",
+			tpl: &ptpv2alpha1.SourceConfig{
+				GNSSConfig: &ptpv2alpha1.GNSSConfig{
+					Match: &ptpv2alpha1.GNSSMatcher{
+						TTYDevice: ttyTpl,
+					},
+				},
+			},
+			user: &ptpv2alpha1.SourceConfig{
+				GNSSConfig: &ptpv2alpha1.GNSSConfig{
+					Init: ptpv2alpha1.GNSSInit{
+						// Dummy field initialization, we just check if it gets copied
+					},
+				},
+			},
+			expected: &ptpv2alpha1.SourceConfig{
+				GNSSConfig: &ptpv2alpha1.GNSSConfig{
+					Init: ptpv2alpha1.GNSSInit{},
+					Match: &ptpv2alpha1.GNSSMatcher{
+						TTYDevice: ttyTpl,
+					},
+				},
+			},
+		},
+		{
+			name: "user GNSS config set, user match overrides tpl match",
+			tpl: &ptpv2alpha1.SourceConfig{
+				GNSSConfig: &ptpv2alpha1.GNSSConfig{
+					Match: &ptpv2alpha1.GNSSMatcher{
+						TTYDevice: ttyTpl,
+					},
+				},
+			},
+			user: &ptpv2alpha1.SourceConfig{
+				GNSSConfig: &ptpv2alpha1.GNSSConfig{
+					Match: &ptpv2alpha1.GNSSMatcher{
+						TTYDevice: ttyUser,
+					},
+				},
+			},
+			expected: &ptpv2alpha1.SourceConfig{
+				GNSSConfig: &ptpv2alpha1.GNSSConfig{
+					Match: &ptpv2alpha1.GNSSMatcher{
+						TTYDevice: ttyUser,
+					},
+				},
+			},
+		},
+		{
+			name: "user GNSS config set with no match, tpl GNSS config set with no match",
+			tpl: &ptpv2alpha1.SourceConfig{
+				GNSSConfig: &ptpv2alpha1.GNSSConfig{},
+			},
+			user: &ptpv2alpha1.SourceConfig{
+				GNSSConfig: &ptpv2alpha1.GNSSConfig{},
+			},
+			expected: &ptpv2alpha1.SourceConfig{
+				GNSSConfig: &ptpv2alpha1.GNSSConfig{},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mergeSourceConfig(tt.tpl, tt.user)
+			assert.Equal(t, tt.expected, tt.tpl)
+
+			// Verify shallow copy for GNSSConfig and Match if they were merged from user
+			if tt.user.GNSSConfig != nil {
+				// changing tpl should not affect user
+				if tt.tpl.GNSSConfig.Match != nil {
+					// We mutate the copied match string to see if the user's match is untouched
+					originalTTY := tt.tpl.GNSSConfig.Match.TTYDevice
+					tt.tpl.GNSSConfig.Match.TTYDevice = "/dev/mutated"
+
+					if tt.user.GNSSConfig.Match != nil {
+						assert.NotEqual(t, "/dev/mutated", tt.user.GNSSConfig.Match.TTYDevice, "user GNSSConfig.Match was not shallow-copied")
+					}
+
+					// Revert mutation
+					tt.tpl.GNSSConfig.Match.TTYDevice = originalTTY
+				}
+			}
+		})
+	}
+}

--- a/pkg/hardwareconfig/gnss_test.go
+++ b/pkg/hardwareconfig/gnss_test.go
@@ -30,6 +30,7 @@ const (
 	testSurveyInArgs    = "SURVEYIN,600,50000"
 	testMonHW           = "MON-HW"
 	testCfgMsg          = "CFG-MSG,1,38,248"
+	testACM0            = "/dev/ttyACM0"
 )
 
 // --- Mock helpers ---
@@ -340,10 +341,10 @@ func TestFindGNSSDevice(t *testing.T) {
 
 	t.Run("ttyDevice returned directly", func(t *testing.T) {
 		device, err := FindGNSSDevice(&ptpv2alpha1.GNSSMatcher{
-			TTYDevice: "/dev/ttyACM0",
+			TTYDevice: testACM0,
 		})
 		assert.NoError(t, err)
-		assert.Equal(t, "/dev/ttyACM0", device)
+		assert.Equal(t, testACM0, device)
 	})
 
 	t.Run("ethernetInterface resolves via sysfs", func(t *testing.T) {
@@ -409,7 +410,7 @@ func TestFindGNSSSource(t *testing.T) {
 			Constellations: []ptpv2alpha1.ConstellationID{ptpv2alpha1.ConstellationGPS},
 			SurveyIn:       ptpv2alpha1.GNSSSurveyParameters{ObservationTime: 600, Accuracy: 5},
 		},
-		Match: &ptpv2alpha1.GNSSMatcher{TTYDevice: "/dev/ttyACM0"},
+		Match: &ptpv2alpha1.GNSSMatcher{TTYDevice: testACM0},
 	}
 
 	hwConfig := ptpv2alpha1.HardwareConfig{
@@ -492,7 +493,7 @@ func TestGetGNSSSerialPort(t *testing.T) {
 									SourceType: ptpv2alpha1.SourceTypeGNSS,
 									GNSSConfig: &ptpv2alpha1.GNSSConfig{
 										Init:  ptpv2alpha1.GNSSInit{},
-										Match: &ptpv2alpha1.GNSSMatcher{TTYDevice: "/dev/ttyACM0"},
+										Match: &ptpv2alpha1.GNSSMatcher{TTYDevice: testACM0},
 									},
 								},
 							},
@@ -504,7 +505,7 @@ func TestGetGNSSSerialPort(t *testing.T) {
 		hcm := makeTestHCM(hwConfig)
 		port, err := hcm.GetGNSSSerialPort(testProfile(testProfileName))
 		assert.NoError(t, err)
-		assert.Equal(t, "/dev/ttyACM0", port)
+		assert.Equal(t, testACM0, port)
 	})
 
 	t.Run("returns empty when no GNSS source", func(t *testing.T) {

--- a/pkg/hardwareconfig/hardware-vendor/dell/XR8720t/behavior-profiles.yaml
+++ b/pkg/hardwareconfig/hardware-vendor/dell/XR8720t/behavior-profiles.yaml
@@ -10,6 +10,9 @@ behaviorProfiles:
         sourceType: gnss
         subsystem: "{subsystem}"
         boardLabel: GNSS_1PPS_IN
+        gnssConfig:
+          match:
+            ttyDevice: "/dev/ttyACM0"
 
     conditions:
       - name: "Initialize T-GM"
@@ -45,17 +48,17 @@ behaviorProfiles:
   t-bc:
     # Pin role mappings - defines which pins serve which roles
     pinRoles:
-      gnssInputPin: GNSS_1PPS_IN  # DPLL pin used for GNSS input (that should be disabled for T-BC)
-      ptpInputPin: ETH01_SDP_TIMESYNC_0  # DPLL pin used for PTP input
-    
+      gnssInputPin: GNSS_1PPS_IN # DPLL pin used for GNSS input (that should be disabled for T-BC)
+      ptpInputPin: ETH01_SDP_TIMESYNC_0 # DPLL pin used for PTP input
+
     # Source template - will be instantiated with resolved variables
     sources:
       - name: PTP
         sourceType: ptpTimeReceiver
-        subsystem: "{subsystem}"  # Will be resolved to subsystem name
-        boardLabel: "{ptpInputPin}"  # Will be resolved from pinRoles
+        subsystem: "{subsystem}" # Will be resolved to subsystem name
+        boardLabel: "{ptpInputPin}" # Will be resolved from pinRoles
         # ptpTimeReceivers will be derived from ptpconfig
-    
+
     # Condition templates - will be instantiated with resolved variables
     conditions:
       - name: "Initialize T-BC"
@@ -101,7 +104,7 @@ behaviorProfiles:
               func: Disabled
               chan: 0
               sourceName: PTP
-      
+
       - name: "PTP Source Locked"
         triggers:
           - conditionType: locked
@@ -136,7 +139,7 @@ behaviorProfiles:
                 state: disconnected
               pps:
                 state: selectable
-      
+
       - name: "PTP Source Lost - Leader Holdover"
         triggers:
           - conditionType: lost
@@ -152,4 +155,3 @@ behaviorProfiles:
               func: Disabled
               chan: 0
               sourceName: PTP
-

--- a/pkg/hardwareconfig/hardware-vendor/hpe/EL140-Gen12/behavior-profiles.yaml
+++ b/pkg/hardwareconfig/hardware-vendor/hpe/EL140-Gen12/behavior-profiles.yaml
@@ -10,6 +10,9 @@ behaviorProfiles:
         sourceType: gnss
         subsystem: "{subsystem}"
         boardLabel: GNSS_1PPS_IN
+        gnssConfig:
+          match:
+            ttyDevice: "/dev/ttyACM0"
 
     conditions:
       - name: "Initialize T-GM"
@@ -45,17 +48,17 @@ behaviorProfiles:
   t-bc:
     # Pin role mappings - defines which pins serve which roles
     pinRoles:
-      gnssInputPin: GNSS_1PPS_IN  # DPLL pin used for GNSS input (that should be disabled for T-BC)
+      gnssInputPin: GNSS_1PPS_IN # DPLL pin used for GNSS input (that should be disabled for T-BC)
       ptpInputPin: 1PPS_IN0 # DPLL pin used for PTP input
 
     # Source template - will be instantiated with resolved variables
     sources:
       - name: PTP
         sourceType: ptpTimeReceiver
-        subsystem: "{subsystem}"  # Will be resolved to subsystem name
-        boardLabel: "{ptpInputPin}"  # Will be resolved from pinRoles
+        subsystem: "{subsystem}" # Will be resolved to subsystem name
+        boardLabel: "{ptpInputPin}" # Will be resolved from pinRoles
         # ptpTimeReceivers will be derived from ptpconfig
-    
+
     # Condition templates - will be instantiated with resolved variables
     conditions:
       - name: "Initialize T-BC"
@@ -101,7 +104,7 @@ behaviorProfiles:
               func: Disabled
               chan: 0
               sourceName: PTP
-      
+
       - name: "PTP Source Locked"
         triggers:
           - conditionType: locked
@@ -136,7 +139,7 @@ behaviorProfiles:
                 state: disconnected
               pps:
                 state: selectable
-      
+
       - name: "PTP Source Lost - Leader Holdover"
         triggers:
           - conditionType: lost
@@ -152,4 +155,3 @@ behaviorProfiles:
               func: Disabled
               chan: 0
               sourceName: PTP
-

--- a/pkg/hardwareconfig/hardware-vendor/intel/e825/behavior-profiles.yaml
+++ b/pkg/hardwareconfig/hardware-vendor/intel/e825/behavior-profiles.yaml
@@ -10,6 +10,9 @@ behaviorProfiles:
         sourceType: gnss
         subsystem: "{subsystem}"
         boardLabel: GNSS_1PPS_IN
+        gnssConfig:
+          match:
+            ttyDevice: "/dev/ttyACM0"
 
     conditions:
       - name: "Initialize T-GM"
@@ -45,17 +48,17 @@ behaviorProfiles:
   t-bc:
     # Pin role mappings - defines which pins serve which roles
     pinRoles:
-      gnssInputPin: GNSS_1PPS_IN  # DPLL pin used for GNSS input (that should be disabled for T-BC)
-      ptpInputPin: GNR-D_SDP0  # DPLL pin used for PTP input
-    
+      gnssInputPin: GNSS_1PPS_IN # DPLL pin used for GNSS input (that should be disabled for T-BC)
+      ptpInputPin: GNR-D_SDP0 # DPLL pin used for PTP input
+
     # Source template - will be instantiated with resolved variables
     sources:
       - name: PTP
         sourceType: ptpTimeReceiver
-        subsystem: "{subsystem}"  # Will be resolved to subsystem name
-        boardLabel: "{ptpInputPin}"  # Will be resolved from pinRoles
+        subsystem: "{subsystem}" # Will be resolved to subsystem name
+        boardLabel: "{ptpInputPin}" # Will be resolved from pinRoles
         # ptpTimeReceivers will be derived from ptpconfig
-    
+
     # Condition templates - will be instantiated with resolved variables
     conditions:
       - name: "Initialize T-BC"
@@ -80,7 +83,7 @@ behaviorProfiles:
               func: Disabled
               chan: 0
               sourceName: PTP
-      
+
       - name: "PTP Source Locked"
         triggers:
           - conditionType: locked
@@ -115,7 +118,7 @@ behaviorProfiles:
                 state: disconnected
               pps:
                 state: selectable
-      
+
       - name: "PTP Source Lost - Leader Holdover"
         triggers:
           - conditionType: lost
@@ -131,4 +134,3 @@ behaviorProfiles:
               func: Disabled
               chan: 0
               sourceName: PTP
-

--- a/pkg/hardwareconfig/hardwareconfig_gnrd_test.go
+++ b/pkg/hardwareconfig/hardwareconfig_gnrd_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 
 	dpll "github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/dpll-netlink"
 	ptpv1 "github.com/k8snetworkplumbingwg/ptp-operator/api/v1"
@@ -928,41 +927,84 @@ func TestDeriveBehavior_MergesUserGNSSConfig(t *testing.T) {
 	clockType := testClockTypeTGM
 	subsystemName := testSubsystemLeader
 
-	// User provides only gnssConfig on the GNSS source — the template
-	// provides the DPLL pin details and conditions.
-	hwConfig := &ptpv2alpha1.HardwareConfig{
-		Spec: ptpv2alpha1.HardwareConfigSpec{
-			Profile: ptpv2alpha1.HardwareProfile{
-				ClockType: &clockType,
-				ClockChain: &ptpv2alpha1.ClockChain{
-					Structure: []ptpv2alpha1.Subsystem{
-						{
-							Name:                        subsystemName,
-							HardwareSpecificDefinitions: HwDefDellXR8720t,
-							DPLL: ptpv2alpha1.DPLL{
-								NetworkInterface: testIfaceEno8703,
+	tests := []struct {
+		name               string
+		hwConfig           *ptpv2alpha1.HardwareConfig
+		expectedBoardLabel string
+		expectedGnssConfig *ptpv2alpha1.GNSSConfig
+	}{
+		{
+			name: "No user override",
+			// User provides only gnssConfig on the GNSS source — the template
+			// provides the DPLL pin details and conditions.
+			hwConfig: &ptpv2alpha1.HardwareConfig{
+				Spec: ptpv2alpha1.HardwareConfigSpec{
+					Profile: ptpv2alpha1.HardwareProfile{
+						ClockType: &clockType,
+						ClockChain: &ptpv2alpha1.ClockChain{
+							Structure: []ptpv2alpha1.Subsystem{
+								{
+									Name:                        subsystemName,
+									HardwareSpecificDefinitions: HwDefDellXR8720t,
+									DPLL: ptpv2alpha1.DPLL{
+										NetworkInterface: testIfaceEno8703,
+									},
+									Ethernet: []ptpv2alpha1.Ethernet{
+										{Ports: []string{testIfaceEno8703}},
+									},
+								},
 							},
-							Ethernet: []ptpv2alpha1.Ethernet{
-								{Ports: []string{testIfaceEno8703}},
+							Behavior: &ptpv2alpha1.Behavior{
+								Sources: []ptpv2alpha1.SourceConfig{},
 							},
 						},
 					},
-					Behavior: &ptpv2alpha1.Behavior{
-						Sources: []ptpv2alpha1.SourceConfig{
-							{
-								Name:       testSourceGNSS,
-								SourceType: ptpv2alpha1.SourceTypeGNSS,
-								GNSSConfig: &ptpv2alpha1.GNSSConfig{
-									Init: ptpv2alpha1.GNSSInit{
-										AntennaVoltage: true,
-										Constellations: []ptpv2alpha1.ConstellationID{ptpv2alpha1.ConstellationGPS},
-										SurveyIn: ptpv2alpha1.GNSSSurveyParameters{
-											ObservationTime: 600,
-											Accuracy:        5,
-										},
+				},
+			},
+			expectedBoardLabel: "GNSS_1PPS_IN",
+			expectedGnssConfig: &ptpv2alpha1.GNSSConfig{
+				Init: ptpv2alpha1.GNSSInit{},
+				Match: &ptpv2alpha1.GNSSMatcher{
+					TTYDevice: testACM0,
+				},
+			},
+		},
+		{
+			name: "User override of init only",
+			// User provides only gnssConfig on the GNSS source — the template
+			// provides the DPLL pin details and conditions.
+			hwConfig: &ptpv2alpha1.HardwareConfig{
+				Spec: ptpv2alpha1.HardwareConfigSpec{
+					Profile: ptpv2alpha1.HardwareProfile{
+						ClockType: &clockType,
+						ClockChain: &ptpv2alpha1.ClockChain{
+							Structure: []ptpv2alpha1.Subsystem{
+								{
+									Name:                        subsystemName,
+									HardwareSpecificDefinitions: HwDefDellXR8720t,
+									DPLL: ptpv2alpha1.DPLL{
+										NetworkInterface: testIfaceEno8703,
 									},
-									Match: &ptpv2alpha1.GNSSMatcher{
-										EthernetInterface: testIfaceEno8703,
+									Ethernet: []ptpv2alpha1.Ethernet{
+										{Ports: []string{testIfaceEno8703}},
+									},
+								},
+							},
+							Behavior: &ptpv2alpha1.Behavior{
+								Sources: []ptpv2alpha1.SourceConfig{
+									{
+										Name:       testSourceGNSS,
+										SourceType: ptpv2alpha1.SourceTypeGNSS,
+										GNSSConfig: &ptpv2alpha1.GNSSConfig{
+											Init: ptpv2alpha1.GNSSInit{
+												AntennaVoltage: true,
+												Constellations: []ptpv2alpha1.ConstellationID{ptpv2alpha1.ConstellationGPS},
+												SurveyIn: ptpv2alpha1.GNSSSurveyParameters{
+													ObservationTime: 600,
+													Accuracy:        5,
+												},
+											},
+										},
 									},
 								},
 							},
@@ -970,159 +1012,235 @@ func TestDeriveBehavior_MergesUserGNSSConfig(t *testing.T) {
 					},
 				},
 			},
-		},
-	}
-
-	err := hcm.deriveBehavior(hwConfig, clockType)
-	assert.NoError(t, err)
-
-	behavior := hwConfig.Spec.Profile.ClockChain.Behavior
-	assert.NotNil(t, behavior)
-
-	// Should have the GNSS source from template with user's gnssConfig merged
-	var gnssSource *ptpv2alpha1.SourceConfig
-	for i, s := range behavior.Sources {
-		if s.SourceType == ptpv2alpha1.SourceTypeGNSS {
-			gnssSource = &behavior.Sources[i]
-			break
-		}
-	}
-	if !assert.NotNil(t, gnssSource, "GNSS source should exist") {
-		return
-	}
-
-	// Template fields should be resolved
-	assert.Equal(t, subsystemName, gnssSource.Subsystem, "subsystem should come from template resolution")
-	assert.Equal(t, "GNSS_1PPS_IN", gnssSource.BoardLabel, "boardLabel should come from template")
-
-	// User fields should be merged
-	assert.NotNil(t, gnssSource.GNSSConfig, "gnssConfig should be merged from user")
-	assert.True(t, gnssSource.GNSSConfig.Init.AntennaVoltage, "antennaVoltage should be user's value")
-	assert.Equal(t, 600, gnssSource.GNSSConfig.Init.SurveyIn.ObservationTime)
-	assert.NotNil(t, gnssSource.GNSSConfig.Match)
-	assert.Equal(t, testIfaceEno8703, gnssSource.GNSSConfig.Match.EthernetInterface)
-
-	// Conditions should come from template
-	assert.NotEmpty(t, behavior.Conditions)
-	assert.Equal(t, "Initialize T-GM", behavior.Conditions[0].Name)
-
-	t.Logf("✓ Merge successful: GNSS source has template pin details + user gnssConfig")
-	t.Logf("  Sources: %d, Conditions: %d", len(behavior.Sources), len(behavior.Conditions))
-}
-
-// TestResolveClockChain_MergesUserBehavior verifies that ResolveClockChain
-// merges user-provided sources onto template-derived sources even when the
-// user supplies a Behavior section (i.e. Behavior is non-nil).
-func TestResolveClockChain_MergesUserBehavior(t *testing.T) {
-	// Use the T-BC minimal config so deriveSubsystemStructure succeeds
-	// (T-BC has upstream ports available from the PTP config).
-	hwConfig, err := loadHardwareConfigFromFile("testdata/gnrd-hwconfig-minimal.yaml")
-	require.NoError(t, err)
-	require.NotNil(t, hwConfig)
-
-	// Attach user-provided Behavior with a custom source — Behavior is now non-nil.
-	// deriveBehavior should still run, merging template sources/conditions.
-	hwConfig.Spec.Profile.ClockChain.Behavior = &ptpv2alpha1.Behavior{
-		Sources: []ptpv2alpha1.SourceConfig{
-			{
-				Name:       "CustomDPLL",
-				SourceType: ptpv2alpha1.SourceTypeDPLL,
-				Subsystem:  testSubsystemLeader,
-				BoardLabel: "CUSTOM_PIN",
+			expectedBoardLabel: "GNSS_1PPS_IN",
+			expectedGnssConfig: &ptpv2alpha1.GNSSConfig{
+				Init: ptpv2alpha1.GNSSInit{
+					AntennaVoltage: true,
+					Constellations: []ptpv2alpha1.ConstellationID{ptpv2alpha1.ConstellationGPS},
+					SurveyIn: ptpv2alpha1.GNSSSurveyParameters{
+						ObservationTime: 600,
+						Accuracy:        5,
+					},
+				},
+				Match: &ptpv2alpha1.GNSSMatcher{
+					TTYDevice: testACM0,
+				},
 			},
 		},
-	}
-
-	ptpConfig, err := loadPtpConfigFromFile("testdata/tbc-gnrd.yaml")
-	require.NoError(t, err)
-
-	// Mock leading interface resolver for T-BC
-	mockResolver := newMockLeadingInterfaceResolver()
-	mockResolver.phcIDs["eno2"] = testDevPtp0
-	mockResolver.symlinks["/sys/class/ptp/ptp0/device"] = "../../../0000:13:00.0"
-	mockResolver.dirEntries["/sys/bus/pci/devices/0000:13:00.0/net"] = []os.DirEntry{
-		&mockDirEntry{name: "eno5", isDir: false},
-	}
-	SetLeadingInterfaceResolver(mockResolver)
-	defer ResetLeadingInterfaceResolver()
-
-	fakeClient := fake.NewClientset()
-	hcm := NewHardwareConfigManager(fakeClient, "default", nil)
-	resolved, err := hcm.ResolveClockChain(hwConfig, ptpConfig)
-	require.NoError(t, err)
-	require.NotNil(t, resolved)
-
-	behavior := resolved.Spec.Profile.ClockChain.Behavior
-	require.NotNil(t, behavior, "Behavior should be derived even when user provides sources")
-
-	// Template conditions should be present (not skipped because Behavior was non-nil)
-	assert.NotEmpty(t, behavior.Conditions, "Template conditions should be derived")
-	initCond := findConditionByName(behavior.Conditions, "Initialize T-BC")
-	assert.NotNil(t, initCond, "Initialize T-BC condition should come from template")
-
-	// Template PTP source should be present
-	ptpSource := findSourceByName(behavior.Sources, testSourcePTP)
-	assert.NotNil(t, ptpSource, "Template PTP source should be derived")
-
-	// User's custom source should also be present (unmatched, added as-is)
-	var customSource *ptpv2alpha1.SourceConfig
-	for i, s := range behavior.Sources {
-		if s.Name == "CustomDPLL" {
-			customSource = &behavior.Sources[i]
-			break
-		}
-	}
-	assert.NotNil(t, customSource, "User custom source should be preserved")
-	if customSource != nil {
-		assert.Equal(t, "CUSTOM_PIN", customSource.BoardLabel)
-	}
-}
-
-func TestDeriveBehavior_NoUserBehavior(t *testing.T) {
-	fakeClient := fake.NewClientset()
-	hcm := NewHardwareConfigManager(fakeClient, "default", nil)
-
-	clockType := testClockTypeTGM
-
-	// No user behavior — everything from template
-	hwConfig := &ptpv2alpha1.HardwareConfig{
-		Spec: ptpv2alpha1.HardwareConfigSpec{
-			Profile: ptpv2alpha1.HardwareProfile{
-				ClockType: &clockType,
-				ClockChain: &ptpv2alpha1.ClockChain{
-					Structure: []ptpv2alpha1.Subsystem{
-						{
-							Name:                        testSubsystemLeader,
-							HardwareSpecificDefinitions: HwDefIntelE825,
-							DPLL: ptpv2alpha1.DPLL{
-								NetworkInterface: testIfaceEns7f0,
+		{
+			name: "Full user override",
+			// User provides only gnssConfig on the GNSS source — the template
+			// provides the DPLL pin details and conditions.
+			hwConfig: &ptpv2alpha1.HardwareConfig{
+				Spec: ptpv2alpha1.HardwareConfigSpec{
+					Profile: ptpv2alpha1.HardwareProfile{
+						ClockType: &clockType,
+						ClockChain: &ptpv2alpha1.ClockChain{
+							Structure: []ptpv2alpha1.Subsystem{
+								{
+									Name:                        subsystemName,
+									HardwareSpecificDefinitions: HwDefDellXR8720t,
+									DPLL: ptpv2alpha1.DPLL{
+										NetworkInterface: testIfaceEno8703,
+									},
+									Ethernet: []ptpv2alpha1.Ethernet{
+										{Ports: []string{testIfaceEno8703}},
+									},
+								},
 							},
-							Ethernet: []ptpv2alpha1.Ethernet{
-								{Ports: []string{testIfaceEns7f0}},
+							Behavior: &ptpv2alpha1.Behavior{
+								Sources: []ptpv2alpha1.SourceConfig{
+									{
+										Name:       testSourceGNSS,
+										SourceType: ptpv2alpha1.SourceTypeGNSS,
+										GNSSConfig: &ptpv2alpha1.GNSSConfig{
+											Init: ptpv2alpha1.GNSSInit{
+												AntennaVoltage: true,
+												Constellations: []ptpv2alpha1.ConstellationID{ptpv2alpha1.ConstellationGPS},
+												SurveyIn: ptpv2alpha1.GNSSSurveyParameters{
+													ObservationTime: 600,
+													Accuracy:        5,
+												},
+											},
+											Match: &ptpv2alpha1.GNSSMatcher{
+												EthernetInterface: testIfaceEno8703,
+											},
+										},
+									},
+								},
 							},
 						},
 					},
 				},
 			},
+			expectedBoardLabel: "GNSS_1PPS_IN",
+			expectedGnssConfig: &ptpv2alpha1.GNSSConfig{
+				Init: ptpv2alpha1.GNSSInit{
+					AntennaVoltage: true,
+					Constellations: []ptpv2alpha1.ConstellationID{ptpv2alpha1.ConstellationGPS},
+					SurveyIn: ptpv2alpha1.GNSSSurveyParameters{
+						ObservationTime: 600,
+						Accuracy:        5,
+					},
+				},
+				Match: &ptpv2alpha1.GNSSMatcher{
+					EthernetInterface: testIfaceEno8703,
+				},
+			},
+		},
+		{
+			name: "User override of init only (no default matcher)",
+			// User provides only gnssConfig on the GNSS source — the template
+			// provides the DPLL pin details and conditions.
+			hwConfig: &ptpv2alpha1.HardwareConfig{
+				Spec: ptpv2alpha1.HardwareConfigSpec{
+					Profile: ptpv2alpha1.HardwareProfile{
+						ClockType: &clockType,
+						ClockChain: &ptpv2alpha1.ClockChain{
+							Structure: []ptpv2alpha1.Subsystem{
+								{
+									Name:                        subsystemName,
+									HardwareSpecificDefinitions: HwDefIntelE810,
+									DPLL: ptpv2alpha1.DPLL{
+										NetworkInterface: testIfaceEno8703,
+									},
+									Ethernet: []ptpv2alpha1.Ethernet{
+										{Ports: []string{testIfaceEno8703}},
+									},
+								},
+							},
+							Behavior: &ptpv2alpha1.Behavior{
+								Sources: []ptpv2alpha1.SourceConfig{
+									{
+										Name:       testSourceGNSS,
+										SourceType: ptpv2alpha1.SourceTypeGNSS,
+										GNSSConfig: &ptpv2alpha1.GNSSConfig{
+											Init: ptpv2alpha1.GNSSInit{
+												AntennaVoltage: true,
+												Constellations: []ptpv2alpha1.ConstellationID{ptpv2alpha1.ConstellationGPS},
+												SurveyIn: ptpv2alpha1.GNSSSurveyParameters{
+													ObservationTime: 600,
+													Accuracy:        5,
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedBoardLabel: "GNSS-1PPS",
+			expectedGnssConfig: &ptpv2alpha1.GNSSConfig{
+				Init: ptpv2alpha1.GNSSInit{
+					AntennaVoltage: true,
+					Constellations: []ptpv2alpha1.ConstellationID{ptpv2alpha1.ConstellationGPS},
+					SurveyIn: ptpv2alpha1.GNSSSurveyParameters{
+						ObservationTime: 600,
+						Accuracy:        5,
+					},
+				},
+				Match: nil,
+			},
+		},
+		{
+			name: "Full user override (no default matcher)",
+			// User provides only gnssConfig on the GNSS source — the template
+			// provides the DPLL pin details and conditions.
+			hwConfig: &ptpv2alpha1.HardwareConfig{
+				Spec: ptpv2alpha1.HardwareConfigSpec{
+					Profile: ptpv2alpha1.HardwareProfile{
+						ClockType: &clockType,
+						ClockChain: &ptpv2alpha1.ClockChain{
+							Structure: []ptpv2alpha1.Subsystem{
+								{
+									Name:                        subsystemName,
+									HardwareSpecificDefinitions: HwDefIntelE810,
+									DPLL: ptpv2alpha1.DPLL{
+										NetworkInterface: testIfaceEno8703,
+									},
+									Ethernet: []ptpv2alpha1.Ethernet{
+										{Ports: []string{testIfaceEno8703}},
+									},
+								},
+							},
+							Behavior: &ptpv2alpha1.Behavior{
+								Sources: []ptpv2alpha1.SourceConfig{
+									{
+										Name:       testSourceGNSS,
+										SourceType: ptpv2alpha1.SourceTypeGNSS,
+										GNSSConfig: &ptpv2alpha1.GNSSConfig{
+											Init: ptpv2alpha1.GNSSInit{
+												AntennaVoltage: true,
+												Constellations: []ptpv2alpha1.ConstellationID{ptpv2alpha1.ConstellationGPS},
+												SurveyIn: ptpv2alpha1.GNSSSurveyParameters{
+													ObservationTime: 600,
+													Accuracy:        5,
+												},
+											},
+											Match: &ptpv2alpha1.GNSSMatcher{
+												EthernetInterface: testIfaceEno8703,
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedBoardLabel: "GNSS-1PPS",
+			expectedGnssConfig: &ptpv2alpha1.GNSSConfig{
+				Init: ptpv2alpha1.GNSSInit{
+					AntennaVoltage: true,
+					Constellations: []ptpv2alpha1.ConstellationID{ptpv2alpha1.ConstellationGPS},
+					SurveyIn: ptpv2alpha1.GNSSSurveyParameters{
+						ObservationTime: 600,
+						Accuracy:        5,
+					},
+				},
+				Match: &ptpv2alpha1.GNSSMatcher{
+					EthernetInterface: testIfaceEno8703,
+				},
+			},
 		},
 	}
 
-	err := hcm.deriveBehavior(hwConfig, clockType)
-	assert.NoError(t, err)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := hcm.deriveBehavior(tt.hwConfig, clockType)
+			assert.NoError(t, err)
 
-	behavior := hwConfig.Spec.Profile.ClockChain.Behavior
-	assert.NotNil(t, behavior)
-	assert.NotEmpty(t, behavior.Sources, "should have template-derived sources")
-	assert.NotEmpty(t, behavior.Conditions, "should have template-derived conditions")
+			behavior := tt.hwConfig.Spec.Profile.ClockChain.Behavior
+			assert.NotNil(t, behavior)
 
-	// GNSS source should exist but without gnssConfig (no user input)
-	var gnssSource *ptpv2alpha1.SourceConfig
-	for i, s := range behavior.Sources {
-		if s.SourceType == ptpv2alpha1.SourceTypeGNSS {
-			gnssSource = &behavior.Sources[i]
-			break
-		}
+			// Should have the GNSS source from template with user's gnssConfig merged
+			var gnssSource *ptpv2alpha1.SourceConfig
+			for i, s := range behavior.Sources {
+				if s.SourceType == ptpv2alpha1.SourceTypeGNSS {
+					gnssSource = &behavior.Sources[i]
+					break
+				}
+			}
+			if !assert.NotNil(t, gnssSource, "GNSS source should exist") {
+				return
+			}
+
+			// Template fields should be resolved
+			assert.Equal(t, subsystemName, gnssSource.Subsystem, "subsystem should come from template resolution")
+			assert.Equal(t, tt.expectedBoardLabel, gnssSource.BoardLabel, "boardLabel should come from template")
+
+			// User fields should be merged
+			assert.NotNil(t, gnssSource.GNSSConfig, "gnssConfig should be merged from user")
+			assert.Equal(t, tt.expectedGnssConfig, gnssSource.GNSSConfig, "gnssConfig should match expected merged value")
+
+			// Conditions should come from template
+			assert.NotEmpty(t, behavior.Conditions)
+			assert.Equal(t, "Initialize T-GM", behavior.Conditions[0].Name)
+
+			t.Logf("✓ Merge successful: GNSS source has template pin details + user gnssConfig")
+			t.Logf("  Sources: %d, Conditions: %d", len(behavior.Sources), len(behavior.Conditions))
+		})
 	}
-	assert.NotNil(t, gnssSource, "GNSS source should come from template")
-	assert.Nil(t, gnssSource.GNSSConfig, "gnssConfig should be nil without user input")
 }


### PR DESCRIPTION
- **Add t-gm for GNR-D documentation**
- **Add reasonable GNSS TTY device defaults for hardwareconfigv2 behavior profiles**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Added documentation with end-to-end configuration examples for T-GM GNSS holdover on Dell XR8720t, including sample profiles and Kubernetes/OpenShift resources.
- **Bug Fixes**
  - Ensured GNSS device matcher settings are preserved during configuration merging, even when the user omits the device match.
- **Tests**
  - Updated GNSS tests to use a shared `/dev/ttyACM0` constant and expanded coverage with table-driven scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Testing Done

Ensured that T-GM goes locked (state s2) on GNR-D with the example config in `doc/t-gm-dell-XR8720t.md`