### PR TITLE
ci: install crun >= 1.14.3 for podman 5.x compatibility

### DIFF
--- a/.github/workflows/netdevsim-ci.yml
+++ b/.github/workflows/netdevsim-ci.yml
@@ -162,6 +162,14 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y podman
           podman --version
+          # The kubic repo may not carry a crun newer than the distro's
+          # 1.14.1 which rejects OCI runtime spec v1.2.1 from podman 5.x.
+          # Install crun >= 1.14.3 from upstream GitHub releases.
+          CRUN_VER=1.19.1
+          sudo curl -fsSL -o /usr/bin/crun \
+            "https://github.com/containers/crun/releases/download/${CRUN_VER}/crun-${CRUN_VER}-linux-amd64"
+          sudo chmod +x /usr/bin/crun
+          crun --version | head -1
 
       - name: Clone ptp-operator
         run: git clone --depth 1 --branch "${PTP_BRANCH}" "${PTP_REPO}" /tmp/ptp-operator
@@ -228,6 +236,14 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y podman
           podman --version
+          # The kubic repo may not carry a crun newer than the distro's
+          # 1.14.1 which rejects OCI runtime spec v1.2.1 from podman 5.x.
+          # Install crun >= 1.14.3 from upstream GitHub releases.
+          CRUN_VER=1.19.1
+          sudo curl -fsSL -o /usr/bin/crun \
+            "https://github.com/containers/crun/releases/download/${CRUN_VER}/crun-${CRUN_VER}-linux-amd64"
+          sudo chmod +x /usr/bin/crun
+          crun --version | head -1
 
       - name: Install OpenShift CLI (oc)
         run: |


### PR DESCRIPTION
## Summary
- Install crun >= 1.14.3 from upstream GitHub releases in both `build-image` and `run-tests` jobs
- The kubic repo may ship crun 1.14.1 which rejects OCI runtime spec v1.2.1 from podman 5.x, causing container build failures
- Mirrors the same fix from k8snetworkplumbingwg/ptp-operator#278

## Test plan
- [ ] netdevsim CI `build-image` job completes without OCI runtime errors
- [ ] netdevsim CI `run-tests` job completes without OCI runtime errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the CI environment to install and verify `crun` version 1.19.1 alongside Podman.
  * Improved consistency of container-related automated checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->