### PR TITLE
OCPBUGS-105554: Fix NAV-TIMELS notification rate

### DIFF
--- a/pkg/ublox/ublox.go
+++ b/pkg/ublox/ublox.go
@@ -25,12 +25,24 @@ const (
 	pollTimeout = "1000000000"
 )
 
+const (
+	// timeLSRateSeconds is the interval in GPS navigation epochs (seconds) at which
+	// the UBX-NAV-TIMELS leap-second notification is sent.
+	timeLSRateSeconds = 60
+)
+
 var (
 	// Disable all binary messages
 	disableBinary = Command{Args: []string{"-d", "BINARY"}}
-	// NAV message types to re-enable
+	// NAV message types to re-enable at the default rate of 1 (every second)
 	navEnableMsg = []string{
-		"CLOCK", "STATUS", "TIMELS",
+		"CLOCK", "STATUS",
+	}
+	// NAV message types to enable at a reduced rate (timeLSRateSeconds).
+	// TIMELS carries leap-second information which changes at most twice a year;
+	// updating every 60 seconds is sufficient.
+	navSlowEnableMsg = []string{
+		"TIMELS",
 	}
 
 	// Enable all NMEA messages
@@ -65,18 +77,26 @@ func batchDisableNmeaMsgs(msgs []string) Command {
 	return batchMsgoutAllBusses("NMEA_ID", msgs, 0)
 }
 
-// Generate a series of commands to enable the given b8nary command on all bus types
+// batchEnableNavMsgs generates commands to enable the given NAV message types
+// at a rate of 1 (every GPS navigation epoch, i.e. every second) on all bus types.
 func batchEnableNavMsgs(msgs []string) Command {
 	return batchMsgoutAllBusses("UBX_NAV", msgs, 1)
+}
+
+// batchEnableNavMsgsAtRate generates commands to enable the given NAV message types
+// at the specified rate (in GPS navigation epochs) on all bus types.
+func batchEnableNavMsgsAtRate(msgs []string, rate int) Command {
+	return batchMsgoutAllBusses("UBX_NAV", msgs, rate)
 }
 
 // Return the default set of commands we need to set at initialization
 func defaultUblxCmds() CommandList {
 	// Begin by disabling all binary commands, then re-adding the ones we need
 	cmds := CommandList{disableBinary}
-	// Re-enable required binary commands
+	// Re-enable high-frequency binary commands (every second)
 	cmds = append(cmds, batchEnableNavMsgs(navEnableMsg))
-
+	// Re-enable low-frequency binary commands (every minute)
+	cmds = append(cmds, batchEnableNavMsgsAtRate(navSlowEnableMsg, timeLSRateSeconds))
 	// Next, enable all NMEA commands, but prune out any we don't need:
 	cmds = append(cmds, enableNMEA)
 	// More pruning of all bus-specific NMEA messages

--- a/pkg/ublox/ublox_internal_test.go
+++ b/pkg/ublox/ublox_internal_test.go
@@ -19,10 +19,11 @@ func Test_BatchMsgoutAllBusses(t *testing.T) {
 }
 
 func Test_BatchMsgoutAllBusses_MultipleMessages(t *testing.T) {
-	cmd := batchMsgoutAllBusses("UBX_NAV", navEnableMsg, 1)
+	allNavMsgs := append(navEnableMsg, navSlowEnableMsg...)
+	cmd := batchMsgoutAllBusses("UBX_NAV", allNavMsgs, 1)
 	// N messages × 5 bus types × 2 args each (-z + value)
-	assert.Equal(t, len(navEnableMsg)*len(ublxBusTypes)*2, len(cmd.Args))
-	for _, msg := range navEnableMsg {
+	assert.Equal(t, len(allNavMsgs)*len(ublxBusTypes)*2, len(cmd.Args))
+	for _, msg := range allNavMsgs {
 		for _, bus := range ublxBusTypes {
 			expected := fmt.Sprintf("CFG-MSGOUT-UBX_NAV_%s_%s,1", msg, bus)
 			assert.Contains(t, cmd.Args, expected)
@@ -50,6 +51,16 @@ func Test_BatchEnableNavMsgs(t *testing.T) {
 	}
 }
 
+func Test_BatchEnableNavMsgsAtRate(t *testing.T) {
+	cmd := batchEnableNavMsgsAtRate(navSlowEnableMsg, timeLSRateSeconds)
+	for _, msg := range navSlowEnableMsg {
+		for _, bus := range ublxBusTypes {
+			expected := fmt.Sprintf("CFG-MSGOUT-UBX_NAV_%s_%s,%d", msg, bus, timeLSRateSeconds)
+			assert.Contains(t, cmd.Args, expected)
+		}
+	}
+}
+
 func Test_DefaultUblxCmds(t *testing.T) {
 	cmds := defaultUblxCmds()
 
@@ -62,12 +73,27 @@ func Test_DefaultUblxCmds(t *testing.T) {
 	// First command should disable all binary
 	assert.Equal(t, disableBinary, cmds[0])
 
-	// All NAV messages should be re-enabled on all bus types
+	// High-frequency NAV messages should be enabled at rate 1 (every second)
 	for _, nav := range navEnableMsg {
 		for _, bus := range ublxBusTypes {
 			expected := fmt.Sprintf("CFG-MSGOUT-UBX_NAV_%s_%s,1", nav, bus)
 			assert.Contains(t, allArgs, expected,
-				"expected NAV %s enable on %s", nav, bus)
+				"expected NAV %s enable at rate 1 on %s", nav, bus)
+		}
+	}
+
+	// Low-frequency NAV messages (TIMELS) should be enabled at timeLSRateSeconds (every minute)
+	for _, nav := range navSlowEnableMsg {
+		for _, bus := range ublxBusTypes {
+			expected := fmt.Sprintf("CFG-MSGOUT-UBX_NAV_%s_%s,%d", nav, bus, timeLSRateSeconds)
+			assert.Contains(t, allArgs, expected,
+				"expected NAV %s enable at rate %d on %s", nav, timeLSRateSeconds, bus)
+		}
+		// Also verify TIMELS is NOT enabled at rate 1
+		for _, bus := range ublxBusTypes {
+			notExpected := fmt.Sprintf("CFG-MSGOUT-UBX_NAV_%s_%s,1", nav, bus)
+			assert.NotContains(t, allArgs, notExpected,
+				"TIMELS should not be enabled at rate 1 on %s", bus)
 		}
 	}
 


### PR DESCRIPTION
NAV-TIMELS notification rate in the hardwareconfig path is reduced from 1 second to 1 minute

Assisted by OpenCode on Claude Sonnet

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance**
  - Reduced the frequency of selected GPS navigation updates to once every 60 seconds.
  - Kept clock and status updates running at every GPS epoch.
  - Applied separate update rates for standard and lower-priority navigation messages.
  - Maintained high-frequency updates for critical navigation data while reducing less frequent message traffic.

- **Bug Fixes**
  - Prevented slower navigation messages from being enabled at the highest update rate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->