### PR TITLE
Add CF (e830) section to the example GNR-D T-GM HardwareConfig

### DIFF
--- a/doc/t-gm-dell-XR8720t.md
+++ b/doc/t-gm-dell-XR8720t.md
@@ -230,18 +230,26 @@ spec:
     clockType: T-GM
     clockChain:
       structure:
-        - name: leader
+        - name: nac
           hardwareSpecificDefinitions: dell/XR8720t
           dpll:
             holdoverParameters:
               maxInSpecOffset: 14400
               localMaxHoldoverOffset: 1500
               localHoldoverTimeout: 1500
+        - name: cf1
+          hardwareSpecificDefinitions: intel/e830
+          dpll:
+            networkInterface: enp108s0f0
+        - name: cf2
+          hardwareSpecificDefinitions: intel/e830
+          dpll:
+            networkInterface: enp110s0f0
       behavior:
         sources:
           - name: GNSS
             sourceType: gnss
-            subsystem: leader
+            subsystem: nac
             gnssConfig:
               init:
                 antennaVoltage: true


### PR DESCRIPTION
Signed-off-by: Jim Ramsay <jramsay@redhat.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration Updates**
  * Updated the Dell XR8720t clock-chain configuration with additional timing components.
  * Added support for two Intel E830 clock interfaces.
  * Updated GNSS source mapping and preserved existing holdover settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->