### PR TITLE
OCPBUGS-7811: preserve process_restart_count across profile teardown

### DIFF
--- a/pkg/daemon/metrics.go
+++ b/pkg/daemon/metrics.go
@@ -649,11 +649,16 @@ func deleteOsClockStateMetrics(profiles map[string][]string) {
 }
 
 func deleteProcessStatusMetrics(config, process string) {
+	// Remove the process_status gauge when the process/config is torn down so
+	// scrapers do not see a stale UP/DOWN sample (OCPBUGS-7808).
+	//
+	// Do NOT delete process_restart_count: it is a cumulative counter keyed by
+	// (process, node, config). applyNodePTPProfiles always stopAllProcesses
+	// before re-applying the same config slot (e.g. ts2phc.0.config); deleting
+	// the series resets the counter and breaks monotonicity across delete/re-apply
+	// (OCPBUGS-7811). Process crash/restart already continues the counter via Inc().
 	ProcessStatus.Delete(prometheus.Labels{
 		"process": process, "node": NodeName, "config": config})
-	ProcessRestartCount.Delete(prometheus.Labels{
-		"process": process, "node": NodeName, "config": config})
-
 }
 func extractPTP4lEventState(output string) (portId int, role ptpPortRole) {
 	replacer := strings.NewReplacer("[", " ", "]", " ", ":", " ")

--- a/pkg/daemon/restart_count_lifecycle_test.go
+++ b/pkg/daemon/restart_count_lifecycle_test.go
@@ -7,80 +7,67 @@ import (
 	"github.com/prometheus/client_golang/prometheus/testutil"
 )
 
-const (
-	restartCountMetric  = "openshift_ptp_process_restart_count"
-	processStatusMetric = "openshift_ptp_process_status"
-	labelConfig         = "config"
-)
+const labelConfig = "config"
 
 // TestProcessRestartCountPreservedAcrossTeardownReapply verifies the OCPBUGS-7811
-// contract: tearing down process_status must not reset process_restart_count for
-// the same (process, node, config) identity.
+// contract by exercising the production cleanup path: deleteProcessStatusMetrics
+// must not reset process_restart_count for the same (process, node, config) identity.
 func TestProcessRestartCountPreservedAcrossTeardownReapply(t *testing.T) {
-	reg := prometheus.NewRegistry()
-	labelNames := []string{labelProcess, labelNode, labelConfig}
-	status := prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Name: processStatusMetric,
-	}, labelNames)
-	restarts := prometheus.NewCounterVec(prometheus.CounterOpts{
-		Name: restartCountMetric,
-	}, labelNames)
-	if err := reg.Register(status); err != nil {
-		t.Fatal(err)
-	}
-	if err := reg.Register(restarts); err != nil {
-		t.Fatal(err)
-	}
+	origNode := NodeName
+	NodeName = "restart-count-lifecycle-node"
+	defer func() {
+		labels := prometheus.Labels{
+			labelProcess: "ts2phc",
+			labelNode:    NodeName,
+			labelConfig:  "ts2phc.0.config",
+		}
+		ProcessStatus.Delete(labels)
+		ProcessRestartCount.Delete(labels) // test isolation only
+		NodeName = origNode
+	}()
+
+	process := "ts2phc"
+	cfg := "ts2phc.0.config"
 	labels := prometheus.Labels{
-		labelProcess: "ts2phc",
-		labelNode:    "n1",
-		labelConfig:  "ts2phc.0.config",
+		labelProcess: process,
+		labelNode:    NodeName,
+		labelConfig:  cfg,
 	}
 
-	status.With(labels).Set(1)
+	// Isolate from any prior series with this identity.
+	ProcessStatus.Delete(labels)
+	ProcessRestartCount.Delete(labels)
+
 	for i := 0; i < 9; i++ {
-		restarts.With(labels).Inc()
+		UpdateProcessStatusMetrics(process, cfg, PtpProcessUp)
 	}
-	if got := testutil.ToFloat64(restarts.With(labels)); got != 9 {
+	if got := testutil.ToFloat64(ProcessRestartCount.With(labels)); got != 9 {
 		t.Fatalf("setup restart count: got %v want 9", got)
 	}
 
-	// Fixed teardown: delete status only (mirrors deleteProcessStatusMetrics).
-	status.Delete(labels)
+	deleteProcessStatusMetrics(cfg, process)
 
-	if n := testutil.CollectAndCount(status); n != 0 {
-		t.Fatalf("process_status should be absent after teardown, got %d series", n)
-	}
-	if n := testutil.CollectAndCount(restarts); n != 1 {
-		t.Fatalf("process_restart_count must remain after teardown (OCPBUGS-7811), got %d series", n)
-	}
-	if got := testutil.ToFloat64(restarts.With(labels)); got != 9 {
-		t.Fatalf("restart count changed during teardown: got %v want 9", got)
+	if got := testutil.ToFloat64(ProcessRestartCount.With(labels)); got != 9 {
+		t.Fatalf("restart count changed during production teardown: got %v want 9", got)
 	}
 
-	// Re-apply: status UP + one restart Inc (same as UpdateProcessStatusMetrics).
-	status.With(labels).Set(1)
-	restarts.With(labels).Inc()
-	got := testutil.ToFloat64(restarts.With(labels))
+	// Re-apply UP (same path as process start after applyNodePTPProfiles).
+	UpdateProcessStatusMetrics(process, cfg, PtpProcessUp)
+	got := testutil.ToFloat64(ProcessRestartCount.With(labels))
 	if got < 9 {
 		t.Fatalf("restart count not monotonic after re-apply: got %v (initial 9)", got)
 	}
 	if got != 10 {
-		t.Fatalf("after single UP Inc: got %v want 10", got)
+		t.Fatalf("after single UP Inc via UpdateProcessStatusMetrics: got %v want 10", got)
 	}
-	t.Logf("post-fix: status cleaned up, restart_count monotonic 9 → 10")
 }
 
 // TestProcessRestartCountDeletedOnTeardown_legacyDocumentsOldBug keeps a
 // regression note for the pre-fix Delete behavior (9 → absent → 5).
 func TestProcessRestartCountDeletedOnTeardown_legacyDocumentsOldBug(t *testing.T) {
-	reg := prometheus.NewRegistry()
 	c := prometheus.NewCounterVec(prometheus.CounterOpts{
-		Name: restartCountMetric,
+		Name: "openshift_ptp_process_restart_count_legacy",
 	}, []string{labelProcess, labelNode, labelConfig})
-	if err := reg.Register(c); err != nil {
-		t.Fatal(err)
-	}
 	labels := prometheus.Labels{
 		labelProcess: "ts2phc",
 		labelNode:    "n1",
@@ -96,7 +83,7 @@ func TestProcessRestartCountDeletedOnTeardown_legacyDocumentsOldBug(t *testing.T
 	for i := 0; i < 5; i++ {
 		c.With(labels).Inc()
 	}
-	if got := testutil.ToFloat64(c.With(labels)); got >= 9 {
-		t.Fatalf("legacy Delete path should reset; got %v", got)
+	if got := testutil.ToFloat64(c.With(labels)); got != 5 {
+		t.Fatalf("legacy Delete path should reset to 5; got %v", got)
 	}
 }

--- a/pkg/daemon/restart_count_lifecycle_test.go
+++ b/pkg/daemon/restart_count_lifecycle_test.go
@@ -4,7 +4,13 @@ import (
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
-	dto "github.com/prometheus/client_model/go"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+)
+
+const (
+	restartCountMetric  = "openshift_ptp_process_restart_count"
+	processStatusMetric = "openshift_ptp_process_status"
+	labelConfig         = "config"
 )
 
 // TestProcessRestartCountPreservedAcrossTeardownReapply verifies the OCPBUGS-7811
@@ -12,49 +18,50 @@ import (
 // the same (process, node, config) identity.
 func TestProcessRestartCountPreservedAcrossTeardownReapply(t *testing.T) {
 	reg := prometheus.NewRegistry()
+	labelNames := []string{labelProcess, labelNode, labelConfig}
 	status := prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "openshift_ptp_process_status",
-	}, []string{"process", "node", "config"})
+		Name: processStatusMetric,
+	}, labelNames)
 	restarts := prometheus.NewCounterVec(prometheus.CounterOpts{
-		Name: "openshift_ptp_process_restart_count",
-	}, []string{"process", "node", "config"})
+		Name: restartCountMetric,
+	}, labelNames)
 	if err := reg.Register(status); err != nil {
 		t.Fatal(err)
 	}
 	if err := reg.Register(restarts); err != nil {
 		t.Fatal(err)
 	}
-	labels := prometheus.Labels{"process": "ts2phc", "node": "n1", "config": "ts2phc.0.config"}
+	labels := prometheus.Labels{
+		labelProcess: "ts2phc",
+		labelNode:    "n1",
+		labelConfig:  "ts2phc.0.config",
+	}
 
 	status.With(labels).Set(1)
 	for i := 0; i < 9; i++ {
 		restarts.With(labels).Inc()
 	}
-	if got := counterValue(t, restarts, labels); got != 9 {
+	if got := testutil.ToFloat64(restarts.With(labels)); got != 9 {
 		t.Fatalf("setup restart count: got %v want 9", got)
 	}
 
 	// Fixed teardown: delete status only (mirrors deleteProcessStatusMetrics).
 	status.Delete(labels)
 
-	mfs, err := reg.Gather()
-	if err != nil {
-		t.Fatal(err)
+	if n := testutil.CollectAndCount(status); n != 0 {
+		t.Fatalf("process_status should be absent after teardown, got %d series", n)
 	}
-	if findMetric(mfs, "openshift_ptp_process_status", labels) != nil {
-		t.Fatal("process_status should be absent after teardown")
+	if n := testutil.CollectAndCount(restarts); n != 1 {
+		t.Fatalf("process_restart_count must remain after teardown (OCPBUGS-7811), got %d series", n)
 	}
-	if findMetric(mfs, "openshift_ptp_process_restart_count", labels) == nil {
-		t.Fatal("process_restart_count must remain after teardown (OCPBUGS-7811)")
-	}
-	if got := counterValue(t, restarts, labels); got != 9 {
+	if got := testutil.ToFloat64(restarts.With(labels)); got != 9 {
 		t.Fatalf("restart count changed during teardown: got %v want 9", got)
 	}
 
 	// Re-apply: status UP + one restart Inc (same as UpdateProcessStatusMetrics).
 	status.With(labels).Set(1)
 	restarts.With(labels).Inc()
-	got := counterValue(t, restarts, labels)
+	got := testutil.ToFloat64(restarts.With(labels))
 	if got < 9 {
 		t.Fatalf("restart count not monotonic after re-apply: got %v (initial 9)", got)
 	}
@@ -69,62 +76,27 @@ func TestProcessRestartCountPreservedAcrossTeardownReapply(t *testing.T) {
 func TestProcessRestartCountDeletedOnTeardown_legacyDocumentsOldBug(t *testing.T) {
 	reg := prometheus.NewRegistry()
 	c := prometheus.NewCounterVec(prometheus.CounterOpts{
-		Name: "openshift_ptp_process_restart_count",
-	}, []string{"process", "node", "config"})
+		Name: restartCountMetric,
+	}, []string{labelProcess, labelNode, labelConfig})
 	if err := reg.Register(c); err != nil {
 		t.Fatal(err)
 	}
-	labels := prometheus.Labels{"process": "ts2phc", "node": "n1", "config": "ts2phc.0.config"}
+	labels := prometheus.Labels{
+		labelProcess: "ts2phc",
+		labelNode:    "n1",
+		labelConfig:  "ts2phc.0.config",
+	}
 	for i := 0; i < 9; i++ {
 		c.With(labels).Inc()
 	}
 	c.Delete(labels) // old bug path
-	mfs, _ := reg.Gather()
-	if findMetric(mfs, "openshift_ptp_process_restart_count", labels) != nil {
-		t.Fatal("expected series absent after Delete")
+	if n := testutil.CollectAndCount(c); n != 0 {
+		t.Fatalf("expected series absent after Delete, got %d", n)
 	}
 	for i := 0; i < 5; i++ {
 		c.With(labels).Inc()
 	}
-	if got := counterValue(t, c, labels); got >= 9 {
+	if got := testutil.ToFloat64(c.With(labels)); got >= 9 {
 		t.Fatalf("legacy Delete path should reset; got %v", got)
 	}
-}
-
-func counterValue(t *testing.T, c *prometheus.CounterVec, labels prometheus.Labels) float64 {
-	t.Helper()
-	m, err := c.GetMetricWith(labels)
-	if err != nil {
-		t.Fatal(err)
-	}
-	var pm dto.Metric
-	if err := m.Write(&pm); err != nil {
-		t.Fatal(err)
-	}
-	return pm.GetCounter().GetValue()
-}
-
-func findMetric(mfs []*dto.MetricFamily, name string, labels prometheus.Labels) *dto.Metric {
-	for _, mf := range mfs {
-		if mf.GetName() != name {
-			continue
-		}
-		for _, m := range mf.Metric {
-			match := true
-			seen := map[string]string{}
-			for _, lp := range m.Label {
-				seen[lp.GetName()] = lp.GetValue()
-			}
-			for k, v := range labels {
-				if seen[k] != v {
-					match = false
-					break
-				}
-			}
-			if match {
-				return m
-			}
-		}
-	}
-	return nil
 }

--- a/pkg/daemon/restart_count_lifecycle_test.go
+++ b/pkg/daemon/restart_count_lifecycle_test.go
@@ -1,0 +1,130 @@
+package daemon
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+)
+
+// TestProcessRestartCountPreservedAcrossTeardownReapply verifies the OCPBUGS-7811
+// contract: tearing down process_status must not reset process_restart_count for
+// the same (process, node, config) identity.
+func TestProcessRestartCountPreservedAcrossTeardownReapply(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	status := prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "openshift_ptp_process_status",
+	}, []string{"process", "node", "config"})
+	restarts := prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "openshift_ptp_process_restart_count",
+	}, []string{"process", "node", "config"})
+	if err := reg.Register(status); err != nil {
+		t.Fatal(err)
+	}
+	if err := reg.Register(restarts); err != nil {
+		t.Fatal(err)
+	}
+	labels := prometheus.Labels{"process": "ts2phc", "node": "n1", "config": "ts2phc.0.config"}
+
+	status.With(labels).Set(1)
+	for i := 0; i < 9; i++ {
+		restarts.With(labels).Inc()
+	}
+	if got := counterValue(t, restarts, labels); got != 9 {
+		t.Fatalf("setup restart count: got %v want 9", got)
+	}
+
+	// Fixed teardown: delete status only (mirrors deleteProcessStatusMetrics).
+	status.Delete(labels)
+
+	mfs, err := reg.Gather()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if findMetric(mfs, "openshift_ptp_process_status", labels) != nil {
+		t.Fatal("process_status should be absent after teardown")
+	}
+	if findMetric(mfs, "openshift_ptp_process_restart_count", labels) == nil {
+		t.Fatal("process_restart_count must remain after teardown (OCPBUGS-7811)")
+	}
+	if got := counterValue(t, restarts, labels); got != 9 {
+		t.Fatalf("restart count changed during teardown: got %v want 9", got)
+	}
+
+	// Re-apply: status UP + one restart Inc (same as UpdateProcessStatusMetrics).
+	status.With(labels).Set(1)
+	restarts.With(labels).Inc()
+	got := counterValue(t, restarts, labels)
+	if got < 9 {
+		t.Fatalf("restart count not monotonic after re-apply: got %v (initial 9)", got)
+	}
+	if got != 10 {
+		t.Fatalf("after single UP Inc: got %v want 10", got)
+	}
+	t.Logf("post-fix: status cleaned up, restart_count monotonic 9 → 10")
+}
+
+// TestProcessRestartCountDeletedOnTeardown_legacyDocumentsOldBug keeps a
+// regression note for the pre-fix Delete behavior (9 → absent → 5).
+func TestProcessRestartCountDeletedOnTeardown_legacyDocumentsOldBug(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	c := prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "openshift_ptp_process_restart_count",
+	}, []string{"process", "node", "config"})
+	if err := reg.Register(c); err != nil {
+		t.Fatal(err)
+	}
+	labels := prometheus.Labels{"process": "ts2phc", "node": "n1", "config": "ts2phc.0.config"}
+	for i := 0; i < 9; i++ {
+		c.With(labels).Inc()
+	}
+	c.Delete(labels) // old bug path
+	mfs, _ := reg.Gather()
+	if findMetric(mfs, "openshift_ptp_process_restart_count", labels) != nil {
+		t.Fatal("expected series absent after Delete")
+	}
+	for i := 0; i < 5; i++ {
+		c.With(labels).Inc()
+	}
+	if got := counterValue(t, c, labels); got >= 9 {
+		t.Fatalf("legacy Delete path should reset; got %v", got)
+	}
+}
+
+func counterValue(t *testing.T, c *prometheus.CounterVec, labels prometheus.Labels) float64 {
+	t.Helper()
+	m, err := c.GetMetricWith(labels)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var pm dto.Metric
+	if err := m.Write(&pm); err != nil {
+		t.Fatal(err)
+	}
+	return pm.GetCounter().GetValue()
+}
+
+func findMetric(mfs []*dto.MetricFamily, name string, labels prometheus.Labels) *dto.Metric {
+	for _, mf := range mfs {
+		if mf.GetName() != name {
+			continue
+		}
+		for _, m := range mf.Metric {
+			match := true
+			seen := map[string]string{}
+			for _, lp := range m.Label {
+				seen[lp.GetName()] = lp.GetValue()
+			}
+			for k, v := range labels {
+				if seen[k] != v {
+					match = false
+					break
+				}
+			}
+			if match {
+				return m
+			}
+		}
+	}
+	return nil
+}

--- a/pkg/metrics/cleanup.go
+++ b/pkg/metrics/cleanup.go
@@ -52,8 +52,10 @@ func deleteOsClockStateMetrics(profiles map[string][]string) {
 	}
 }
 
-// DeleteProcessStatusMetrics ...
+// DeleteProcessStatusMetrics removes the process_status gauge for a torn-down
+// process/config. process_restart_count is intentionally left in place so the
+// cumulative counter remains monotonic when the same config identity is
+// re-applied after applyNodePTPProfiles teardown (OCPBUGS-7811).
 func DeleteProcessStatusMetrics(config, process string) {
 	ProcessStatus.Delete(prometheus.Labels{"process": process, "node": NodeName, "config": config})
-	ProcessRestartCount.Delete(prometheus.Labels{"process": process, "node": NodeName, "config": config})
 }


### PR DESCRIPTION
## Summary
- Stop deleting `openshift_ptp_process_restart_count` during process/config teardown in `deleteProcessStatusMetrics` / `DeleteProcessStatusMetrics`.
- Still delete `openshift_ptp_process_status` so scrapers do not see a stale UP/DOWN sample after teardown (OCPBUGS-7808).
- Add a unit test that models teardown + re-apply and asserts the counter stays monotonic (OCPBUGS-7811).

`applyNodePTPProfiles` always tears processes down before re-applying the same config slot (e.g. `ts2phc.0.config`). Deleting the restart counter removed the Prometheus series, so the next `Inc()` started from zero — observed in ptp-operator T-GM conformance as `restart_count` dropping (e.g. 9→5) after GM `PtpConfig` delete/re-apply.

## Test plan
- [x] `go test ./pkg/daemon/ -run TestProcessRestartCount -count=1`
- [ ] Confirm ptp-operator serial test "Verify ts2phc metrics are cleaned up after GM PtpConfig delete and re-apply" passes against a daemon image built from this branch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved cumulative process restart counts when process status metrics are removed and later restored.
  * Restart counters now continue from their previous value instead of resetting after process or configuration teardown.

* **Tests**
  * Added coverage validating restart-count preservation and continued incrementing across teardown and reapplication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->