### PR TITLE
CNF-26080: Add ipc cache for cloud event proxy v2

### DIFF
--- a/cmd/cloud-event-proxy/main.go
+++ b/cmd/cloud-event-proxy/main.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/cep"
+	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/ipc"
 
 	"github.com/golang/glog"
 )
@@ -73,7 +74,13 @@ func main() {
 				glog.Errorf("accept error: %v", acceptErr)
 				continue
 			}
-			glog.Info("daemon connected")
+			glog.Info("daemon connected, requesting current state")
+			conn.SetWriteDeadline(time.Now().Add(5 * time.Second))
+			if encodeErr := ipc.Transmit(conn, ipc.Message{Type: ipc.TypeStatusRequest, Version: ipc.Version}); encodeErr != nil {
+				glog.Errorf("failed to send status_request: %v", encodeErr)
+				conn.Close()
+				continue
+			}
 			proxy.Listen(conn)
 			conn.Close()
 			glog.Warning("daemon disconnected")

--- a/pkg/cep/cep.go
+++ b/pkg/cep/cep.go
@@ -172,10 +172,6 @@ func (l *CloudEventProxy) Listen(r io.Reader) {
 			glog.Info("received cache_clear from daemon, clearing event cache")
 			l.cache.Clear()
 			continue
-		case ipc.TypeStatusResponse:
-			// TODO: handle this
-			glog.Info("received status_response from daemon")
-			continue
 		case ipc.TypeStatusRequest:
 			glog.Warning("received status_request from daemon (unexpected direction)")
 			continue

--- a/pkg/cep/cep_test.go
+++ b/pkg/cep/cep_test.go
@@ -134,10 +134,10 @@ func TestListenerResilience(t *testing.T) {
 			name: "version mismatch ignored",
 			input: func() io.Reader {
 				var buf bytes.Buffer
-				ipc.Encode(&buf, []ipc.Message{{
+				ipc.Transmit(&buf, ipc.Message{
 					Version: 99, Type: ipc.TypePTPState, Profile: testProfile,
 					IFace: testIFace, Values: ipc.StateValue{State: ipc.StateLocked},
-				}})
+				})
 				return &buf
 			},
 			wantCached: false,
@@ -147,7 +147,7 @@ func TestListenerResilience(t *testing.T) {
 			input: func() io.Reader {
 				var buf bytes.Buffer
 				buf.WriteString("not json\n")
-				ipc.Encode(&buf, []ipc.Message{validMsg})
+				ipc.Transmit(&buf, validMsg)
 				return &buf
 			},
 			wantCached: true,
@@ -161,26 +161,11 @@ func TestListenerResilience(t *testing.T) {
 			wantCached: true,
 		},
 		{
-			name: "status_response not cached",
-			input: func() io.Reader {
-				var buf bytes.Buffer
-				ipc.Encode(&buf, []ipc.Message{{
-					Version: ipc.Version,
-					Type:    ipc.TypeStatusResponse,
-				}})
-				return &buf
-			},
-			wantCached: false,
-		},
-		{
 			name: "cache_clear wipes prior entries",
 			input: func() io.Reader {
 				var buf bytes.Buffer
-				ipc.Encode(&buf, []ipc.Message{
-					{Version: ipc.Version, Type: ipc.TypePTPState, Profile: testProfile,
-						IFace: testIFace, Values: ipc.StateValue{State: ipc.StateLocked}},
-					{Version: ipc.Version, Type: ipc.TypeCacheClear},
-				})
+				ipc.Transmit(&buf, ipc.Message{Version: ipc.Version, Type: ipc.TypePTPState, Profile: testProfile, IFace: testIFace, Values: ipc.StateValue{State: ipc.StateLocked}})
+				ipc.Transmit(&buf, ipc.Message{Version: ipc.Version, Type: ipc.TypeCacheClear})
 				return &buf
 			},
 			wantCached: false,
@@ -246,14 +231,15 @@ func TestIntegrationEventDelivery(t *testing.T) {
 			close(done)
 		}()
 
-		ipc.Encode(pw, []ipc.Message{
-			{Version: ipc.Version, Type: ipc.TypePTPState, Profile: testProfile,
-				IFace: testIFace, Values: ipc.StateValue{State: ipc.StateLocked}},
-			{Version: ipc.Version, Type: ipc.TypeGNSSState, Profile: "ts2phc.0.config",
-				IFace: testIFace, Values: ipc.GNSSStateValue{State: ipc.GNSSSynchronized}},
-			{Version: ipc.Version, Type: ipc.TypePTPState, Profile: testProfile,
-				IFace: testIFace, Values: ipc.StateValue{State: ipc.StateFreerun}},
-		})
+		ipc.Transmit(pw, ipc.Message{
+			Version: ipc.Version, Type: ipc.TypePTPState, Profile: testProfile,
+			IFace: testIFace, Values: ipc.StateValue{State: ipc.StateLocked}})
+		ipc.Transmit(pw, ipc.Message{
+			Version: ipc.Version, Type: ipc.TypeGNSSState, Profile: "ts2phc.0.config",
+			IFace: testIFace, Values: ipc.GNSSStateValue{State: ipc.GNSSSynchronized}})
+		ipc.Transmit(pw, ipc.Message{
+			Version: ipc.Version, Type: ipc.TypePTPState, Profile: testProfile,
+			IFace: testIFace, Values: ipc.StateValue{State: ipc.StateFreerun}})
 
 		pw.Close()
 		<-done
@@ -463,12 +449,12 @@ func TestIntegrationCurrentState(t *testing.T) {
 		close(done)
 	}()
 
-	ipc.Encode(pw, []ipc.Message{
-		{Version: ipc.Version, Type: ipc.TypePTPState, Profile: testProfile,
-			IFace: testIFace, Values: ipc.StateValue{State: ipc.StateLocked}},
-		{Version: ipc.Version, Type: ipc.TypePTPState, Profile: testProfile,
-			IFace: testIFace, Values: ipc.StateValue{State: ipc.StateFreerun}},
-	})
+	ipc.Transmit(pw, ipc.Message{
+		Version: ipc.Version, Type: ipc.TypePTPState, Profile: testProfile,
+		IFace: testIFace, Values: ipc.StateValue{State: ipc.StateLocked}})
+	ipc.Transmit(pw, ipc.Message{
+		Version: ipc.Version, Type: ipc.TypePTPState, Profile: testProfile,
+		IFace: testIFace, Values: ipc.StateValue{State: ipc.StateFreerun}})
 
 	pw.Close()
 	<-done

--- a/pkg/cep/event_cache_test.go
+++ b/pkg/cep/event_cache_test.go
@@ -24,11 +24,9 @@ func TestEventCache_GetBySource(t *testing.T) {
 		proxy := NewCloudEventProxy(cache, nil)
 
 		var buf bytes.Buffer
-		ipc.Encode(&buf, []ipc.Message{{
-			Version: ipc.Version, Type: ipc.TypePTPState,
-			Profile: testProfile, IFace: testIFace,
-			Values: ipc.StateValue{State: ipc.StateLocked},
-		}})
+		ipc.Transmit(&buf, ipc.Message{
+			Version: ipc.Version, Type: ipc.TypePTPState, Profile: testProfile, IFace: testIFace, Values: ipc.StateValue{State: ipc.StateLocked},
+		})
 		proxy.Listen(&buf)
 
 		e, ok := cache.GetBySource(testPTPLockState)

--- a/pkg/event/event.go
+++ b/pkg/event/event.go
@@ -736,10 +736,13 @@ func (e *EventHandler) reconnectEventSocket() bool {
 	}()
 	defer cancel()
 	dialer := net.Dialer{Timeout: socketDialTimeout}
-	newConn := utils.ReconnectWithBackoff(ctx,
+	newConn, err := utils.ReconnectWithBackoff(ctx,
 		func() (net.Conn, error) { return dialer.DialContext(ctx, "unix", e.stdoutSocket) },
 		utils.DefaultReconnectConfig(),
 	)
+	if err != nil {
+		glog.Errorf("failed to reconnect to event socket %s: %v", e.stdoutSocket, err)
+	}
 	if newConn != nil {
 		e.setConn(newConn)
 		return true

--- a/pkg/ipc/cache.go
+++ b/pkg/ipc/cache.go
@@ -1,0 +1,81 @@
+package ipc
+
+import (
+	"sync"
+	"time"
+)
+
+type cacheKey struct {
+	msgType string
+	profile string
+	iface   string
+}
+
+// Cache tracks the latest IPC message per (type, profile, iface) and provides a channel for outbound messages. It
+// deduplicates by suppressing messages whose values match the last-emitted state for the same key.
+type Cache struct {
+	mu    sync.Mutex
+	store map[cacheKey]Message
+	outCh chan Message
+}
+
+// NewCache creates a cache with a buffered outbound channel of the given size.
+func NewCache(bufSize int) *Cache {
+	return &Cache{
+		store: make(map[cacheKey]Message),
+		outCh: make(chan Message, bufSize),
+	}
+}
+
+// Send stores a message in the cache and writes it to the outbound channel. Returns false if the message is a duplicate
+// (same Values and IFace as the last message for this type/profile key).
+func (c *Cache) Send(msg Message) bool {
+	if msg.Version == 0 {
+		msg.Version = Version
+	}
+	if msg.Timestamp == "" {
+		msg.Timestamp = time.Now().UTC().Format(time.RFC3339Nano)
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	key := cacheKey{msgType: msg.Type, profile: msg.Profile, iface: msg.IFace}
+	if prev, ok := c.store[key]; ok && prev.ValuesEqual(msg) {
+		return false
+	}
+	c.store[key] = msg
+
+	// In case of a full buffer, drop the message. The state will be recorded within the cache, but not sent
+	// This should only realistically happen if cloud-event-proxy goes down for some reason. In that case, when it comes
+	// back up it will request a snapshot, and will receive the missed event.
+	select {
+	case c.outCh <- msg:
+	default:
+		// drop message
+	}
+	return true
+}
+
+// Snapshot returns a copy of all cached messages.
+func (c *Cache) Snapshot() []Message {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	msgs := make([]Message, 0, len(c.store))
+	for _, msg := range c.store {
+		msgs = append(msgs, msg)
+	}
+	return msgs
+}
+
+// Clear removes all cached messages.
+func (c *Cache) Clear() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.store = make(map[cacheKey]Message)
+}
+
+// Out returns the read-only outbound message channel.
+func (c *Cache) Out() <-chan Message {
+	return c.outCh
+}

--- a/pkg/ipc/cache_test.go
+++ b/pkg/ipc/cache_test.go
@@ -1,0 +1,203 @@
+package ipc
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	testProfile = "ptp4l.0.config"
+	testIFace   = "ens2f0"
+)
+
+func TestCacheSendAndDedup(t *testing.T) {
+	c := NewCache(10)
+
+	msg := Message{
+		Type:    TypePTPState,
+		Profile: testProfile,
+		IFace:   testIFace,
+		Values:  StateValue{State: StateLocked},
+	}
+
+	assert.True(t, c.Send(msg), "first send should store")
+	assert.False(t, c.Send(msg), "duplicate should be suppressed")
+
+	updated := msg
+	updated.Values = StateValue{State: StateFreerun}
+	assert.True(t, c.Send(updated), "changed values should store")
+	assert.False(t, c.Send(updated), "same changed values should be suppressed")
+}
+
+func TestCacheSendDifferentKeys(t *testing.T) {
+	c := NewCache(10)
+
+	ptpMsg := Message{
+		Type:    TypePTPState,
+		Profile: testProfile,
+		Values:  StateValue{State: StateLocked},
+	}
+	clockMsg := Message{
+		Type:    TypeClockClass,
+		Profile: testProfile,
+		Values:  ClockClassValue{ClockClass: 6},
+	}
+
+	assert.True(t, c.Send(ptpMsg))
+	assert.True(t, c.Send(clockMsg))
+
+	snap := c.Snapshot()
+	assert.Len(t, snap, 2)
+}
+
+func TestCacheSendDifferentProfiles(t *testing.T) {
+	c := NewCache(10)
+
+	msg0 := Message{
+		Type:    TypePTPState,
+		Profile: testProfile,
+		Values:  StateValue{State: StateLocked},
+	}
+	msg1 := Message{
+		Type:    TypePTPState,
+		Profile: "ptp4l.1.config",
+		Values:  StateValue{State: StateFreerun},
+	}
+
+	assert.True(t, c.Send(msg0))
+	assert.True(t, c.Send(msg1))
+
+	snap := c.Snapshot()
+	assert.Len(t, snap, 2)
+}
+
+func TestCacheOutChannel(t *testing.T) {
+	c := NewCache(10)
+
+	msg := Message{
+		Type:    TypePTPState,
+		Profile: testProfile,
+		Values:  StateValue{State: StateLocked},
+	}
+	c.Send(msg)
+
+	select {
+	case got := <-c.Out():
+		assert.Equal(t, TypePTPState, got.Type)
+		assert.Equal(t, StateValue{State: StateLocked}, got.Values)
+	case <-time.After(time.Second):
+		t.Fatal("expected message on outbound channel")
+	}
+
+	// Duplicate should not produce a channel message
+	c.Send(msg)
+	select {
+	case <-c.Out():
+		t.Fatal("duplicate should not produce outbound message")
+	case <-time.After(50 * time.Millisecond):
+	}
+}
+
+func TestCacheOutChannelNonBlocking(t *testing.T) {
+	c := NewCache(1) // buffer size 1
+
+	msg1 := Message{Type: TypePTPState, Profile: testProfile, Values: StateValue{State: StateLocked}}
+	msg2 := Message{Type: TypeClockClass, Profile: testProfile, Values: ClockClassValue{ClockClass: 6}}
+
+	c.Send(msg1) // fills the channel buffer
+	c.Send(msg2) // should not block even though channel is full
+
+	snap := c.Snapshot()
+	assert.Len(t, snap, 2, "both messages should be in the cache store even if channel is full")
+}
+
+func TestCacheSnapshot(t *testing.T) {
+	c := NewCache(10)
+
+	c.Send(Message{Type: TypePTPState, Profile: testProfile, Values: StateValue{State: StateLocked}})
+	c.Send(Message{Type: TypeClockClass, Profile: testProfile, Values: ClockClassValue{ClockClass: 7}})
+
+	snap := c.Snapshot()
+	require.Len(t, snap, 2)
+
+	types := map[string]bool{}
+	for _, m := range snap {
+		types[m.Type] = true
+	}
+	assert.True(t, types[TypePTPState])
+	assert.True(t, types[TypeClockClass])
+}
+
+func TestCacheClear(t *testing.T) {
+	c := NewCache(10)
+
+	c.Send(Message{Type: TypePTPState, Profile: testProfile, Values: StateValue{State: StateLocked}})
+	assert.Len(t, c.Snapshot(), 1)
+
+	c.Clear()
+	assert.Len(t, c.Snapshot(), 0)
+
+	// After clear, same message should be accepted again (no longer a duplicate)
+	assert.True(t, c.Send(Message{Type: TypePTPState, Profile: testProfile, Values: StateValue{State: StateLocked}}))
+}
+
+func TestCacheAutoFillsVersionAndTimestamp(t *testing.T) {
+	c := NewCache(10)
+
+	msg := Message{
+		Type:    TypePTPState,
+		Profile: testProfile,
+		Values:  StateValue{State: StateLocked},
+	}
+	c.Send(msg)
+
+	got := <-c.Out()
+	assert.Equal(t, Version, got.Version)
+	assert.NotEmpty(t, got.Timestamp)
+
+	_, err := time.Parse(time.RFC3339Nano, got.Timestamp)
+	assert.NoError(t, err, "timestamp should be valid RFC3339Nano")
+}
+
+func TestCachePreservesExplicitVersionAndTimestamp(t *testing.T) {
+	c := NewCache(10)
+
+	msg := Message{
+		Version:   42,
+		Timestamp: "2024-01-15T10:30:00.123456789Z",
+		Type:      TypePTPState,
+		Profile:   testProfile,
+		Values:    StateValue{State: StateLocked},
+	}
+	c.Send(msg)
+
+	got := <-c.Out()
+	assert.Equal(t, 42, got.Version)
+	assert.Equal(t, "2024-01-15T10:30:00.123456789Z", got.Timestamp)
+}
+
+func TestCacheIFaceChangeIsNotDuplicate(t *testing.T) {
+	c := NewCache(10)
+
+	msg1 := Message{
+		Type:    TypePTPState,
+		Profile: testProfile,
+		IFace:   testIFace,
+		Values:  StateValue{State: StateLocked},
+	}
+	msg2 := Message{
+		Type:    TypePTPState,
+		Profile: testProfile,
+		IFace:   "ens3f0",
+		Values:  StateValue{State: StateLocked},
+	}
+
+	assert.True(t, c.Send(msg1))
+	assert.True(t, c.Send(msg2), "different IFace should not be treated as duplicate")
+
+	snap := c.Snapshot()
+	assert.Len(t, snap, 2, "snapshot should retain both interface entries")
+}

--- a/pkg/ipc/ipc.go
+++ b/pkg/ipc/ipc.go
@@ -19,7 +19,6 @@ const (
 	TypeSyncState         = "sync_state"
 	TypeCacheClear        = "cache_clear"
 	TypeStatusRequest     = "status_request"
-	TypeStatusResponse    = "status_response"
 )
 
 // Synchronization state values.
@@ -122,9 +121,36 @@ func (m *Message) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+// ValuesEqual reports whether m and other carry the same Values.
+func (m Message) ValuesEqual(other Message) bool {
+	switch v := m.Values.(type) {
+	case StateValue:
+		w, ok := other.Values.(StateValue)
+		return ok && v == w
+	case GNSSStateValue:
+		w, ok := other.Values.(GNSSStateValue)
+		return ok && v == w
+	case SyncStateValue:
+		w, ok := other.Values.(SyncStateValue)
+		return ok && v == w
+	case SyncEStateValue:
+		w, ok := other.Values.(SyncEStateValue)
+		return ok && v == w
+	case ClockClassValue:
+		w, ok := other.Values.(ClockClassValue)
+		return ok && v == w
+	case SyncEClockQualityValue:
+		w, ok := other.Values.(SyncEClockQualityValue)
+		return ok && v == w
+	default:
+		return false
+	}
+}
+
 // StateValue carries a PTP or OS clock synchronization state.
 type StateValue struct {
-	State string `json:"state"`
+	State  string `json:"state"`
+	Offset int64  `json:"offset,omitempty"`
 }
 
 // Value implements Value.
@@ -171,11 +197,11 @@ type SyncEClockQualityValue struct {
 // Value implements Value.
 func (SyncEClockQualityValue) Value() {}
 
-// Encode encodes the given msgs as newline deliminated JSON, and writes them to the given writer
-func Encode(w io.Writer, msgs []Message) error {
+// Transmit encodes the given messages as newline-delimited JSON and writes them to the given writer.
+func Transmit(w io.Writer, msgs ...Message) error {
 	enc := json.NewEncoder(w)
-	for _, m := range msgs {
-		if err := enc.Encode(m); err != nil {
+	for _, msg := range msgs {
+		if err := enc.Encode(msg); err != nil {
 			return err
 		}
 	}

--- a/pkg/ipc/ipc_test.go
+++ b/pkg/ipc/ipc_test.go
@@ -19,16 +19,16 @@ func TestMessageJSON(t *testing.T) {
 			msg: Message{
 				Version: Version, Type: TypePTPState,
 				Timestamp: "2024-01-15T10:30:00.123456789Z",
-				Profile:   "ptp4l.0.config", IFace: "ens2f0",
-				Values: StateValue{State: StateLocked},
+				Profile:   testProfile, IFace: testIFace,
+				Values: StateValue{State: StateLocked, Offset: -42},
 			},
-			wantValues: StateValue{State: StateLocked},
+			wantValues: StateValue{State: StateLocked, Offset: -42},
 		},
 		{
 			name: "gnss state value",
 			msg: Message{
 				Version: Version, Type: TypeGNSSState,
-				Profile: "ts2phc.0.config", IFace: "ens2f0",
+				Profile: "ts2phc.0.config", IFace: testIFace,
 				Values: GNSSStateValue{State: GNSSSynchronized},
 			},
 			wantValues: GNSSStateValue{State: GNSSSynchronized},
@@ -37,7 +37,7 @@ func TestMessageJSON(t *testing.T) {
 			name: "sync state value",
 			msg: Message{
 				Version: Version, Type: TypeSyncState,
-				Profile: "ptp4l.0.config",
+				Profile: testProfile,
 				Values:  SyncStateValue{State: StateLocked},
 			},
 			wantValues: SyncStateValue{State: StateLocked},
@@ -55,7 +55,7 @@ func TestMessageJSON(t *testing.T) {
 			name: "clock class value",
 			msg: Message{
 				Version: Version, Type: TypeClockClass,
-				Profile: "ptp4l.0.config",
+				Profile: testProfile,
 				Values:  ClockClassValue{ClockClass: 6},
 			},
 			wantValues: ClockClassValue{ClockClass: 6},

--- a/pkg/ipc/link.go
+++ b/pkg/ipc/link.go
@@ -1,0 +1,153 @@
+package ipc
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"time"
+
+	"github.com/golang/glog"
+	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/utils"
+)
+
+const (
+	linkDialTimeout  = 5 * time.Second
+	linkWriteTimeout = 5 * time.Second
+)
+
+// Link is the bridge between an ipc.Cache and an external program. Link drains a Cache's outbound channel and writes
+// each message to a Unix socket as newline-delimited JSON. It also reads from the connection: when it receives a
+// status_request, the Link responds with the current state of the cache.
+type Link struct {
+	socketPath string
+	dialFn     func(ctx context.Context) (net.Conn, error)
+	cache      *Cache
+}
+
+// NewLink creates a Link using the given socket and cache.
+func NewLink(socketPath string, cache *Cache) *Link {
+	return &Link{
+		socketPath: socketPath,
+		dialFn: func(ctx context.Context) (net.Conn, error) {
+			d := net.Dialer{Timeout: linkDialTimeout}
+			return d.DialContext(ctx, "unix", socketPath)
+		},
+		cache: cache,
+	}
+}
+
+// Run establishes a connection to the socket, and blocks, waiting on new messages. It will also drain the cache.Out
+// channel writing each message to the socket.
+func (l *Link) Run(ctx context.Context) {
+	for {
+		conn := l.dial(ctx)
+		if conn == nil {
+			return
+		}
+		inCh := make(chan Message)
+		go l.scan(ctx, conn, inCh)
+
+		l.serve(ctx, conn, inCh)
+		if err := conn.Close(); err != nil {
+			glog.Errorf("Failed to close socket: %v", err)
+		}
+
+		if ctx.Err() != nil {
+			return
+		}
+		glog.Info("IPC link: peer disconnected, reconnecting")
+	}
+}
+
+// dial retries indefinitely with exponential backoff until a connection
+// is established or the context is canceled.
+func (l *Link) dial(ctx context.Context) net.Conn {
+	dialFn := func() (net.Conn, error) { return l.dialFn(ctx) }
+
+	for {
+		conn, err := utils.ReconnectWithBackoff(ctx, dialFn, utils.DefaultReconnectConfig())
+		if conn != nil {
+			return conn
+		}
+		select {
+		case <-ctx.Done():
+			return nil
+		default:
+			glog.Warningf("IPC link: failed to connect to socket: %v, retrying", err)
+		}
+	}
+}
+
+// scan reads incoming messages from r and sends them on ch.
+// It closes ch when the scanner fails, signaling that the connection
+// is broken.
+func (l *Link) scan(ctx context.Context, r io.Reader, ch chan<- Message) {
+	defer close(ch)
+
+	scanner := bufio.NewScanner(r)
+	for scanner.Scan() {
+		var msg Message
+		if err := json.Unmarshal(scanner.Bytes(), &msg); err != nil {
+			glog.Warningf("IPC link: failed to unmarshal incoming message: %v", err)
+			continue
+		}
+		select {
+		case ch <- msg:
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+// serve writes data to the socket as required
+func (l *Link) serve(ctx context.Context, conn net.Conn, statusCh <-chan Message) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		// handle status requests
+		case msg, ok := <-statusCh:
+			if !ok {
+				// when scan() closes the chan this will return
+				return
+			}
+			if msg.Type == TypeStatusRequest {
+				glog.V(11).Info("IPC link: received status_request, sending snapshot")
+				if err := l.writeSnapshot(conn); err != nil {
+					glog.Errorf("IPC link: snapshot response failed: %v", err)
+
+					return
+				}
+			}
+		// new cache entry needs to be pushed out
+		case msg := <-l.cache.Out():
+			if err := l.transmit(conn, msg); err != nil {
+				return
+			}
+		}
+	}
+}
+
+// writeSnapshot will generate individual messages based on every entry in the cache, and send them to the socket.
+func (l *Link) writeSnapshot(conn net.Conn) error {
+	msgs := l.cache.Snapshot()
+	if len(msgs) == 0 {
+		return nil
+	}
+	for _, msg := range msgs {
+		if err := l.transmit(conn, msg); err != nil {
+			return fmt.Errorf("failed to encode message: %w", err)
+		}
+	}
+	return nil
+}
+
+func (l *Link) transmit(conn net.Conn, msg Message) error {
+	if err := conn.SetWriteDeadline(time.Now().Add(linkWriteTimeout)); err != nil {
+		glog.Warningf("IPC link: failed to set write deadline: %v", err)
+	}
+	return Transmit(conn, msg)
+}

--- a/pkg/ipc/link_test.go
+++ b/pkg/ipc/link_test.go
@@ -1,0 +1,112 @@
+package ipc
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newTestLink creates a Link wired to an in-memory net.Pipe.
+// Returns the Link (not yet running) and the remote end of the pipe.
+// Because dial() is called once per Run() connection cycle, the dialFn
+// returns the same linkEnd every time; for reconnection tests a more
+// sophisticated factory would be needed.
+func newTestLink(cache *Cache) (*Link, net.Conn) {
+	linkEnd, remoteEnd := net.Pipe()
+
+	l := NewLink("", cache)
+	l.dialFn = func(context.Context) (net.Conn, error) {
+		return linkEnd, nil
+	}
+	return l, remoteEnd
+}
+
+func TestLinkSnapshotOnStatusRequest(t *testing.T) {
+	cache := NewCache(64)
+	cache.Send(Message{Type: TypePTPState, Profile: "ptp4l.0.config", IFace: "ens2f0", Values: StateValue{State: StateLocked}})
+	cache.Send(Message{Type: TypeClockClass, Profile: "ptp4l.0.config", Values: ClockClassValue{ClockClass: 6}})
+	for len(cache.outCh) > 0 {
+		<-cache.outCh
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	l, remote := newTestLink(cache)
+	defer remote.Close()
+	go l.Run(ctx)
+
+	err := Transmit(remote, Message{Type: TypeStatusRequest, Version: Version})
+	require.NoError(t, err)
+
+	scanner := bufio.NewScanner(remote)
+	received := map[string]Message{}
+	for len(received) < 2 {
+		remote.SetReadDeadline(time.Now().Add(5 * time.Second))
+		if !scanner.Scan() {
+			t.Fatalf("scanner stopped after %d messages: %v", len(received), scanner.Err())
+		}
+		var msg Message
+		require.NoError(t, json.Unmarshal(scanner.Bytes(), &msg))
+		received[msg.Type] = msg
+	}
+
+	assert.Contains(t, received, TypePTPState)
+	assert.Contains(t, received, TypeClockClass)
+	assert.Equal(t, StateLocked, received[TypePTPState].Values.(StateValue).State)
+	assert.Equal(t, uint8(6), received[TypeClockClass].Values.(ClockClassValue).ClockClass)
+}
+
+func TestLinkLiveMessages(t *testing.T) {
+	cache := NewCache(64)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	l, remote := newTestLink(cache)
+	defer remote.Close()
+	go l.Run(ctx)
+
+	cache.Send(Message{Type: TypeGNSSState, Profile: "ts2phc.0.config", IFace: "ens2f0", Values: GNSSStateValue{State: GNSSSynchronized}})
+
+	scanner := bufio.NewScanner(remote)
+	remote.SetReadDeadline(time.Now().Add(5 * time.Second))
+	require.True(t, scanner.Scan(), "expected to read a message")
+
+	var msg Message
+	require.NoError(t, json.Unmarshal(scanner.Bytes(), &msg))
+	assert.Equal(t, TypeGNSSState, msg.Type)
+	assert.Equal(t, GNSSSynchronized, msg.Values.(GNSSStateValue).State)
+}
+
+func TestLinkShutdown(t *testing.T) {
+	cache := NewCache(64)
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	l, remote := newTestLink(cache)
+	defer remote.Close()
+
+	done := make(chan struct{})
+	go func() {
+		l.Run(ctx)
+		close(done)
+	}()
+
+	// Give Run() time to dial and start loops
+	time.Sleep(50 * time.Millisecond)
+
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Link.Run() did not exit after context cancellation")
+	}
+}

--- a/pkg/utils/reconnect.go
+++ b/pkg/utils/reconnect.go
@@ -5,6 +5,7 @@ package utils
 
 import (
 	"context"
+	"fmt"
 	"net"
 	"time"
 
@@ -42,24 +43,26 @@ func DefaultReconnectConfig() ReconnectConfig {
 // ReconnectWithBackoff attempts to establish a connection using the provided dial function.
 // It retries with exponential backoff up to cfg.MaxAttempts times, and is responsive to
 // cancellation via the provided context.
-// Returns the new connection, or nil if all attempts are exhausted or the context is cancelled.
-func ReconnectWithBackoff(ctx context.Context, dialFn func() (net.Conn, error), cfg ReconnectConfig) net.Conn {
+// Returns the new connection, or an error if all attempts are exhausted or the context is cancelled.
+func ReconnectWithBackoff(ctx context.Context, dialFn func() (net.Conn, error), cfg ReconnectConfig) (net.Conn, error) {
 	glog.Info("Attempting to reconnect to event socket")
 
+	var lastErr error
 	backoff := cfg.BackoffBase
 	for attempt := 1; attempt <= cfg.MaxAttempts; attempt++ {
 		select {
 		case <-ctx.Done():
 			glog.Info("Stop signal received, aborting reconnect attempt")
-			return nil
+			return nil, ctx.Err()
 		default:
 		}
 
 		newConn, err := dialFn()
 		if err == nil {
 			glog.Infof("Successfully reconnected to event socket after %d attempt(s)", attempt)
-			return newConn
+			return newConn, nil
 		}
+		lastErr = err
 
 		if attempt < cfg.MaxAttempts {
 			glog.Warningf("Failed to reconnect to event socket (attempt %d/%d): %v, retrying in %v",
@@ -68,7 +71,7 @@ func ReconnectWithBackoff(ctx context.Context, dialFn func() (net.Conn, error), 
 			case <-time.After(backoff):
 			case <-ctx.Done():
 				glog.Info("Stop signal received during backoff, aborting reconnect")
-				return nil
+				return nil, ctx.Err()
 			}
 			backoff *= 2
 			if backoff > cfg.MaxBackoff {
@@ -78,5 +81,5 @@ func ReconnectWithBackoff(ctx context.Context, dialFn func() (net.Conn, error), 
 	}
 
 	glog.Errorf("Failed to reconnect to event socket after %d attempts", cfg.MaxAttempts)
-	return nil
+	return nil, fmt.Errorf("failed after %d attempts: %w", cfg.MaxAttempts, lastErr)
 }

--- a/pkg/utils/reconnect_test.go
+++ b/pkg/utils/reconnect_test.go
@@ -35,8 +35,9 @@ func TestReconnectWithBackoff_SuccessOnFirstAttempt(t *testing.T) {
 		BackoffBase: 1 * time.Millisecond,
 		MaxBackoff:  10 * time.Millisecond,
 	}
-	conn := utils.ReconnectWithBackoff(context.Background(), dialFn, cfg)
+	conn, err := utils.ReconnectWithBackoff(context.Background(), dialFn, cfg)
 	assert.NotNil(t, conn)
+	assert.NoError(t, err)
 }
 
 func TestReconnectWithBackoff_SuccessAfterRetries(t *testing.T) {
@@ -57,8 +58,9 @@ func TestReconnectWithBackoff_SuccessAfterRetries(t *testing.T) {
 		BackoffBase: 1 * time.Millisecond,
 		MaxBackoff:  5 * time.Millisecond,
 	}
-	conn := utils.ReconnectWithBackoff(context.Background(), dialFn, cfg)
+	conn, err := utils.ReconnectWithBackoff(context.Background(), dialFn, cfg)
 	assert.NotNil(t, conn)
+	assert.NoError(t, err)
 	assert.Equal(t, 3, attempts)
 }
 
@@ -71,8 +73,9 @@ func TestReconnectWithBackoff_ExhaustedRetries(t *testing.T) {
 		BackoffBase: 1 * time.Millisecond,
 		MaxBackoff:  5 * time.Millisecond,
 	}
-	conn := utils.ReconnectWithBackoff(context.Background(), dialFn, cfg)
+	conn, err := utils.ReconnectWithBackoff(context.Background(), dialFn, cfg)
 	assert.Nil(t, conn)
+	assert.Error(t, err)
 }
 
 func TestReconnectWithBackoff_CancelledBeforeStart(t *testing.T) {
@@ -89,8 +92,9 @@ func TestReconnectWithBackoff_CancelledBeforeStart(t *testing.T) {
 		BackoffBase: 1 * time.Millisecond,
 		MaxBackoff:  5 * time.Millisecond,
 	}
-	conn := utils.ReconnectWithBackoff(ctx, dialFn, cfg)
+	conn, err := utils.ReconnectWithBackoff(ctx, dialFn, cfg)
 	assert.Nil(t, conn)
+	assert.Error(t, err)
 	assert.False(t, called, "dialFn should not have been called after context was cancelled")
 }
 
@@ -115,9 +119,10 @@ func TestReconnectWithBackoff_CancelledDuringBackoff(t *testing.T) {
 		MaxBackoff:  1 * time.Second,
 	}
 	start := time.Now()
-	conn := utils.ReconnectWithBackoff(ctx, dialFn, cfg)
+	conn, err := utils.ReconnectWithBackoff(ctx, dialFn, cfg)
 	elapsed := time.Since(start)
 	assert.Nil(t, conn)
+	assert.Error(t, err)
 	assert.Equal(t, 1, attempts, "should have stopped after first attempt due to cancellation")
 	assert.Less(t, elapsed, 500*time.Millisecond, "should have returned quickly after cancellation")
 }
@@ -134,9 +139,10 @@ func TestReconnectWithBackoff_BackoffCapsAtMaxBackoff(t *testing.T) {
 		MaxBackoff:  2 * time.Millisecond, // base=1ms, doubles to 2ms then caps
 	}
 	start := time.Now()
-	conn := utils.ReconnectWithBackoff(context.Background(), dialFn, cfg)
+	conn, err := utils.ReconnectWithBackoff(context.Background(), dialFn, cfg)
 	elapsed := time.Since(start)
 	assert.Nil(t, conn)
+	assert.Error(t, err)
 	assert.Equal(t, 5, attempts)
 	// With cap at 2ms and 4 sleeps: 1 + 2 + 2 + 2 = 7ms total sleep (plus overhead)
 	assert.Less(t, elapsed, 200*time.Millisecond, "backoff should be capped and fast")

--- a/test/cloud-event-proxy/e2e.sh
+++ b/test/cloud-event-proxy/e2e.sh
@@ -35,6 +35,23 @@ check_port() {
     fi
 }
 
+# poll_current_state waits until CurrentState for RESOURCE contains the given string.
+poll_current_state() {
+    local want="$1"
+    local attempts=20
+    for ((i=0; i<attempts; i++)); do
+        CURRENT="$("$TMPDIR/consumer" \
+            --api-url "http://localhost:$API_PORT" \
+            --resource "$RESOURCE" \
+            --current-state 2>/dev/null)" || true
+        if echo "$CURRENT" | grep -q "$want"; then
+            return 0
+        fi
+        sleep 0.5
+    done
+    return 1
+}
+
 # ── Preflight ──
 check_port "$API_PORT"
 check_port "$CONSUMER_PORT"
@@ -45,18 +62,37 @@ echo "Building binaries..."
 (cd "$ROOT_DIR" && go build -o "$TMPDIR/consumer" ./test/consumer/)
 (cd "$ROOT_DIR" && go build -o "$TMPDIR/ipc-sender" ./test/ipc-sender/)
 
+# ── Start ipc-sender ──
+# Message 0 (immediate): clock_class=6, pre-populates cache → snapshot
+# Message 1 (SIGUSR1):   clock_class=7, live event
+# Message 2 (SIGUSR1):   gnss_state, live event (wrong resource for subscriber)
+MESSAGES='[
+  {"message":{"version":1,"type":"clock_class","profile":"ptp4l.0.config","values":{"clock_class":6}}},
+  {"message":{"version":1,"type":"clock_class","profile":"ptp4l.0.config","values":{"clock_class":7}}},
+  {"message":{"version":1,"type":"gnss_state","profile":"ts2phc.0.config","iface":"ens2f0","values":{"state":"SYNCHRONIZED"}}}
+]'
+
+echo "Starting ipc-sender..."
+"$TMPDIR/ipc-sender" --socket "$SOCKET" --messages "$MESSAGES" >"$TMPDIR/sender.log" 2>&1 &
+SENDER_PID=$!
+PIDS+=($SENDER_PID)
+
 # ── Start cloud-event-proxy ──
 NODE_NAME="$NODE_NAME" "$TMPDIR/cloud-event-proxy" \
     --socket "$SOCKET" \
     --api-port "$API_PORT" \
     --store-path "$TMPDIR" >"$TMPDIR/proxy.log" 2>&1 &
-PIDS+=($!)
-sleep 1
+PIDS+=("$!")
 
-# ── Step 1: Send initial clock class event (clock_class=6) ──
-echo "Sending clock_class=6..."
-"$TMPDIR/ipc-sender" --socket "$SOCKET" --type clock_class --profile ptp4l.0.config --clock-class 6
-sleep 0.5
+# ── Step 1: Verify snapshot — poll until clock_class appears ──
+echo "Waiting for snapshot..."
+if poll_current_state '"value":"6"'; then
+    pass "CurrentState returned clock_class=6 from snapshot"
+else
+    echo "Proxy log:"; cat "$TMPDIR/proxy.log"
+    echo "Sender log:"; cat "$TMPDIR/sender.log"
+    fail "CurrentState did not return expected event"
+fi
 
 # ── Step 2: Start consumer in subscribe mode ──
 CONSUMER_LOG="$TMPDIR/consumer.log"
@@ -65,42 +101,40 @@ CONSUMER_LOG="$TMPDIR/consumer.log"
     --api-url "http://localhost:$API_PORT" \
     --resource "$RESOURCE" \
     > "$CONSUMER_LOG" 2>"$TMPDIR/consumer.err" &
-PIDS+=($!)
+PIDS+=("$!")
 sleep 1
 
-# ── Step 3: Query CurrentState — should return the cached clock_class=6 event ──
-echo "Querying CurrentState..."
-CURRENT="$("$TMPDIR/consumer" \
-    --api-url "http://localhost:$API_PORT" \
-    --resource "$RESOURCE" \
-    --current-state 2>/dev/null)" || true
+# ── Step 3: Signal ipc-sender to send clock_class=7 (live event) ──
+echo "Signaling clock_class=7..."
+kill -USR1 "$SENDER_PID"
 
-if echo "$CURRENT" | grep -q "clock-class"; then
-    pass "CurrentState returned cached clock class event"
-else
-    echo "CurrentState output: $CURRENT"
-    echo "Proxy log:"; cat "$TMPDIR/proxy.log"
-    fail "CurrentState did not return expected event"
-fi
+# Poll subscriber log for the live event
+ATTEMPTS=20
+RECEIVED=false
+for ((i=0; i<ATTEMPTS; i++)); do
+    if grep -q '"value":"7"' "$CONSUMER_LOG"; then
+        RECEIVED=true
+        break
+    fi
+    sleep 0.5
+done
 
-# ── Step 4: Send new clock class event (clock_class=7) — subscriber should receive it ──
-echo "Sending clock_class=7..."
-"$TMPDIR/ipc-sender" --socket "$SOCKET" --type clock_class --profile ptp4l.0.config --clock-class 7
-sleep 1
-
-if grep -q "clock-class" "$CONSUMER_LOG"; then
-    pass "Subscriber received clock class push event"
+if $RECEIVED; then
+    pass "Subscriber received live clock_class=7 push event"
 else
     echo "Consumer log:"; cat "$CONSUMER_LOG"
     echo "Consumer err:"; cat "$TMPDIR/consumer.err"
+    echo "Sender log:"; cat "$TMPDIR/sender.log"
     fail "Subscriber did not receive clock class event"
 fi
 
-# ── Step 5: Send GNSS event — subscriber should NOT receive it ──
+# ── Step 4: Signal ipc-sender to send gnss_state — subscriber should NOT receive it ──
 LINES_BEFORE=$(wc -l < "$CONSUMER_LOG")
-echo "Sending gnss_state=SYNCHRONIZED..."
-"$TMPDIR/ipc-sender" --socket "$SOCKET" --type gnss_state --profile ts2phc.0.config --iface ens2f0 --state SYNCHRONIZED
-sleep 1
+echo "Signaling gnss_state..."
+kill -USR1 "$SENDER_PID"
+
+# Give it time to propagate (if it were going to)
+sleep 2
 
 LINES_AFTER=$(wc -l < "$CONSUMER_LOG")
 if [ "$LINES_AFTER" -eq "$LINES_BEFORE" ]; then

--- a/test/ipc-sender/main.go
+++ b/test/ipc-sender/main.go
@@ -1,80 +1,64 @@
 package main
 
 import (
+	"context"
+	"encoding/json"
 	"flag"
 	"log"
-	"net"
-	"strconv"
+	"os"
+	"os/signal"
+	"syscall"
 
 	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/ipc"
 )
 
+type step struct {
+	Message ipc.Message `json:"message"`
+}
+
 func main() {
 	socket := flag.String("socket", "/var/run/ptp/events.sock", "Path to cloud-event-proxy Unix socket")
-	msgType := flag.String("type", "", "IPC message type (e.g. clock_class, ptp_state, gnss_state)")
-	profile := flag.String("profile", "ptp4l.0.config", "Profile name")
-	iface := flag.String("iface", "", "Interface name")
-	state := flag.String("state", "", "State value (for state-type messages)")
-	clockClass := flag.String("clock-class", "", "Clock class value (for clock_class messages)")
+	messages := flag.String("messages", "", "JSON array of {message} steps")
 	flag.Parse()
 
-	if *msgType == "" {
-		log.Fatal("--type is required")
+	if *messages == "" {
+		log.Fatal("--messages is required")
 	}
 
-	msg := ipc.Message{
-		Version: ipc.Version,
-		Type:    *msgType,
-		Profile: *profile,
-		IFace:   *iface,
+	var steps []step
+	if err := json.Unmarshal([]byte(*messages), &steps); err != nil {
+		log.Fatalf("invalid --messages JSON: %v", err)
+	}
+	if len(steps) == 0 {
+		log.Fatal("--messages must contain at least one step")
 	}
 
-	switch *msgType {
-	case ipc.TypePTPState, ipc.TypeOSClockState:
-		if *state == "" {
-			log.Fatal("--state is required for state-type messages")
-		}
-		msg.Values = ipc.StateValue{State: *state}
-	case ipc.TypeGNSSState:
-		if *state == "" {
-			log.Fatal("--state is required for state-type messages")
-		}
-		msg.Values = ipc.GNSSStateValue{State: *state}
-	case ipc.TypeSyncEState:
-		if *state == "" {
-			log.Fatal("--state is required for state-type messages")
-		}
-		msg.Values = ipc.SyncEStateValue{State: *state}
-	case ipc.TypeSyncState:
-		if *state == "" {
-			log.Fatal("--state is required for state-type messages")
-		}
-		msg.Values = ipc.SyncStateValue{State: *state}
+	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer cancel()
 
-	case ipc.TypeClockClass:
-		if *clockClass == "" {
-			log.Fatal("--clock-class is required for clock_class messages")
-		}
-		cc, err := strconv.ParseUint(*clockClass, 10, 8)
-		if err != nil {
-			log.Fatalf("invalid clock-class value: %v", err)
-		}
-		msg.Values = ipc.ClockClassValue{ClockClass: uint8(cc)}
+	cache := ipc.NewCache(64)
 
-	case ipc.TypeCacheClear:
-		// no values needed
+	// First message pre-populates the cache before the Link connects
+	cache.Send(steps[0].Message)
+	log.Printf("cached initial message: type=%s profile=%s", steps[0].Message.Type, steps[0].Message.Profile)
 
-	default:
-		log.Fatalf("unsupported message type: %s", *msgType)
+	link := ipc.NewLink(*socket, cache)
+	go link.Run(ctx)
+	log.Printf("link started, dialing %s", *socket)
+
+	// Each subsequent message is sent on SIGUSR1
+	usr1 := make(chan os.Signal, 1)
+	signal.Notify(usr1, syscall.SIGUSR1)
+
+	for i, s := range steps[1:] {
+		select {
+		case <-usr1:
+		case <-ctx.Done():
+			return
+		}
+		cache.Send(s.Message)
+		log.Printf("sent message %d: type=%s profile=%s", i+1, s.Message.Type, s.Message.Profile)
 	}
 
-	conn, err := net.Dial("unix", *socket)
-	if err != nil {
-		log.Fatalf("failed to connect to socket %s: %v", *socket, err)
-	}
-	defer conn.Close()
-
-	if encodeErr := ipc.Encode(conn, []ipc.Message{msg}); encodeErr != nil {
-		log.Fatalf("failed to send message: %v", encodeErr)
-	}
+	<-ctx.Done()
 }


### PR DESCRIPTION
This is not hooked up to the daemon yet, and thus will not impact existing functionality.

Adds a cache to store the latest state of all clocks watched by the daemon. As new state events come into the cache they will be pushed to the cloud-event-proxy v2 socket.

Allows a new instance of cloud event proxy v2 to get the current state of the system by querying the daemon.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic daemon state synchronization on IPC connect via status requests and on-demand snapshots.
  * Introduced IPC message caching with duplicate suppression and buffered forwarding.
  * Improved IPC socket communication with reconnect behavior and live forwarding.
  * Extended state payload to support an optional offset field.
* **Bug Fixes**
  * Status updates are now retained and forwarded instead of being discarded.
* **Tests**
  * Updated unit, integration, and end-to-end tests, including signal-driven IPC sender flows and snapshot verification via polling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->