### PR TITLE
Make use of GNSSConfig.DeepCopy()

### DIFF
--- a/pkg/hardwareconfig/clockchain_resolution.go
+++ b/pkg/hardwareconfig/clockchain_resolution.go
@@ -1,7 +1,6 @@
 package hardwareconfig
 
 import (
-	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -489,10 +488,7 @@ func resolveTemplateString(s string, vars templateVariables) string {
 
 // deepCopyAndResolveSourceConfig deep copies a SourceConfig and resolves template variables
 func deepCopyAndResolveSourceConfig(src ptpv2alpha1.SourceConfig, vars templateVariables, upstreamPorts []string) ptpv2alpha1.SourceConfig {
-	// Deep copy using JSON marshal/unmarshal
-	data, _ := json.Marshal(src)
-	var resolved ptpv2alpha1.SourceConfig
-	_ = json.Unmarshal(data, &resolved)
+	resolved := src.DeepCopy()
 
 	// Resolve template variables
 	resolved.Subsystem = resolveTemplateString(resolved.Subsystem, vars)
@@ -504,15 +500,12 @@ func deepCopyAndResolveSourceConfig(src ptpv2alpha1.SourceConfig, vars templateV
 		copy(resolved.PTPTimeReceivers, upstreamPorts)
 	}
 
-	return resolved
+	return *resolved
 }
 
 // deepCopyAndResolveCondition deep copies a Condition and resolves template variables
 func deepCopyAndResolveCondition(cond ptpv2alpha1.Condition, vars templateVariables) ptpv2alpha1.Condition {
-	// Deep copy using JSON marshal/unmarshal
-	data, _ := json.Marshal(cond)
-	var resolved ptpv2alpha1.Condition
-	_ = json.Unmarshal(data, &resolved)
+	resolved := cond.DeepCopy()
 
 	// Resolve template variables in desired states
 	for i := range resolved.DesiredStates {
@@ -525,7 +518,7 @@ func deepCopyAndResolveCondition(cond ptpv2alpha1.Condition, vars templateVariab
 		}
 	}
 
-	return resolved
+	return *resolved
 }
 
 // deriveBehavior derives behavior section from templates
@@ -661,16 +654,11 @@ func mergeSourceConfig(tpl, user *ptpv2alpha1.SourceConfig) {
 	}
 	if user.GNSSConfig != nil {
 		// Explicitly shallow-copy the user GNSS config
-		gnss := *user.GNSSConfig
-		if user.GNSSConfig.Match != nil {
-			// Prefer: shallow-copy the user GNSS matcher (if set)
-			match := *user.GNSSConfig.Match
-			gnss.Match = &match
-		} else if tpl.GNSSConfig != nil && tpl.GNSSConfig.Match != nil {
-			// Fallback: shallow-copy the original template matcher (if set)
-			match := *tpl.GNSSConfig.Match
-			gnss.Match = &match
+		gnss := user.GNSSConfig.DeepCopy()
+		if user.GNSSConfig.Match == nil && tpl.GNSSConfig != nil && tpl.GNSSConfig.Match != nil {
+			// Fallback to the template matcher if no user matcher was provided
+			gnss.Match = tpl.GNSSConfig.Match.DeepCopy()
 		}
-		tpl.GNSSConfig = &gnss
+		tpl.GNSSConfig = gnss
 	}
 }

--- a/pkg/hardwareconfig/clockchain_resolution_test.go
+++ b/pkg/hardwareconfig/clockchain_resolution_test.go
@@ -900,6 +900,8 @@ func TestDeriveBehavior_UserConditionsPreserved(t *testing.T) {
 func Test_mergeSourceConfig(t *testing.T) {
 	const ttyTpl = "/dev/tty-tpl"
 	const ttyUser = "/dev/tty-user"
+	const testCustomCommand = "custom-command"
+	const testStandardCommand = "standard-command"
 
 	tests := []struct {
 		name     string
@@ -1053,6 +1055,36 @@ func Test_mergeSourceConfig(t *testing.T) {
 			},
 			expected: &ptpv2alpha1.SourceConfig{
 				GNSSConfig: &ptpv2alpha1.GNSSConfig{},
+			},
+		},
+		{
+			name: "user provides init value, already one in template",
+			tpl: &ptpv2alpha1.SourceConfig{
+				GNSSConfig: &ptpv2alpha1.GNSSConfig{
+					Init: ptpv2alpha1.GNSSInit{
+						ExtraCommands: []ptpv2alpha1.UBLXCommand{
+							{Args: []string{testStandardCommand}, Record: true},
+						},
+					},
+				},
+			},
+			user: &ptpv2alpha1.SourceConfig{
+				GNSSConfig: &ptpv2alpha1.GNSSConfig{
+					Init: ptpv2alpha1.GNSSInit{
+						ExtraCommands: []ptpv2alpha1.UBLXCommand{
+							{Args: []string{testCustomCommand}, Record: true},
+						},
+					},
+				},
+			},
+			expected: &ptpv2alpha1.SourceConfig{
+				GNSSConfig: &ptpv2alpha1.GNSSConfig{
+					Init: ptpv2alpha1.GNSSInit{
+						ExtraCommands: []ptpv2alpha1.UBLXCommand{
+							{Args: []string{testCustomCommand}, Record: true},
+						},
+					},
+				},
 			},
 		},
 	}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved hardware configuration merging to preserve template settings while safely applying user overrides.
  * Ensured GNSS matcher data is copied correctly during merges, preventing unintended shared-pointer behavior.
  * Maintained proper resolution of template variables after copying and merging.
* **Tests**
  * Extended merge tests to cover GNSS `Init` override behavior when the template already defines matching values, including command list merging assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->