### PR TITLE
OCPBUGS-100049: Fix T-GM ntpfailover deadlock

### DIFF
--- a/addons/generic/ntpfailover.go
+++ b/addons/generic/ntpfailover.go
@@ -15,9 +15,10 @@ import (
 type ntpFailoverPluginData struct {
 	gnssFailover    bool
 	cmdSetEnabled   map[string]func(bool)
+	enableQueues    map[string]chan bool
+	enableQueueMu   sync.Mutex
 	pcfsmState      int
 	pcfsmMutex      sync.Mutex
-	pcfsmLocked     bool
 	ts2phcTolerance time.Duration
 	startupDelay    time.Duration
 	expiryTime      time.Time
@@ -49,6 +50,41 @@ var (
 	ts2phcOffsetRegex  = regexp.MustCompile("offset .*s3 freq")
 	chronydOnlineRegex = regexp.MustCompile("chronyd .* starting")
 )
+
+// invokeSetEnabled queues enable/disable on a persistent per-process worker so
+// requests stay ordered and off the ProcessLog/scanner goroutine.
+func invokeSetEnabled(pluginData *ntpFailoverPluginData, pname string, enabled bool) {
+	if pluginData == nil {
+		return
+	}
+	if pluginData.cmdSetEnabled[pname] == nil {
+		return
+	}
+	pluginData.queueFor(pname) <- enabled
+}
+
+func (d *ntpFailoverPluginData) queueFor(pname string) chan bool {
+	d.enableQueueMu.Lock()
+	defer d.enableQueueMu.Unlock()
+	if d.enableQueues == nil {
+		d.enableQueues = make(map[string]chan bool)
+	}
+	ch, ok := d.enableQueues[pname]
+	if ok {
+		return ch
+	}
+	ch = make(chan bool, 16)
+	d.enableQueues[pname] = ch
+	go func() {
+		for enabled := range ch {
+			fn := d.cmdSetEnabled[pname]
+			if fn != nil {
+				fn(enabled)
+			}
+		}
+	}()
+	return ch
+}
 
 func onPTPConfigChangeNtpFailover(data *interface{}, nodeProfile *ptpv1.PtpProfile) error {
 	var _ntpFailoverOpts ntpFailoverOpts
@@ -117,93 +153,75 @@ func processLogNtpFailover(data *interface{}, pname string, log string) string {
 				pluginData.expiryTime = currentTime.Add(pluginData.ts2phcTolerance)
 			}
 
-			pluginData.pcfsmMutex.Lock()
-			ownLock := !pluginData.pcfsmLocked //If locked, then skip, otherwise take lock
-			pluginData.pcfsmMutex.Unlock()
-			if ownLock {
-			done:
-				for {
-					switch pluginData.pcfsmState {
-					case pcsmsStartupDefault:
-						_, foundChronyd := pluginData.cmdSetEnabled[chronydPname]
-						_, foundPhc2Sys := pluginData.cmdSetEnabled[phc2sysPname]
-						if foundChronyd && foundPhc2Sys {
-							pluginData.pcfsmState = pcsmsStartupBoth
-						} else if foundChronyd {
-							pluginData.pcfsmState = pcsmsStartupChronyd
-						} else if foundPhc2Sys {
-							pluginData.pcfsmState = pcsmsStartupPhc2sys
-						} else {
-							break done
-						}
-					case pcsmsStartupPhc2sys:
-						_, foundChronyd := pluginData.cmdSetEnabled[chronydPname]
-						if foundChronyd {
-							pluginData.pcfsmState = pcsmsStartupBoth
-						} else {
-							break done
-						}
-					case pcsmsStartupChronyd:
-						_, foundPhc2Sys := pluginData.cmdSetEnabled[phc2sysPname]
-						if foundPhc2Sys {
-							pluginData.pcfsmState = pcsmsStartupBoth
-						} else {
-							break done
-						}
-					case pcsmsStartupBoth:
-						chronydSetEnabled, ok := pluginData.cmdSetEnabled[chronydPname]
-						if ok {
-							chronydSetEnabled(false)
-						}
-						phc2sysSetEnabled, ok := pluginData.cmdSetEnabled[phc2sysPname]
-						if ok {
-							phc2sysSetEnabled(true)
-						}
-						pluginData.pcfsmState = pcsmsActive
-						continue
-					case pcsmsActive:
-						if pname == ts2phcPname {
-							if currentTime.After(pluginData.expiryTime) {
-								pluginData.pcfsmState = pcsmsOutOfSpec
-								continue
-							}
-						}
-						if pname == chronydPname && chronydOnlineRegex.MatchString(log) {
-							chronydSetEnabled, ok := pluginData.cmdSetEnabled[chronydPname]
-							if ok {
-								chronydSetEnabled(false)
-							}
-						}
-						break done
-					case pcsmsOutOfSpec:
-						if pname == ts2phcPname {
-							if currentTime.After(pluginData.expiryTime) {
-								pluginData.pcfsmState = pcsmsFailover
-								chronydSetEnabled, ok := pluginData.cmdSetEnabled[chronydPname]
-								if ok {
-									chronydSetEnabled(true)
-								}
-								phc2sysSetEnabled, ok := pluginData.cmdSetEnabled[phc2sysPname]
-								if ok {
-									phc2sysSetEnabled(false)
-								}
-								continue
-							}
-						}
-						break done
-					case pcsmsFailover:
-						if pname == ts2phcPname {
-							if currentTime.Before(pluginData.expiryTime) {
-								pluginData.pcfsmState = pcsmsStartupDefault
-								continue
-							}
-						}
+			// Non-blocking: another ProcessLog may already be driving the FSM.
+			if !pluginData.pcfsmMutex.TryLock() {
+				return ret
+			}
+			defer pluginData.pcfsmMutex.Unlock()
+		done:
+			for {
+				switch pluginData.pcfsmState {
+				case pcsmsStartupDefault:
+					_, foundChronyd := pluginData.cmdSetEnabled[chronydPname]
+					_, foundPhc2Sys := pluginData.cmdSetEnabled[phc2sysPname]
+					if foundChronyd && foundPhc2Sys {
+						pluginData.pcfsmState = pcsmsStartupBoth
+					} else if foundChronyd {
+						pluginData.pcfsmState = pcsmsStartupChronyd
+					} else if foundPhc2Sys {
+						pluginData.pcfsmState = pcsmsStartupPhc2sys
+					} else {
 						break done
 					}
+				case pcsmsStartupPhc2sys:
+					_, foundChronyd := pluginData.cmdSetEnabled[chronydPname]
+					if foundChronyd {
+						pluginData.pcfsmState = pcsmsStartupBoth
+					} else {
+						break done
+					}
+				case pcsmsStartupChronyd:
+					_, foundPhc2Sys := pluginData.cmdSetEnabled[phc2sysPname]
+					if foundPhc2Sys {
+						pluginData.pcfsmState = pcsmsStartupBoth
+					} else {
+						break done
+					}
+				case pcsmsStartupBoth:
+					invokeSetEnabled(pluginData, chronydPname, false)
+					invokeSetEnabled(pluginData, phc2sysPname, true)
+					pluginData.pcfsmState = pcsmsActive
+					continue
+				case pcsmsActive:
+					if pname == ts2phcPname {
+						if currentTime.After(pluginData.expiryTime) {
+							pluginData.pcfsmState = pcsmsOutOfSpec
+							continue
+						}
+					}
+					if pname == chronydPname && chronydOnlineRegex.MatchString(log) {
+						invokeSetEnabled(pluginData, chronydPname, false)
+					}
+					break done
+				case pcsmsOutOfSpec:
+					if pname == ts2phcPname {
+						if currentTime.After(pluginData.expiryTime) {
+							pluginData.pcfsmState = pcsmsFailover
+							invokeSetEnabled(pluginData, chronydPname, true)
+							invokeSetEnabled(pluginData, phc2sysPname, false)
+							continue
+						}
+					}
+					break done
+				case pcsmsFailover:
+					if pname == ts2phcPname {
+						if currentTime.Before(pluginData.expiryTime) {
+							pluginData.pcfsmState = pcsmsStartupDefault
+							continue
+						}
+					}
+					break done
 				}
-				pluginData.pcfsmMutex.Lock()
-				pluginData.pcfsmLocked = false //If took lock, then return it
-				pluginData.pcfsmMutex.Unlock()
 			}
 		}
 	}
@@ -224,8 +242,10 @@ func NtpFailover(name string) (*plugin.Plugin, *interface{}) {
 		ProcessLog:             processLogNtpFailover,
 	}
 	pluginData := ntpFailoverPluginData{pcfsmState: pcsmsStartupDefault,
-		pcfsmMutex: sync.Mutex{}}
-	pluginData.cmdSetEnabled = make(map[string]func(bool))
+		pcfsmMutex:    sync.Mutex{},
+		cmdSetEnabled: make(map[string]func(bool)),
+		enableQueues:  make(map[string]chan bool),
+	}
 	var iface interface{} = &pluginData
 	return &_plugin, &iface
 }

--- a/addons/generic/ntpfailover_test.go
+++ b/addons/generic/ntpfailover_test.go
@@ -1,0 +1,226 @@
+package generic
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func newTestPluginData(gnssFailover bool) *interface{} {
+	pluginData := &ntpFailoverPluginData{
+		gnssFailover:    gnssFailover,
+		pcfsmState:      pcsmsStartupDefault,
+		cmdSetEnabled:   make(map[string]func(bool)),
+		startupDelay:    90 * time.Second,
+		ts2phcTolerance: 5 * time.Second,
+		expiryTime:      time.Now().Add(90 * time.Second),
+	}
+	var iface interface{} = pluginData
+	return &iface
+}
+
+func TestProcessLogNtpFailover_StartupDisablesChronydEnablesPhc2sys(t *testing.T) {
+	data := newTestPluginData(true)
+	pluginData := (*data).(*ntpFailoverPluginData)
+
+	var chronydEnabled atomic.Bool
+	var phc2sysEnabled atomic.Bool
+	var chronydCalls, phc2sysCalls atomic.Int32
+	chronydDone := make(chan struct{}, 1)
+	phc2sysDone := make(chan struct{}, 1)
+
+	pluginData.cmdSetEnabled[chronydPname] = func(enabled bool) {
+		chronydEnabled.Store(enabled)
+		if chronydCalls.Add(1) == 1 {
+			chronydDone <- struct{}{}
+		}
+	}
+	pluginData.cmdSetEnabled[phc2sysPname] = func(enabled bool) {
+		phc2sysEnabled.Store(enabled)
+		if phc2sysCalls.Add(1) == 1 {
+			phc2sysDone <- struct{}{}
+		}
+	}
+
+	// Use a non-chronyd line so pcsmsActive does not immediately re-disable chronyd.
+	out := processLogNtpFailover(data, ts2phcPname, "ts2phc[123]: nmea delay")
+	if out != "ts2phc[123]: nmea delay" {
+		t.Fatalf("expected log passthrough, got %q", out)
+	}
+
+	select {
+	case <-chronydDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for chronyd disable")
+	}
+	select {
+	case <-phc2sysDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for phc2sys enable")
+	}
+
+	if chronydCalls.Load() == 0 || chronydEnabled.Load() {
+		t.Fatalf("expected chronyd disabled, calls=%d enabled=%v", chronydCalls.Load(), chronydEnabled.Load())
+	}
+	if phc2sysCalls.Load() == 0 || !phc2sysEnabled.Load() {
+		t.Fatalf("expected phc2sys enabled, calls=%d enabled=%v", phc2sysCalls.Load(), phc2sysEnabled.Load())
+	}
+	if pluginData.pcfsmState != pcsmsActive {
+		t.Fatalf("expected pcsmsActive, got %d", pluginData.pcfsmState)
+	}
+}
+
+func TestProcessLogNtpFailover_DoesNotBlockOnSyncCallback(t *testing.T) {
+	// Simulates the production deadlock: ProcessLog runs on the scanner goroutine
+	// and must not wait for a callback that itself waits for the scanner to finish.
+	data := newTestPluginData(true)
+	pluginData := (*data).(*ntpFailoverPluginData)
+
+	scannerFinished := make(chan struct{})
+	callbackStarted := make(chan struct{})
+
+	pluginData.cmdSetEnabled[chronydPname] = func(_ bool) {
+		close(callbackStarted)
+		// Would deadlock if ProcessLog invoked this synchronously.
+		<-scannerFinished
+	}
+	pluginData.cmdSetEnabled[phc2sysPname] = func(_ bool) {}
+
+	done := make(chan struct{})
+	go func() {
+		processLogNtpFailover(data, chronydPname, "chronyd starting")
+		close(scannerFinished)
+		close(done)
+	}()
+
+	select {
+	case <-callbackStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("callback was never invoked")
+	}
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("processLogNtpFailover blocked on enable/disable callback (deadlock)")
+	}
+}
+
+func TestProcessLogNtpFailover_TryLockExcludesConcurrentDrivers(t *testing.T) {
+	data := newTestPluginData(true)
+	pluginData := (*data).(*ntpFailoverPluginData)
+
+	var calls atomic.Int32
+	pluginData.cmdSetEnabled[chronydPname] = func(_ bool) { calls.Add(1) }
+	pluginData.cmdSetEnabled[phc2sysPname] = func(_ bool) { calls.Add(1) }
+
+	// Simulate another goroutine already driving the FSM.
+	pluginData.pcfsmMutex.Lock()
+	processLogNtpFailover(data, chronydPname, "line-while-locked")
+	time.Sleep(50 * time.Millisecond)
+
+	if got := calls.Load(); got != 0 {
+		pluginData.pcfsmMutex.Unlock()
+		t.Fatalf("expected no enable/disable calls while mutex held, got %d", got)
+	}
+	if pluginData.pcfsmState != pcsmsStartupDefault {
+		pluginData.pcfsmMutex.Unlock()
+		t.Fatalf("state should remain default while locked, got %d", pluginData.pcfsmState)
+	}
+	pluginData.pcfsmMutex.Unlock()
+
+	processLogNtpFailover(data, chronydPname, "line-after-unlock")
+	deadline := time.Now().Add(2 * time.Second)
+	for calls.Load() < 2 && time.Now().Before(deadline) {
+		time.Sleep(10 * time.Millisecond)
+	}
+	if got := calls.Load(); got != 2 {
+		t.Fatalf("expected 2 enable/disable calls after unlock, got %d", got)
+	}
+}
+
+func TestProcessLogNtpFailover_DisabledWhenGnssFailoverFalse(t *testing.T) {
+	data := newTestPluginData(false)
+	pluginData := (*data).(*ntpFailoverPluginData)
+
+	var called atomic.Bool
+	pluginData.cmdSetEnabled[chronydPname] = func(_ bool) { called.Store(true) }
+	pluginData.cmdSetEnabled[phc2sysPname] = func(_ bool) { called.Store(true) }
+
+	processLogNtpFailover(data, chronydPname, "chronyd starting")
+	time.Sleep(50 * time.Millisecond)
+
+	if called.Load() {
+		t.Fatal("callbacks must not run when gnssFailover is false")
+	}
+	if pluginData.pcfsmState != pcsmsStartupDefault {
+		t.Fatalf("state should remain default, got %d", pluginData.pcfsmState)
+	}
+}
+
+func TestRegisterProcessNtpFailover_OnlyWhenGnssFailover(t *testing.T) {
+	data := newTestPluginData(false)
+	registerProcessNtpFailover(data, chronydPname, func(bool) {})
+	pluginData := (*data).(*ntpFailoverPluginData)
+	if _, ok := pluginData.cmdSetEnabled[chronydPname]; ok {
+		t.Fatal("should not register callbacks when gnssFailover is false")
+	}
+
+	pluginData.gnssFailover = true
+	registerProcessNtpFailover(data, chronydPname, func(bool) {})
+	if _, ok := pluginData.cmdSetEnabled[chronydPname]; !ok {
+		t.Fatal("should register callbacks when gnssFailover is true")
+	}
+}
+
+func TestInvokeSetEnabled_NilSafe(_ *testing.T) {
+	invokeSetEnabled(nil, chronydPname, false)
+	data := newTestPluginData(true)
+	pluginData := (*data).(*ntpFailoverPluginData)
+	invokeSetEnabled(pluginData, chronydPname, false) // no callback registered
+}
+
+func TestInvokeSetEnabled_SerializesPerProcess(t *testing.T) {
+	data := newTestPluginData(true)
+	pluginData := (*data).(*ntpFailoverPluginData)
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+	var order []bool
+	var mu sync.Mutex
+	done := make(chan struct{}, 2)
+
+	pluginData.cmdSetEnabled[chronydPname] = func(enabled bool) {
+		if !enabled {
+			close(started)
+			<-release
+		}
+		mu.Lock()
+		order = append(order, enabled)
+		mu.Unlock()
+		done <- struct{}{}
+	}
+
+	invokeSetEnabled(pluginData, chronydPname, false)
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("first callback did not start")
+	}
+	invokeSetEnabled(pluginData, chronydPname, true)
+	close(release)
+
+	for i := 0; i < 2; i++ {
+		select {
+		case <-done:
+		case <-time.After(2 * time.Second):
+			t.Fatal("timed out waiting for serialized callbacks")
+		}
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if len(order) != 2 || order[0] || !order[1] {
+		t.Fatalf("expected disable then enable in order, got %v", order)
+	}
+}

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -2011,7 +2011,9 @@ func (p *ptpProcess) processPTPMetrics(output string) {
 	}
 }
 
-// cmdStop stops ptpProcess launched by cmdRun
+// cmdStop stops ptpProcess launched by cmdRun.
+// Only one caller owns the stop: getAndSetStopped prevents concurrent waiters
+// on the unbuffered exitCh.
 func (p *ptpProcess) cmdStop() {
 	glog.Infof("stopping %s...", p.name)
 	cmd := p.cmd
@@ -2019,13 +2021,13 @@ func (p *ptpProcess) cmdStop() {
 		glog.Infof("cmdStop is nil %s", p.name)
 		return
 	}
-	if p.Stopped() {
+	// getAndSetStopped returns the previous value: true means already stopped.
+	if p.getAndSetStopped(true) {
 		glog.Infof("%s is already stopped", p.name)
 		return
 	}
 	glog.Infof("%s setStopped true", p.name)
 
-	p.setStopped(true)
 	if cmd.Process != nil {
 		glog.Infof("Sending TERM to (%s) PID: %d", p.name, cmd.Process.Pid)
 		err := cmd.Process.Signal(syscall.SIGTERM)
@@ -2042,11 +2044,20 @@ func (p *ptpProcess) cmdStop() {
 
 func (p *ptpProcess) cmdSetEnabled(enabled bool) {
 	glog.Infof("cmdSetEnabled %s set to %t", p.name, enabled)
-	p.cmdSetEnabledMutex.Lock()
-	defer p.cmdSetEnabledMutex.Unlock()
 	switch p.name {
-	case "chronyd":
+	case "chronyd", phc2sysProcessName:
+		p.cmdSetEnabledMutex.Lock()
+		defer p.cmdSetEnabledMutex.Unlock()
 		if enabled {
+			// Respect the delayed-startup gate. ntpfailover may call enable during
+			// chronyd's first log line, long before PHC/UTC offset is ready; starting
+			// then makes phc2sys exit ("failed to get UTC offset") and cmdRun
+			// crash-loops it. HandleDelayedPhc2sysStartup clears skipInitialStartup
+			// before calling us.
+			if p.skipInitialStartup != "" {
+				glog.Infof("cmdSetEnabled %s deferred: %s", p.name, p.skipInitialStartup)
+				return
+			}
 			if p.Stopped() && p.cmd != nil {
 				cmd := p.cmd
 				newCmd := exec.Command(cmd.Args[0], cmd.Args[1:]...)
@@ -2054,18 +2065,10 @@ func (p *ptpProcess) cmdSetEnabled(enabled bool) {
 				go p.cmdRun(p.dn.stdoutToSocket, &p.dn.pluginManager)
 			}
 		} else {
-			p.cmdStop()
-		}
-	case phc2sysProcessName:
-		if enabled {
-			if p.Stopped() && p.cmd != nil {
-				cmd := p.cmd
-				newCmd := exec.Command(cmd.Args[0], cmd.Args[1:]...)
-				p.cmd = newCmd
-				go p.cmdRun(p.dn.stdoutToSocket, &p.dn.pluginManager)
-			}
-		} else {
-			p.cmdStop()
+			// Never block the caller on exitCh. ProcessLog (and thus ntpfailover)
+			// runs on the process stdout scanner; a synchronous cmdStop from that
+			// path deadlocks because exitCh is only signaled after the scanner ends.
+			go p.cmdStop()
 		}
 	default:
 		glog.Warningf("cmdSetEnabled called for unhandled process %s", p.name)

--- a/pkg/daemon/daemon_internal_test.go
+++ b/pkg/daemon/daemon_internal_test.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"os/exec"
 	"strconv"
 	"strings"
 	"sync"
@@ -3595,6 +3596,29 @@ func TestDelayedPhc2sysStartup(t *testing.T) {
 	ts2phc.ProcessTs2PhcEvents(smallOffset, ts2phcProcessName, "eth0", event.PTP_LOCKED, nil)
 	assert.Equal(t, "", phc2sys.skipInitialStartup)
 	assert.False(t, dn.delayedPhc2sys.Load())
+}
+
+// TestCmdSetEnabled_RespectsPhc2sysDelay ensures ntpfailover's early
+// phc2sysSetEnabled(true) cannot bypass skipInitialStartup and crash-loop
+// phc2sys before UTC offset is available.
+func TestCmdSetEnabled_RespectsPhc2sysDelay(t *testing.T) {
+	dn := &Daemon{}
+	phc2sys := &ptpProcess{
+		name:               phc2sysProcessName,
+		skipInitialStartup: testSkipStartupReason,
+		stopped:            true,
+		cmd:                exec.Command("true"),
+		dn:                 dn,
+	}
+
+	phc2sys.cmdSetEnabled(true)
+	assert.True(t, phc2sys.Stopped(), "phc2sys must stay stopped while delayed")
+	assert.Equal(t, testSkipStartupReason, phc2sys.skipInitialStartup)
+
+	phc2sys.skipInitialStartup = ""
+	// Without a real cmdRun path we only assert the delay gate; clearing the
+	// skip flag is what HandleDelayedPhc2sysStartup does before enable.
+	assert.Equal(t, "", phc2sys.skipInitialStartup)
 }
 
 // TestDelayedPhc2sysStartup_HAProfile verifies that a phc2sys process in a


### PR DESCRIPTION
chronyd's disable mechanism drained exitCh and blocked ts2phc's stdout pipe. Dispatch enable/disable asynchronously, use pcfsmLocked, and defer cmdSetEnabled(true) while phc2sys skipInitialStartup is set, so the PHC delay gate still applies after failover.

## What broke

With `ntpfailover` / `gnssFailover: true`, T-GM stayed FREERUN: `ts2phc` produced no logs (blocked in `pipe_write`), `phc2sys` never started, `chronyd` was a zombie. GM state stays freerun when `ts2phc` never reports locked — see `updateGMState` in `pkg/event/event.go` (combines DPLL/GNSS/`ts2phc` state).

## The deadlock (self-wait on the scanner)

**1. Stdout scanner calls plugins inline**

`cmdRun` reads process stdout and calls `processOutput` per line:

```1915:1920:pkg/daemon/daemon.go
			go func() {
				for scanner.Scan() {
					p.processOutput(scanner.Text(), pm, profileClockType)
				}
				doneCh <- struct{}{}
			}()
```

`processOutput` invokes the plugin hook on that same goroutine:

```1777:1781:pkg/daemon/daemon.go
func (p *ptpProcess) processOutput(output string, pm *plugin.PluginManager, profileClockType string) string {
	// ...
	output = pm.ProcessLog(p.name, output)
```

Wired through `pkg/plugin/plugin.go` (`PluginManager.ProcessLog` → each plugin’s `ProcessLog`).

**2. ntpfailover FSM disables chronyd from that hook**

On startup, once both callbacks are registered, state becomes `pcsmsStartupBoth` and it **synchronously** disables chronyd (and enables phc2sys):

```153:161:addons/generic/ntpfailover.go
					case pcsmsStartupBoth:
						chronydSetEnabled, ok := pluginData.cmdSetEnabled[chronydPname]
						if ok {
							chronydSetEnabled(false)
						}
						phc2sysSetEnabled, ok := pluginData.cmdSetEnabled[phc2sysPname]
						if ok {
							phc2sysSetEnabled(true)
						}
```

Callbacks are registered as `ptpProcess.cmdSetEnabled` via `RegisterEnableCallback` (`pkg/plugin/plugin.go` + `registerProcessNtpFailover` in `addons/generic/ntpfailover.go`).

**3. `cmdSetEnabled(false)` blocks the scanner on `exitCh`**

On main, disable calls `cmdStop()` while holding `cmdSetEnabledMutex`:

```2055:2057:pkg/daemon/daemon.go
		} else {
			p.cmdStop()
		}
```

`cmdStop()` signals TERM then waits forever on `exitCh`:

```2015:2040:pkg/daemon/daemon.go
func (p *ptpProcess) cmdStop() {
	// ...
	err := cmd.Process.Signal(syscall.SIGTERM)
	// ...
	<-p.exitCh
}
```

**4. `exitCh` is only signaled after the scanner ends**

`cmdRun`’s deferred send happens only after the process/scanner lifecycle completes:

```1887:1894:pkg/daemon/daemon.go
	defer func() {
		// ...
		p.exitCh <- true
	}()
```

So chronyd’s **own** scanner is blocked inside `cmdStop` → never returns to `scanner.Scan()` → never EOF → never `exitCh`. Classic self-deadlock. Chronyd dies from SIGTERM but is never reaped → `<defunct>`.

**5. Other processes get dragged in**

The intended “only one FSM driver” flag was broken: `pcfsmLocked` was read but never set `true`:

```120:123:addons/generic/ntpfailover.go
			pluginData.pcfsmMutex.Lock()
			ownLock := !pluginData.pcfsmLocked //If locked, then skip, otherwise take lock
			pluginData.pcfsmMutex.Unlock()
```

So ts2phc/ptp4l scanners also entered `pcsmsStartupBoth`, called `chronydSetEnabled(false)`, and blocked on chronyd’s held mutex / stop path. Their stdout pipes stopped draining → ts2phc stuck in kernel `pipe_write`.

## How the fix addresses it

(On branch `ts2phc-deadlock`, commit `8cb389f4`.)

| Change | File | Effect |
|--------|------|--------|
| Queue enable/disable off the scanner | `addons/generic/ntpfailover.go` — `invokeSetEnabled` / `queueFor` (~L54–90); FSM uses `invokeSetEnabled(...)` in `pcsmsStartupBoth` / failover (~L190–211) | `ProcessLog` only enqueues; never waits on `cmdStop` |
| FSM exclusion via `TryLock` | `addons/generic/ntpfailover.go` (~L156–160) | One FSM driver at a time (replaces broken `pcfsmLocked`) |
| Async stop from enable API | `pkg/daemon/daemon.go` — `cmdSetEnabled` uses `go p.cmdStop()` (~L2068–2071) | Disable returns immediately; scanner can finish and signal `exitCh` |
| Single stop waiter | `pkg/daemon/daemon.go` — `cmdStop` uses `getAndSetStopped(true)` (~L2017–2042) | Avoids two waiters on unbuffered `exitCh` |
| Honor phc2sys delay gate | `pkg/daemon/daemon.go` — `cmdSetEnabled` checks `skipInitialStartup` (~L2055–2059); gate cleared in `HandleDelayedPhc2sysStartup` (~L2118–2143); armed at ~L1293 | Failover can’t start phc2sys before PHC/UTC offset is ready (prevents “failed to get UTC offset” crash-loop) |

**Tests:** `addons/generic/ntpfailover_test.go` (non-blocking callbacks, serialization, FSM lock); `pkg/daemon/daemon_internal_test.go` (`TestCmdSetEnabled_RespectsPhc2sysDelay`).

Net: chronyd can stop without wedging the log path; ts2phc keeps producing output; phc2sys starts only after the delayed PHC gate clears.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved NTP failover transitions to prevent concurrent state changes.
  - Prevented enable/disable operations from blocking processing or causing deadlocks.
  - Ensured process shutdown requests are handled safely when multiple stop actions occur.
  - Preserved delayed startup behavior for `phc2sys`.

- **Tests**
  - Added coverage for failover transitions, callback handling, concurrency protection, disabled configurations, and delayed startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->