### PR TITLE
Suppress T-BC FSM updates while applying PTP profiles

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -783,6 +783,13 @@ func (dn *Daemon) applyNodePTPProfiles() error {
 
 	glog.Infof("in applyNodePTPProfiles - starting to apply %d node profiles", len(dn.ptpUpdate.NodeProfiles))
 
+	// Suppress T-BC FSM updates during teardown/restart so in-flight DPLL
+	// events after ts2phc Reset cannot emit LOCKED→HOLDOVER / T-BC-STATUS s1.
+	if dn.processManager != nil && dn.processManager.ptpEventHandler != nil {
+		dn.processManager.ptpEventHandler.SetApplying(true)
+		defer dn.processManager.ptpEventHandler.SetApplying(false)
+	}
+
 	dn.stopAllProcesses()
 	// All process should have been stopped,
 	// clear process in process manager.

--- a/pkg/dpll/dpll.go
+++ b/pkg/dpll/dpll.go
@@ -704,7 +704,7 @@ func (d *DpllConfig) stateDecision() {
 
 	case DPLL_LOCKED_HO_ACQ, DPLL_LOCKED:
 		if d.isOffsetInRange() {
-			glog.Infof("%s dpll is locked, source is not lost, offset is in range, state is DPLL_LOCKED_HO_ACQ", d.iface)
+			glog.Infof("%s dpll is locked, source is not lost, offset is in range, state is DPLL_%s", d.iface, stateName(dpllStatus))
 			if d.hasLeadingSource() && d.onHoldover {
 				select {
 				case d.holdoverCloseCh <- true:
@@ -716,7 +716,7 @@ func (d *DpllConfig) stateDecision() {
 			d.sourceLost = false
 			d.state = event.PTP_LOCKED
 		} else {
-			glog.Infof("%s dpll is not in spec, state is DPLL_LOCKED_HO_ACQ, offset is out of range, state is FREERUN", d.iface)
+			glog.Infof("%s dpll is not in spec, state is DPLL_%s, offset is out of range, state is FREERUN", d.iface, stateName(dpllStatus))
 			d.state = event.PTP_FREERUN
 			d.inSpec = false
 			d.phaseOffset = FaultyPhaseOffset

--- a/pkg/event/event.go
+++ b/pkg/event/event.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/k8snetworkplumbingwg/linuxptp-daemon/pkg/alias"
@@ -186,6 +187,20 @@ type EventHandler struct {
 	ReduceLog          bool                          // reduce logs for every announce
 	LeadingClockData   *LeadingClockParams
 	portRole           map[string]map[string]*parser.PTPEvent
+	// applyingProfiles is set while applyNodePTPProfiles is tearing down /
+	// restarting processes. When true, updateBCState is skipped so teardown
+	// races (e.g. ts2phc Reset wiping e.data) cannot emit T-BC HOLDOVER.
+	applyingProfiles atomic.Bool
+}
+
+// SetApplying marks whether a PTP profile apply is in progress.
+func (e *EventHandler) SetApplying(v bool) {
+	e.applyingProfiles.Store(v)
+}
+
+// IsApplying reports whether a PTP profile apply is in progress.
+func (e *EventHandler) IsApplying() bool {
+	return e.applyingProfiles.Load()
 }
 
 // getConn returns the current event socket connection under lock.
@@ -957,12 +972,19 @@ func (e *EventHandler) ProcessEvents() {
 					}
 				} else { // T-BC or T-TSC
 					e.Lock()
+					applying := e.IsApplying()
+					if applying {
+						// Ignore in-flight events during profile apply/teardown so
+						// convergeConfig/addEvent/updateBCState cannot race with Reset.
+						e.Unlock()
+						continue
+					}
 					event = e.convergeConfig(event)
 					dataDetails = e.addEvent(event)
 					var needsTTSCAnnounce, needsDownstreamUpdate bool
 					clockState, needsTTSCAnnounce, needsDownstreamUpdate = e.updateBCState(event)
 					e.Unlock()
-					// Perform I/O after releasing the lock
+					// Perform I/O after releasing the lock.
 					if needsTTSCAnnounce {
 						e.emitClockClass(clockState.clockClass, event.CfgName)
 					}
@@ -989,8 +1011,10 @@ func (e *EventHandler) ProcessEvents() {
 						debug.UpdateTs2phcState(string(d.State), 0, debug.OverallTs2phcKey)
 					}
 				}
-				debug.UpdateGMState(string(clockState.state))
-
+				// GM debug state only; T-BC/T-TSC clockState is not a GM state.
+				if event.ClockType == GM {
+					debug.UpdateGMState(string(clockState.state))
+				}
 				if clockState.clkLog != "" && clockState.leadingIFace != LEADING_INTERFACE_UNKNOWN {
 					logOut = append(logOut, clockState.clkLog)
 				}

--- a/pkg/event/event_internal_test.go
+++ b/pkg/event/event_internal_test.go
@@ -2,6 +2,7 @@
 package event
 
 import (
+	"net"
 	"testing"
 	"time"
 
@@ -1266,6 +1267,92 @@ func TestUpdateBCState(t *testing.T) {
 		assert.False(t, needsTTSCAnnounce, "not a TTSC")
 		assert.True(t, needsDownstreamUpdate, "clockClass changed, downstream needs update")
 	})
+}
+
+// TestApplyingSkipsUpdateBCState verifies that while SetApplying(true), ProcessEvents
+// does not run updateBCState, so a source-lost DPLL event cannot move LOCKED→HOLDOVER
+// or rewrite clkLog to T-BC-STATUS s1 (teardown race during applyNodePTPProfiles).
+func TestApplyingSkipsUpdateBCState(t *testing.T) {
+	const cfg = "ts2phc.1.config"
+	const iface = "ens2f0"
+
+	makeBCEvent := func(process EventSource, state PTPState, offset int64, sourceLost bool) Event {
+		return Event{
+			Source:     process,
+			IFace:      iface,
+			CfgName:    cfg,
+			ClockType:  BC,
+			Time:       time.Now().UnixMilli(),
+			WriteToLog: true,
+			Data: &PTPData{
+				State:      state,
+				Values:     map[ValueType]interface{}{OFFSET: offset},
+				SourceLost: sourceLost,
+			},
+		}
+	}
+
+	// Real listener so ProcessEvents can connect without retry/sleep races.
+	socketPath := shortSocketPath(t)
+	ln, err := net.Listen("unix", socketPath)
+	assert.NoError(t, err)
+	defer ln.Close()
+	go acceptAndHold(ln)
+
+	e := &EventHandler{
+		data:           map[string][]*Data{},
+		clkSyncState:   map[string]*clockSyncState{},
+		stdoutToSocket: true,
+		stdoutSocket:   socketPath,
+		LeadingClockData: &LeadingClockParams{
+			leadingInterface:         iface,
+			inSyncConditionThreshold: 100,
+			inSyncConditionTimes:     1,
+			toFreeRunThreshold:       1500,
+			MaxInSpecOffset:          500,
+			upstreamParentDataSet:    &protocol.ParentDataSet{},
+			upstreamTimeProperties:   &protocol.TimePropertiesDS{},
+			downstreamParentDataSet:  &protocol.ParentDataSet{},
+			downstreamTimeProperties: &protocol.TimePropertiesDS{},
+		},
+	}
+
+	// Establish LOCKED
+	e.addEvent(makeBCEvent(DPLL, PTP_LOCKED, 10, false))
+	e.addEvent(makeBCEvent(PTP4lProcessName, PTP_LOCKED, 10, false))
+	fillDataWindows(e, cfg, 10)
+	result, _, _ := e.updateBCState(makeBCEvent(DPLL, PTP_LOCKED, 10, false))
+	assert.Equal(t, PTP_LOCKED, result.state, "setup: should be LOCKED")
+	lockedLog := e.clkSyncState[cfg].clkLog
+
+	// Source-lost inputs that would HOLDOVER if updateBCState ran
+	e.addEvent(makeBCEvent(PTP4lProcessName, PTP_FREERUN, 10, true))
+	e.addEvent(makeBCEvent(DPLL, PTP_HOLDOVER, 10, false))
+
+	e.SetApplying(true)
+	ch := make(chan Event, 4)
+	closeCh := make(chan bool)
+	e.processChannel = ch
+	e.closeCh = closeCh
+	go e.ProcessEvents()
+
+	// Allow ProcessEvents to finish the initial socket connect.
+	time.Sleep(50 * time.Millisecond)
+	ch <- makeBCEvent(DPLL, PTP_HOLDOVER, 10, false)
+	time.Sleep(100 * time.Millisecond)
+	closeCh <- true
+	time.Sleep(50 * time.Millisecond)
+
+	assert.Equal(t, PTP_LOCKED, e.clkSyncState[cfg].state,
+		"must not transition to HOLDOVER while applying")
+	assert.Equal(t, lockedLog, e.clkSyncState[cfg].clkLog,
+		"clkLog must not be rewritten to T-BC-STATUS s1 while applying")
+
+	// Control: same inputs without applying produce HOLDOVER
+	e.SetApplying(false)
+	result, _, needsDownstreamUpdate := e.updateBCState(makeBCEvent(DPLL, PTP_HOLDOVER, 10, false))
+	assert.Equal(t, PTP_HOLDOVER, result.state, "without applying, source lost must HOLDOVER")
+	assert.True(t, needsDownstreamUpdate, "holdover should request downstream update")
 }
 
 func TestUpdateSpecState(t *testing.T) {


### PR DESCRIPTION
Prevent teardown races from emitting LOCKED→HOLDOVER / T-BC-STATUS s1 when in-flight DPLL events arrive after ts2phc Reset clears event data.

Generated-by: Cursor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented T-BC/T-TSC clock-state and status side effects while PTP profiles are being applied or restarted.
  * Avoided unintended GM debug-state updates except for GM-related events.
  * Improved DPLL transition logging to report the actual current DPLL state.

* **Tests**
  * Added coverage ensuring clock state and related logs remain unchanged during profile application, and that the expected state transition occurs once profile application ends.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->